### PR TITLE
Transifex improvements

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,7 @@
+[main]
+host = https://www.transifex.com
+
+[bitcoin.tx]
+file_filter = src/qt/locale/bitcoin_<lang>.ts
+source_file = src/qt/locale/bitcoin_en.ts
+source_lang = en

--- a/contrib/devtools/README.md
+++ b/contrib/devtools/README.md
@@ -69,3 +69,15 @@ If there are 'unsupported' symbols, the return value will be 1 a list like this 
     .../64/test_bitcoin: symbol std::out_of_range::~out_of_range() from unsupported version GLIBCXX_3.4.15
     .../64/test_bitcoin: symbol _ZNSt8__detail15_List_nod from unsupported version GLIBCXX_3.4.15
 
+update-translations.py
+=======================
+
+Run this script from the root of the repository to update all translations from transifex.
+It will do the following automatically:
+
+- fetch all translations
+- post-process them into valid and committable format
+- add missing translations to the build system (TODO)
+
+See doc/translation-process.md for more information.
+

--- a/contrib/devtools/update-translations.py
+++ b/contrib/devtools/update-translations.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+# Copyright (c) 2014 Wladimir J. van der Laan
+# Distributed under the MIT/X11 software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+'''
+Run this script from the root of the repository to update all translations from
+transifex.
+It will do the following automatically:
+
+- fetch all translations using the tx tool
+- post-process them into valid and committable format
+  - remove invalid control characters
+  - remove location tags (makes diffs less noisy)
+
+TODO:
+- auto-add new translations to the build system according to the translation process
+- remove 'unfinished' translation items
+'''
+from __future__ import division, print_function
+import subprocess
+import re
+import sys
+import os
+
+# Name of transifex tool
+TX = 'tx'
+# Name of source language file
+SOURCE_LANG = 'bitcoin_en.ts'
+# Directory with locale files
+LOCALE_DIR = 'src/qt/locale'
+
+def check_at_repository_root():
+    if not os.path.exists('.git'):
+        print('No .git directory found')
+        print('Execute this script at the root of the repository', file=sys.stderr)
+        exit(1)
+
+def fetch_all_translations():
+    if subprocess.call([TX, 'pull', '-f']):
+        print('Error while fetching translations', file=sys.stderr)
+        exit(1)
+
+def postprocess_translations():
+    print('Postprocessing...')
+    for filename in os.listdir(LOCALE_DIR):
+        # process only language files, and do not process source language
+        if not filename.endswith('.ts') or filename == SOURCE_LANG: 
+            continue
+        filepath = os.path.join(LOCALE_DIR, filename)
+        with open(filepath, 'rb') as f:
+            data = f.read()
+        # remove non-allowed control characters
+        data = re.sub('[\x00-\x09\x0b\x0c\x0e-\x1f]', '', data)
+        data = data.split('\n')
+        # strip locations from non-origin translation
+        # location tags are used to guide translators, they are not necessary for compilation
+        # TODO: actually process XML instead of relying on Transifex's one-tag-per-line output format
+        data = [line for line in data if not '<location' in line]
+        with open(filepath, 'wb') as f:
+            f.write('\n'.join(data))
+
+if __name__ == '__main__':
+    check_at_repository_root()
+    fetch_all_translations()
+    postprocess_translations()
+

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -71,14 +71,15 @@ We are using https://transifex.com as a frontend for translating the client.
 https://www.transifex.com/projects/p/bitcoin/resource/tx/
 
 The "Transifex client" (see: http://support.transifex.com/customer/portal/topics/440187-transifex-client/articles)
-will help with fetching new translations from Transifex. The Transifex configuration (`.tx/config`)
+is used to fetch new translations from Transifex. The configuration for this client (`.tx/config`)
 is part of the repository.
 
-It is also possible to directly download new translations one by one from the Transifex website.
+Do not directly download translations one by one from the Transifex website, as we do a few
+postprocessing steps before committing the translations.
 
 ### Fetching new translations
 
-1. `tx pull -a`
+1. `python contrib/devtools/update-translations.py`
 2. update `src/qt/bitcoin.qrc` manually or via
    `ls src/qt/locale/*ts|xargs -n1 basename|sed 's/\(bitcoin_\(.*\)\).ts/<file alias="\2">locale\/\1.qm<\/file>/'`
 3. update `src/qt/Makefile.am` manually or via

--- a/doc/translation_process.md
+++ b/doc/translation_process.md
@@ -71,28 +71,8 @@ We are using https://transifex.com as a frontend for translating the client.
 https://www.transifex.com/projects/p/bitcoin/resource/tx/
 
 The "Transifex client" (see: http://support.transifex.com/customer/portal/topics/440187-transifex-client/articles)
-will help with fetching new translations from Transifex. Use the following
-config to be able to connect with the client:
-
-### .tx/config
-
-    [main]
-    host = https://www.transifex.com
-
-    [bitcoin.tx]
-    file_filter = src/qt/locale/bitcoin_<lang>.ts
-    source_file = src/qt/locale/bitcoin_en.ts
-    source_lang = en
-    
-### .tx/config (for Windows)
-
-    [main]
-    host = https://www.transifex.com
-
-    [bitcoin.tx]
-    file_filter = src\qt\locale\bitcoin_<lang>.ts
-    source_file = src\qt\locale\bitcoin_en.ts
-    source_lang = en
+will help with fetching new translations from Transifex. The Transifex configuration (`.tx/config`)
+is part of the repository.
 
 It is also possible to directly download new translations one by one from the Transifex website.
 

--- a/src/qt/locale/bitcoin_ach.ts
+++ b/src/qt/locale/bitcoin_ach.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_af_ZA.ts
+++ b/src/qt/locale/bitcoin_af_ZA.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dubbel-klik om die adres of etiket te wysig</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Skep &apos;n nuwe adres</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Maak &apos;n kopie van die huidige adres na die stelsel klipbord</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Verwyder</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(geen etiket)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Tik Wagwoord in</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nuwe wagwoord</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Herhaal nuwe wagwoord</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Tik die nuwe wagwoord vir die beursie in.&lt;br/&gt;Gebruik asseblief &apos;n wagwoord van &lt;b&gt;ten minste 10 ewekansige karakters&lt;/b&gt;, of &lt;b&gt;agt (8) of meer woorde.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Enkripteer beursie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Hierdie operasie benodig &apos;n wagwoord om die beursie oop te sluit.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Sluit beursie oop</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Hierdie operasie benodig &apos;n wagwoord om die beursie oop te sluit.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Sluit beursie oop</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Verander wagwoord</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Tik asseblief die ou en nuwe wagwoord vir die beursie in.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Bevestig beursie enkripsie.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Die beursie is nou bewaak</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Die beursie kon nie bewaak word nie</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Beursie bewaaking het misluk as gevolg van &apos;n interne fout. Die beursie is nie bewaak nie!</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Die wagwoord stem nie ooreen nie</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Beursie oopsluiting het misluk</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Die wagwoord wat ingetik was om die beursie oop te sluit, was verkeerd.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Beursie dekripsie het misluk</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sinchroniseer met die netwerk ...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Oorsig</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Wys algemene oorsig van die beursie</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transaksies</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Besoek transaksie geskiedenis</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>S&amp;luit af</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Sluit af</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Wys inligting oor Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Wys inligting oor Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opsies</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Beursie</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Lêer</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Instellings</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Hulp</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Blad nutsbalk</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin klient</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 agter</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Ontvangs van laaste blok is %1 terug.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informasie</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Bedrag:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Maak kopie van adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(geen etiket)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nuwe ontvangende adres</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nuwe stuurende adres</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Wysig ontvangende adres</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Wysig stuurende adres</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Kon nie die beursie oopsluit nie.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Gebruik:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opsies</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Vorm</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Beursie</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Onlangse transaksies&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Die adres waarheen die betaling gestuur moet word (b.v. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Boodskap</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Boodskap</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(geen etiket)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Stuur Munstukke</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Bedrag:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Stuur aan vele ontvangers op eens</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Balans:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>S&amp;tuur</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(geen etiket)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Die adres waarheen die betaling gestuur moet word (b.v. 1H7wyVL5HCNoVFyyBJSDojwyxcCChU7TPA)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Boodskap:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Teken boodskap</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Handtekening</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Teken &amp;Boodskap</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Die adres waarheen die betaling gestuur moet word (b.v. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Van</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Na</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>eie adres</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etiket</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Krediet</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>nie aanvaar nie</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debiet</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Transaksie fooi</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Netto bedrag</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Boodskap</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Transaksie ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>waar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>onwaar</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>onbekend</translation>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Ontvang met</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Ontvang van</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Gestuur na</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Betalings Aan/na jouself</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Gemyn</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n.v.t)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Datum en tyd wat die transaksie ontvang was.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipe transaksie.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Vandag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Hierdie week</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Hierdie maand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Verlede maand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Hierdie jaar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Reeks...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Ontvang met</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Gestuur na</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Aan/na jouself</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Gemyn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Ander</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Min bedrag</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Maak kopie van adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Reeks:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>aan</translation>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Stuur Munstukke</translation>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Gebruik:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Opsies:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Luister vir konneksies op &lt;port&gt; (standaard: 8333 of testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Onderhou op die meeste &lt;n&gt; konneksies na eweknieë (standaard: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Gebruik die toets netwerk</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Fout: Hardeskyf spasie is baie laag!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informasie</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Sisteem fout:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Hierdie help boodskap</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Laai adresse...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Ongeldige bedrag</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Onvoldoende fondse</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Laai blok indeks...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Laai beursie...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Klaar gelaai</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ar.ts
+++ b/src/qt/locale/bitcoin_ar.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,18 +19,14 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -41,122 +34,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>أنقر على الماوس مرتين لتعديل العنوان</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>انشأ عنوان جديد</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>قم بنسخ القوانين المختارة لحافظة النظام</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>انسخ العنوان</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;أمسح</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>تعديل</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>وصف</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>عنوان</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(لا وصف)</translation>
     </message>
@@ -182,142 +148,108 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>ادخل كلمة المرور</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>عبارة مرور جديدة</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>ادخل الجملة السرية مرة أخرى</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>أدخل عبارة مرور جديدة إلى المحفظة. الرجاء استخدام عبارة مرور تتكون من10  حروف عشوائية على الاقل, أو أكثر من 7 كلمات </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>تشفير المحفظة</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>هذه العملية تحتاج عبارة المرور محفظتك لفتحها</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>إفتح المحفظة</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>هذه العملية تحتاج عبارة المرور محفظتك فك تشفيرها</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>فك تشفير المحفظة</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>تغيير عبارة المرور</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>أدخل عبارة المرور القديمة والجديدة إلى المحفظة.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>تأكيد التشفير المحفظة</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>محفظة مشفرة</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>بتكوين سوف يغلق الآن لإنهاء عملية التشفير. تذكر أن التشفير لا يستطيع حماية محفظتك تمامًا من السرقة من خلال البرمجيات الخبيثة التي تصيب جهازك </translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>فشل تشفير المحفظة</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>شل تشفير المحفظة بسبب خطأ داخلي. لم يتم تشفير محفظتك.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>عبارتي المرور ليستا متطابقتان
 </translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>فشل فتح المحفظة</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>عبارة المرور التي تم إدخالها لفك شفرة المحفظة غير صحيحة.
 </translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>فشل   فك التشفير المحفظة</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -325,363 +257,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>التوقيع و الرسائل</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>مزامنة مع شبكة ...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>نظرة عامة</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>إظهار نظرة عامة على المحفظة</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>المعاملات</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>تصفح التاريخ المعاملات</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>خروج</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>الخروج من التطبيق</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>  إظهار المزيد معلومات حول Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>عن</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>اظهر المعلومات</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>خيارات ...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>ارسل عملات الى عنوان بيتكوين</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>احفظ نسخة احتياطية للمحفظة في مكان آخر</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>تغيير عبارة المرور المستخدمة لتشفير المحفظة</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>بت كوين</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>محفظة</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>ملف</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>الاعدادات</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>مساعدة</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>شريط أدوات علامات التبويب</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>عميل بتكوين</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>محين</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>اللحاق بالركب ...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>المعاملات  المرسلة</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>المعاملات واردة</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -690,17 +545,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>المحفظة مشفرة و مفتوحة حاليا</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>المحفظة مشفرة و مقفلة حاليا</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -708,7 +560,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -716,291 +567,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>المبلغ</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>عنوان</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>تأكيد</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>  انسخ عنوان</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation> انسخ التسمية</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>نسخ الكمية</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>نعم</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>لا</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(لا وصف)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1008,68 +798,55 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>عدل العنوان</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>العنوان</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>عنوان تلقي جديد</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>عنوان إرسال جديد</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>تعديل عنوان التلقي
 </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>تعديل عنوان الارسال</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>هدا العنوان &quot;%1&quot; موجود مسبقا في دفتر العناوين</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation> يمكن فتح المحفظة.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>فشل توليد مفتاح جديد.</translation>
     </message>
@@ -1077,27 +854,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1105,57 +877,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>النسخة</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>المستخدم</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>خيارات UI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1163,57 +924,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>بت كوين</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1221,27 +971,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1249,258 +994,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>خيارات ...</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>الرئيسي</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>نافذه</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>عرض العناوين في قائمة الصفقة</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>الغاء</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>الافتراضي</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>عنوان الوكيل توفيره غير صالح.</translation>
     </message>
@@ -1508,69 +1201,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>نمودج</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>محفظة</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>متوفر</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>غير ناضجة</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>اخر المعملات </translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>خارج المزامنه</translation>
     </message>
@@ -1578,93 +1256,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1672,29 +1327,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>بت كوين</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>إدخال عنوانBitcoin (مثال :1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1702,22 +1350,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1725,194 +1369,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>اسم العميل</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>غير معروف</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>نسخه العميل</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>المعلومات</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>الشبكه</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>الاسم</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>عدد الاتصالات</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>الفتح</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>وقت البناء</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1920,105 +1516,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation> انسخ التسمية</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>انسخ الرسالة</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>نسخ الكمية</translation>
     </message>
@@ -2026,67 +1599,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>عنوان</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>المبلغ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>وصف</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2094,37 +1654,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>وصف</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>المبلغ</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(لا وصف)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2132,247 +1685,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>إرسال Coins</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>إرسال إلى عدة مستلمين في وقت واحد</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>مسح الكل</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>الرصيد:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>تأكيد الإرسال</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>تأكيد الإرسال Coins</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>نسخ الكمية</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>المبلغ المدفوع يجب ان يكون اكبر من 0</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(لا وصف)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2380,98 +1880,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>ادفع الى </translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>إدخال تسمية لهذا العنوان لإضافته إلى دفتر العناوين الخاص بك</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>انسخ العنوان من لوحة المفاتيح</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>الرسائل</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2479,12 +1955,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2492,186 +1966,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>انسخ العنوان من لوحة المفاتيح</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>مسح الكل</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>إدخال عنوانBitcoin (مثال :1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>العنوان المدخل غير صالح</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>الرجاء التأكد من العنوان والمحاولة مرة اخرى</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>العنوان المدخل لا يشير الى مفتاح</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>المفتاح الخاص للعنوان المدخل غير موجود.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>فشل توقيع الرسالة.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>الرسالة موقعة.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>فشلت عملية التأكد من الرسالة.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>تم تأكيد الرسالة.</translation>
     </message>
@@ -2679,17 +2109,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2697,7 +2124,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2705,184 +2131,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>مفتوح حتى 1٪</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>1% غير متواجد</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>غير مؤكدة/1%</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>تأكيد %1</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>الحالة.</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>المصدر</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>تم اصداره.</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>من</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>الى</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>عنوانه</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>غير مقبولة</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>دين</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>رسوم التحويل</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>تعليق</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>رقم المعاملة</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>معاملة</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>المبلغ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>صحيح</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>خاطئ</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>لم يتم حتى الآن البث بنجاح</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>غير معروف</translation>
     </message>
@@ -2890,12 +2270,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>تفاصيل المعاملة</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>يبين هذا الجزء وصفا مفصلا لهده المعاملة</translation>
     </message>
@@ -2903,127 +2281,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>النوع</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>عنوان</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>المبلغ</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>مفتوح حتى 1٪</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>تأكيد الإرسال Coins</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>لم يتم تلقى هذه الكتلة (Block) من قبل أي العقد الأخرى وربما لن تكون مقبولة!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>ولدت ولكن لم تقبل</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>غير متصل</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>استقبل مع</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>استقبل من</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>أرسل إلى</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>دفع لنفسك</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Mined</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>غير متوفر</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>حالة المعاملة. تحوم حول هذا الحقل لعرض عدد  التأكيدات.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>التاريخ والوقت الذي تم فيه تلقي المعاملة.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>نوع المعاملات</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>عنوان وجهة  المعاملة</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>المبلغ الذي أزيل أو أضيف الى الرصيد</translation>
     </message>
@@ -3031,178 +2384,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>الكل</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>اليوم</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>هدا الاسبوع</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>هدا الشهر</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>الشهر الماضي</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>هدا العام</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>v</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>استقبل مع</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>أرسل إلى</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>إليك</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Mined</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>اخرى</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>ادخل عنوان أووصف للبحث</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>  انسخ عنوان</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation> انسخ التسمية</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>نسخ الكمية</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>عدل الوصف</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>نجح الاستخراج</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>تأكيد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>التاريخ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>النوع</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>وصف</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>عنوان</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>المبلغ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>العنوان</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>الى</translation>
     </message>
@@ -3210,7 +2527,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3218,7 +2534,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>إرسال Coins</translation>
     </message>
@@ -3226,42 +2541,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3269,107 +2576,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>المستخدم</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>اعرض الأوامر</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>مساعدة في كتابة الاوامر</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>خيارات: </translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>حدد موقع مجلد المعلومات او data directory</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>استخدم التحقق من الشبكه</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>قبول الاتصالات من خارج</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3384,852 +2670,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>فشل في الاستماع على أي منفذ. استخدام الاستماع = 0 إذا كنت تريد هذا.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>النسخة</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>رسالة المساعدة هذه</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>تحميل العنوان</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>خطأ عند تنزيل wallet.dat: المحفظة تالفة</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>خطأ عند تنزيل wallet.dat: المحفظة تتطلب نسخة أحدث من بتكوين</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>المحفظة تحتاج لإعادة إنشاء: أعد تشغيل بتكوين للإتمام</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>خطأ عند تنزيل wallet.dat</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>تحميل المحفظه</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>إعادة مسح</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>انتهاء التحميل</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>خطأ</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_be_BY.ts
+++ b/src/qt/locale/bitcoin_be_BY.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Двайны клік для рэдагавання адрасу ці пазнакі</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Стварыць новы адрас</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Капіяваць пазначаны адрас у сістэмны буфер абмену</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>Экспарт</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>Выдаліць</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Коскамі падзелены файл (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Пазнака</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адрас</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>непазначаны</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Увядзіце кодавую фразу</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Новая кодавая фраза</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Паўтарыце новую кодавую фразу</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Увядзіце новую кодавую фразу для гаманца. &lt;br/&gt;Калі ласка, ўжывайце пароль &lt;b&gt;не меньша за 10 адвольных сімвалаў&lt;/b&gt;, ці &lt;b&gt;болей васьмі слоў&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Зашыфраваць гаманец.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Гэтая аперацыя патрабуе кодавую фразу, каб рзблакаваць гаманец.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Разблакаваць гаманец</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Гэтая аперацыя патрабуе пароль каб расшыфраваць гаманец.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Рачшыфраваць гаманец</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Змяніць пароль</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Увядзіце стары і новы пароль да гаманца.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Пацвердзіце шыфраванне гаманца</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Гаманец зашыфраваны</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin зачыняецца дзеля завяршэння працэсса шыфравання. Памятайце, што шыфраванне гаманца цалкам абараняе вашыя сродкі ад скрадання шкоднымі праграмамі якія могуць пранікнуць у ваш камп&apos;ютар.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Шыфраванне гаманца няўдалае</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Шыфраванне гаманца не адбылося з-за ўнутранай памылкі. Гаманец незашыфраваны.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Уведдзеныя паролі не супадаюць</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Разблакаванне гаманца няўдалае</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Уведзена пароль  дзеля расшыфравання гаманца памылковы</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Расшыфраванне гаманца няўдалае</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Сінхранізацыя з сецівам...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>Агляд</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Паказвае агульныя звесткі аб гаманцы</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>Транзакцыі</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Праглядзець гісторыю транзакцый</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>Выйсці</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Выйсці з праграмы</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Паказаць звесткі пра Біткойн</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Аб Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Паказаць інфармацыю аб Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>Опцыі...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Зрабіце копію гаманца ў іншае месца</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Змяніць пароль шыфравання гаманца</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>Даслаць</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>Атрымаць</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>Ф&amp;айл</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>Наладкі</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>Дапамога</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin кліент</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n актыўнае злучэнне з Bitcoin-сецівам</numerusform><numerusform>%n актыўных злучэнняў з Bitcoin-сецівам</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Памылка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Сінхранізавана</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Наганяем...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Дасланыя транзакцыі</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Прынятыя транзакцыі</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -691,17 +547,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Гаманец &lt;b&gt;зашыфраваны&lt;/b&gt; і зараз &lt;b&gt;разблакаваны&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Гаманец &lt;b&gt;зашыфраваны&lt;/b&gt; і зараз &lt;b&gt;заблакаваны&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -709,7 +562,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -717,291 +569,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Колькасць</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Адрас</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Пацверджана</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Капіяваць адрас</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Капіяваць пазнаку</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Капіяваць колькасць</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Капіяваць ID транзакцыі</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>непазначаны</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1009,67 +800,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Рэдагаваць Адрас</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>Пазнака</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>Адрас</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Новы адрас для атрымання</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Новы адрас для дасылання</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Рэдагаваць адрас прымання</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Рэдагаваць адрас дасылання</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Уведзены адрас &quot;%1&quot; ужо ў кніге адрасоў</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Немагчыма разблакаваць гаманец</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Генерацыя новага ключа няўдалая</translation>
     </message>
@@ -1077,27 +855,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1105,52 +878,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Ужыванне:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1158,57 +925,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Памылка</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1216,27 +972,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1244,253 +995,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Опцыі</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1498,69 +1202,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Нядаўнія транзаццыі&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1568,93 +1257,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1662,23 +1328,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Увядзіце Біткойн-адрас (ўзор 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1686,22 +1351,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1709,192 +1370,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1902,105 +1517,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>Пазнака:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Капіяваць пазнаку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Капіяваць колькасць</translation>
     </message>
@@ -2008,67 +1600,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Адрас</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Колькасць</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Пазнака</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2076,37 +1655,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Пазнака</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Колькасць</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>непазначаны</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2114,247 +1686,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Даслаць Манеты</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Даслаць адразу некалькім атрымальнікам</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Баланс:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Пацвердзіць дасыланне</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Пацвердзіць дасыланне манет</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Капіяваць колькасць</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Велічыня плацяжу мае быць больш за 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>непазначаны</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2362,98 +1881,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Колькасць:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Заплаціць да:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Увядзіце пазнаку гэтаму адрасу, каб дадаць яго ў адрасную кнігу</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>Пазнака:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Уставіць адрас з буферу абмена</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2461,12 +1956,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2474,186 +1967,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Уставіць адрас з буферу абмена</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Увядзіце Біткойн-адрас (ўзор 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2661,17 +2110,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2679,7 +2125,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2687,184 +2132,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/непацверджана</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 пацверджанняў</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Колькасць</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, пакуль не было паспяхова транслявана</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>невядома</translation>
     </message>
@@ -2872,12 +2271,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Дэталі транзакцыі</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Гэтая панэль паказвае дэтальнае апісанне транзакцыі</translation>
     </message>
@@ -2885,127 +2282,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Тып</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адрас</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Колькасць</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Пацверджана (%1 пацверджанняў)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Гэты блок не быў прыняты іншымі вузламі і магчыма не будзе ўхвалены!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Згенеравана, але не прынята</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Прынята з</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Прынята ад</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Даслана да</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Плацёж самому сабе</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Здабыта</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Статус транзакцыі. Навядзіце курсар на гэтае поле, каб паказаць колькасць пацверджанняў.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Дата і час, калі транзакцыя была прынята.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Тып транзакцыі</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Адрас прызначэння транзакцыі.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Колькасць аднятая ці даданая да балансу.</translation>
     </message>
@@ -3013,178 +2385,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Усё</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Сёння</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Гэты тыдзень</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Гэты месяц</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Мінулы месяц</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Гэты год</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Прамежак...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Прынята з</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Даслана да</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Да сябе</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Здабыта</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Іншыя</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Увядзіце адрас ці пазнаку для пошуку</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Мін. колькасць</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Капіяваць адрас</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Капіяваць пазнаку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Капіяваць колькасць</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Капіяваць ID транзакцыі</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Рэдагаваць пазнаку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Коскамі падзелены файл (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Пацверджана</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Тып</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Пазнака</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Адрас</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Колькасць</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Прамежак:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>да</translation>
     </message>
@@ -3192,7 +2528,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3200,7 +2535,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Даслаць Манеты</translation>
     </message>
@@ -3208,42 +2542,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>Экспарт</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3251,107 +2577,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Ужыванне:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Спіс каманд</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Атрымаць дапамогу для каманды</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Опцыі:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Вызначыць канфігурацыйны файл (зыходна: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Вызначыць pid-файл (зыходна: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Вызначыць каталог даных</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Пазначыць памер кэшу базы звестак у мегабайтах (тыпова: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Слухаць злучэнні на &lt;port&gt; (зыходна: 8333 ці testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Трымаць не больш за &lt;n&gt; злучэнняў на асобу (зыходна: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Парог для адлучэння злаўмысных карыстальнікаў (тыпова: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Колькасць секунд для ўстрымання асобаў да перадалучэння (заходна: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Прымаць камандны радок і JSON-RPC каманды</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Запусціць у фоне як дэман і прымаць каманды</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Ужываць тэставае сеціва</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3366,722 +2671,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Слаць trace/debug звесткі ў кансоль замест файла debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Імя карыстальника для JSON-RPC злучэнняў</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Пароль для JSON-RPC злучэнняў</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Дазволіць  JSON-RPC злучэнні з пэўнага IP адрасу</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Адпраўляць каманды вузлу на &lt;ip&gt; (зыходна: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Выканаць каманду калі лепшы блок зменіцца (%s замяняецца на хэш блока)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Абнавіць гаманец на новы фармат</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Устанавіць памер фонда ключоў у &lt;n&gt; (тыпова: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Перасканаваць ланцуг блокаў дзеля пошуку адсутных транзакцый</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Ужываць OpenSSL (https) для JSON-RPC злучэнняў</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Файл-сертыфікат сервера (зыходна: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Прыватны ключ сервера (зыходна: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Загружаем адрасы...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Памылка загрузкі wallet.dat: гаманец пашкоджаны</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Памылка загрузкі wallet.dat: гаманец патрабуе новую версію Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Гаманец мае быць перазапісаны: патрэбны перазапуск Bitcoin для выканання</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Памылка загрузкі wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Памылковая колькасць</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Недастаткова сродкаў</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Загружаем індэкс блокаў...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Загружаем гаманец...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Перасканаванне...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Загрузка выканана</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Памылка</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_bg.ts
+++ b/src/qt/locale/bitcoin_bg.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ This product includes software developed by the OpenSSL Project for use in the O
 Използван е софтуер, разработен от OpenSSL Project за употреба в OpenSSL Toolkit (http://www.openssl.org/), криптографски софтуер разработен от Eric Young (eay@cryptsoft.com) и UPnP софтуер разработен от Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
-        <translation type="unfinished"/>
+        <translation>Авторски права</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Двоен клик за редакция на адрес или име</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Създаване на нов адрес</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Копирай избрания адрес</translation>
+        <translation>Копиране на избрания адрес</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Копирай</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Изтрий избрания адрес от списъка</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Запишете данните от текущия раздел във файл</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
-        <translation>&amp;Изтрий</translation>
+        <translation>&amp;Изтриване</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Копирай &amp;име</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Редактирай</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>CSV файл (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Име</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(без име)</translation>
     </message>
@@ -187,140 +153,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Въведи парола</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Нова парола</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Още веднъж</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Въведете нова парола за портфейла.&lt;br/&gt;Моля използвайте &lt;b&gt;поне 10 случайни символа&lt;/b&gt; или &lt;b&gt;8 или повече думи&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Криптиране на портфейла</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Тази операция изисква Вашата парола за отключване на портфейла.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Отключване на портфейла</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Тази операция изисква Вашата парола за декриптиране на портфейла.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Декриптиране на портфейла</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Смяна на паролата</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Въведете текущата и новата парола за портфейла.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Потвърждаване на криптирането</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished"/>
+        <translation>Наистина ли искате да шифрирате портфейла?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished"/>
+        <translation>Внимание: Caps Lock (главни букви) е включен.</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Портфейлът е криптиран</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Биткоин ще се затоври сега за да завърши процеса на криптиране. Запомнете, че криптирането на вашия портефейл не може напълно да предпази вашите Бит-монети от кражба чрез зловреден софтуер, инфектирал вашия компютър</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Криптирането беше неуспешно</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Криптирането на портфейла беше неуспешно поради неизвестен проблем. Портфейлът не е криптиран.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Паролите не съвпадат</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Отключването беше неуспешно</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Паролата въведена за декриптиране на портфейла е грешна.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Декриптирането беше неуспешно</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Паролата на портфейла беше променена успешно.</translation>
     </message>
@@ -328,362 +260,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Подписване на &amp;съобщение...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Синхронизиране с мрежата...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Баланс</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Обобщена информация за портфейла</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Транзакции</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>История на транзакциите</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>Из&amp;ход</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Изход от приложението</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Информация за Биткоин</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>За &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Покажи информация за Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Опции...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Криптиране на портфейла...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Запазване на портфейла...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Смяна на паролата...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Изпращане към Биткоин адрес</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Променя паролата за портфейла</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Проверка на съобщение...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Биткоин</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Портфейл</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
-        <translation type="unfinished"/>
+        <translation>Показване и скриване на основния прозорец</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Настройки</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Помощ</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Раздели</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n връзка към Биткоин мрежата</numerusform><numerusform>%n връзки към Биткоин мрежата</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Грешка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
-        <translation type="unfinished"/>
+        <translation>Предупреждение</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
-        <translation type="unfinished"/>
+        <translation>Данни</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Синхронизиран</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Зарежда блокове...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Изходяща транзакция</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Входяща транзакция</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -692,17 +548,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Портфейлът е &lt;b&gt;криптиран&lt;/b&gt; и &lt;b&gt;отключен&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Портфейлът е &lt;b&gt;криптиран&lt;/b&gt; и &lt;b&gt;заключен&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -710,7 +563,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -718,291 +570,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Сума:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Такса:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Сума</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished"/>
+        <translation>Потвърждения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Потвърдени</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Копирай адрес</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Копирай име</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Копирай сума</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
-        <translation type="unfinished"/>
+        <translation>да</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
-        <translation type="unfinished"/>
+        <translation>не</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(без име)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1010,67 +801,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Редактиране на адрес</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Име</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Адрес</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Нов адрес за получаване</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Нов адрес за изпращане</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Редактиране на входящ адрес</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Редактиране на изходящ адрес</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Вече има адрес &quot;%1&quot; в списъка с адреси.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>&quot;%1&quot; не е валиден Биткоин адрес.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Отключването на портфейла беше неуспешно.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Създаването на ключ беше неуспешно.</translation>
     </message>
@@ -1078,27 +856,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
-        <translation type="unfinished"/>
+        <translation>име</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1106,52 +879,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
-        <translation type="unfinished"/>
+        <translation>версия</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Използване:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI Опции</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1159,57 +926,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
-        <translation type="unfinished"/>
+        <translation>Добре дошли</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Биткоин</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Грешка</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1217,27 +973,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1245,253 +996,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Основни</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>&amp;Такса за изходяща транзакция</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Пускане на Биткоин при вход в системата</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Мрежа</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Автоматично отваряне на входящия Bitcoin порт. Работи само с рутери поддържащи UPnP.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Отваряне на входящия порт чрез &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Прозорец</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>След минимизиране ще е видима само иконата в системния трей.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Минимизиране в системния трей</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>При затваряне на прозореца приложението остава минимизирано. Ако изберете тази опция, приложението може да се затвори само чрез Изход в менюто.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>М&amp;инимизиране при затваряне</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Интерфейс</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Език:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Промяната на езика ще влезе в сила след рестартиране на Биткоин.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Мерни единици:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Изберете единиците, показвани по подразбиране в интерфейса.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Ще се показват адресите в списъка с транзакции независимо от наличието на кратко име.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>Показвай и адресите в списъка с транзакции</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Прокси адресът е невалиден.</translation>
     </message>
@@ -1499,69 +1203,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Портфейл</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
-        <translation type="unfinished"/>
+        <translation>Общо:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
-        <translation type="unfinished"/>
+        <translation>Текущият ви общ баланс</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Последни транзакции&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>несинхронизиран</translation>
     </message>
@@ -1569,93 +1258,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1663,23 +1329,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Биткоин</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Въведете Биткоин адрес (например 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1687,22 +1352,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1710,192 +1371,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
-        <translation type="unfinished"/>
+        <translation>Име на клиента</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
-        <translation type="unfinished"/>
+        <translation>Версия на клиента</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Мрежа</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
-        <translation type="unfinished"/>
+        <translation>Име</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
-        <translation type="unfinished"/>
+        <translation>Брой връзки</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
-        <translation type="unfinished"/>
+        <translation>Текущ брой блокове</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
-        <translation type="unfinished"/>
+        <translation>Предвидени общо блокове</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
-        <translation type="unfinished"/>
+        <translation>Време на последния блок</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Изчисти конзолата</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Използвайте стрелки надолу и нагореза разглеждане на историятаот команди и &lt;b&gt;Ctrl-L&lt;/b&gt; за изчистване на конзолата.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1903,105 +1518,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Име:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation>Изчистване</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
-        <translation type="unfinished"/>
+        <translation>Показване</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
-        <translation type="unfinished"/>
+        <translation>Премахване</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Копирай име</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Копирай сума</translation>
     </message>
@@ -2009,67 +1601,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
-        <translation type="unfinished"/>
+        <translation>Данни за плащането</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Сума</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Име</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Съобщение</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Грешка при създаването на QR Code от URI.</translation>
     </message>
@@ -2077,37 +1656,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Име</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Съобщение</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Сума</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(без име)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2115,247 +1687,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Изпращане</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Сума:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Такса:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Изпращане към повече от един получател</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Добави &amp;получател</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Изчисти</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Баланс:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Потвърдете изпращането</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>И&amp;зпрати</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Потвърждаване</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Копирай сума</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
-        <translation type="unfinished"/>
+        <translation>или</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Невалиден адрес на получателя.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Сумата трябва да е по-голяма от 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
-        <translation type="unfinished"/>
+        <translation>Сумата надвишава текущия баланс</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(без име)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2363,98 +1882,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>С&amp;ума:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Плати &amp;На:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Въведете име за този адрес, за да го добавите в списъка с адреси</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Име:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Вмъкни от клипборда</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Съобщение:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2462,12 +1957,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2475,186 +1968,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Подпиши / Провери съобщение</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Подпиши</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Можете да подпишете съобщение като доказателство, че притежавате определен адрес. Бъдете внимателни и не подписвайте съобщения, които биха разкрили лична информация без вашето съгласие.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Адресът, с който ще подпишете съобщението (например 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Вмъкни от клипборда</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Въведете съобщението тук</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
-        <translation type="unfinished"/>
+        <translation>Подпис</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Копиране на текущия подпис</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Подпишете съобщение като доказателство, че притежавате определен адрес</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Изчисти</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Провери</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Адресът, с който е подписано съобщението (например 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Проверете съобщение, за да сте сигурни че е подписано с определен Биткоин адрес</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Въведете Биткоин адрес (например 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Натиснете &quot;Подписване на съобщение&quot; за да създадете подпис</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Въведеният адрес е невалиден.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Моля проверете адреса и опитайте отново.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Не е наличен частният ключ за въведеният адрес.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Подписването на съобщение бе неуспешно.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Съобщението е подписано.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Подписът не може да бъде декодиран.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Проверете подписа и опитайте отново.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Подписът не отговаря на комбинацията от съобщение и адрес.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Проверката на съобщението беше неуспешна.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Съобщението е потвърдено.</translation>
     </message>
@@ -2662,17 +2111,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2680,7 +2126,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2688,184 +2133,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Подлежи на промяна до %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/офлайн</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/непотвърдени</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>включена в %1 блока</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Статус</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Източник</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Издадени</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>От</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>За</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>собствен адрес</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>име</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Кредит</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Дебит</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Такса</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Сума нето</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Съобщение</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Коментар</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
-        <translation type="unfinished"/>
+        <translation>Търговец</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Транзакция</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Сума</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>true</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>false</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, все още не е изпратено</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>неизвестен</translation>
     </message>
@@ -2873,12 +2272,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Транзакция</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Описание на транзакцията</translation>
     </message>
@@ -2886,127 +2283,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Сума</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Подлежи на промяна до %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Потвърдени (%1 потвърждения)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Блокът не е получен от останалите участници и най-вероятно няма да бъде одобрен.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Генерирана, но отхвърлена от мрежата</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Получени с</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Получен от</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Изпратени на</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
-        <translation type="unfinished"/>
+        <translation>Плащане към себе си</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Емитирани</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Състояние на транзакцията. Задръжте върху това поле за брой потвърждения.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Дата и час на получаване.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Тип на транзакцията.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Получател на транзакцията.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Сума извадена или добавена към баланса.</translation>
     </message>
@@ -3014,178 +2386,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Всички</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Днес</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Тази седмица</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Този месец</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Предния месец</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Тази година</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>От - до...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Получени</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Изпратени на</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Собствени</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Емитирани</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Други</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Търсене по адрес или име</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Минимална сума</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Копирай адрес</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Копирай име</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Копирай сума</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Редактирай име</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>CSV файл (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Потвърдени</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Име</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Сума</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ИД</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>От:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>до</translation>
     </message>
@@ -3193,7 +2529,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3201,7 +2536,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Изпращане</translation>
     </message>
@@ -3209,42 +2543,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Запишете данните от текущия раздел във файл</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3252,107 +2578,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Използване:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Вписване на команди</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Получете помощ за команда</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Опции:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
-        <translation type="unfinished"/>
+        <translation>Задаване на файл с настройки (по подразбиране bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Определете директория за данните</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Праг на прекъсване на връзката при непорядъчно държащи се пиъри (по подразбиране:100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Брой секунди до възтановяване на връзката за зле държащите се пиъри (по подразбиране:86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Използвайте тестовата мрежа</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3367,722 +2672,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
-        <translation type="unfinished"/>
+        <translation>Грешка при четене данни на блок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
-        <translation type="unfinished"/>
+        <translation>Грешка при четене на блок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
-        <translation type="unfinished"/>
+        <translation>Грешка при запис данни на блок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
-        <translation type="unfinished"/>
+        <translation>Грешка при запис на блок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Изпращане на команда до Биткойн сървъра</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Включи Биткойн сървър</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
-        <translation type="unfinished"/>
+        <translation>Проверка на блоковете...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
-        <translation type="unfinished"/>
+        <translation>Проверка на портфейла...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
-        <translation type="unfinished"/>
+        <translation>Настройки на портфейла:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
-        <translation type="unfinished"/>
+        <translation>Данни</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Изпрати локализиращата или дебъг информацията към конзолата, вместо файлът debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <source>System error: </source>
+        <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>System error: </source>
+        <translation>Системна грешка:</translation>
+    </message>
+    <message>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Потребителско име за JSON-RPC връзките</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
-        <translation type="unfinished"/>
+        <translation>Предупреждение</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>version</source>
+        <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>version</source>
+        <translation>версия</translation>
+    </message>
+    <message>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Парола за  JSON-RPC връзките</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Разреши  JSON-RPC връзките от отучнен IP адрес</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Изпрати команди до възел функциониращ на &lt;ip&gt; (По подразбиране: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
-        <translation type="unfinished"/>
+        <translation>Обновяване на портфейла до най-новия формат</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Повторно сканиране на блок-връзка за липсващи портефейлни транзакции</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Използвайте OpenSSL (https) за JSON-RPC връзките</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Сертификатен файл на сървъра (По подразбиране:server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Поверителен ключ за сървъра (default: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Това помощно съобщение</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Зареждане на адресите...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
-        <translation type="unfinished"/>
+        <translation>Грешка при зареждане на wallet.dat: портфейлът е повреден</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
-        <translation type="unfinished"/>
+        <translation>Грешка при зареждане на  wallet.dat: портфейлът изисква по-нова версия на Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
-        <translation type="unfinished"/>
+        <translation>Грешка при зареждане на wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Невалиден -proxy address: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
-        <translation type="unfinished"/>
+        <translation>Недостатъчно средства</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Зареждане на блок индекса...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Зареждане на портфейла...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Преразглеждане на последовтелността от блокове...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Зареждането е завършено</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Грешка</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_bs.ts
+++ b/src/qt/locale/bitcoin_bs.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Jezrga</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Jezrga</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Jezrga</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Sve</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Danas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Ovaj mjesec</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Prošli mjesec</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Ove godine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ca.ts
+++ b/src/qt/locale/bitcoin_ca.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Doble click per editar l&apos;adreça o l&apos;etiqueta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crear una nova adrça</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copia la selecció actual al porta-retalls del sistema</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Eliminar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Fitxer separat per comes (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adreça</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Introduïu la frase-contrasenya</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nova frase-contrasenya</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repetiu la nova frase-contrasenya</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introduïu la nova frase-contrasenya per a la cartera.&lt;br/&gt;Empreu una frase-contrasenya de &lt;b&gt;10 o més caràcters aleatoris&lt;b/&gt;, o &lt;b&gt;vuit o més paraules&lt;b/&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Encriptar cartera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Cal que introduïu la frase-contrasenya de la cartera per a desbloquejar-la.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desbloquejar cartera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Cal que introduïu la frase-contrasenya de la cartera per a desencriptar-la.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Desencriptar cartera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Canviar frase-contrasenya</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Introduïu l&apos;antiga i la nova frase-contrasenya per a la cartera.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmeu l&apos;encriptació de cartera</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Cartera encriptada</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>L&apos;encriptació de cartera ha fallat</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>L&apos;encriptació de cartera ha fallat degut a un error intern. La vostra cartera no ha estat encriptada.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Les frases-contrasenya no concorden.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>El desbloqueig de cartera ha fallat</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La frase-contrasenya per a la desencriptació de cartera és incorrecta.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>La desencriptació de cartera ha fallat</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sincronitzant amb la xarxa...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Visió general</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Mostrar visió general de la cartera</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transaccions</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Exploreu l&apos;historial de transaccions</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Sortir de l&apos;aplicació</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Informació sobre Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opcions...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Canviar frase-contrasenya per a l&apos;escriptació de la cartera</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Fitxer</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuració</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Ajuda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra d&apos;eines</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Actualitzant...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transacció enviada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transacció entrant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>La cartera està &lt;b&gt;encriptada&lt;b/&gt; i &lt;b&gt;desbloquejada&lt;b/&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>La cartera està &lt;b&gt;encriptada&lt;b/&gt; i &lt;b&gt;bloquejada&lt;b/&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adreça</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editar adreça</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adreça</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adreça</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adreça</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Fitxer separat per comes (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adreça</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ca@valencia.ts
+++ b/src/qt/locale/bitcoin_ca@valencia.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,18 +19,14 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -41,122 +34,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Doble click per editar la direccio o la etiqueta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crear nova direccio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copieu l&apos;adreça seleccionada al porta-retalls del sistema</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,363 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -688,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -706,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -714,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1006,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1074,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1102,57 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1160,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1218,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1246,258 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1505,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1575,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1669,29 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1699,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1722,194 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1917,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2023,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2091,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2129,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2377,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2476,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2489,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2676,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2694,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2702,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2887,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2900,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3028,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3207,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3215,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3223,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3266,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,852 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ca_ES.ts
+++ b/src/qt/locale/bitcoin_ca_ES.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Sobre el Nucli de Bitcoin</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>\n Aquest és software experimental.\n\n Distribuït sota llicència de software MIT/11, veure l&apos;arxiu COPYING o http://www.opensource.org/licenses/mit-license.php.\n\nAquest producte inclou software desarrollat pel projecte OpenSSL per a l&apos;ús de OppenSSL Toolkit (http://www.openssl.org/) i de softwqre criptogràfic escrit per l&apos;Eric Young (eay@cryptsoft.com) i software UPnP escrit per en Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Feu doble clic per editar l&apos;adreça o l&apos;etiqueta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crear una nova adreça</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nou</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copiar l&apos;adreça seleccionada al porta-retalls del sistema</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiar</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copiar adreça</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Esborrar l&apos;adreça sel·leccionada</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar les dades de la pestanya actual a un arxiu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Esborrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Escull una adreça a la qual enviar coins</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Escull l&apos;adreça a la quals vols rebre coins</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Enviant adreces</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Rebent adreces</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Aquestes són la seva adreça de Bitcoin per enviar els pagaments. Sempre revisi la quantitat i l&apos;adreça del destinatari abans transferència de monedes.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar &amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exportar la llista d&apos;adre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Arxiu de separació per comes (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adreça</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Dialeg de contrasenya</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Introdueix contrasenya</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nova contrasenya</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repeteix la nova contrasenya</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introdueixi la nova contrasenya al moneder&lt;br/&gt;Si us plau useu una contrasenya de &lt;b&gt;10 o més caracters aleatoris&lt;/b&gt;, o &lt;b&gt;vuit o més paraules&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Xifrar la cartera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Aquesta operació requereix la seva contrasenya del moneder per a desbloquejar-lo.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desbloqueja el moneder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Aquesta operació requereix la seva contrasenya del moneder per a desencriptar-lo.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Desencripta el moneder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Canviar la contrasenya</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Introdueixi tant l&apos;antiga com la nova contrasenya de moneder.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar l&apos;encriptació del moneder</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Advertència: Si encripteu el vostre moneder i perdeu la constrasenya, &lt;b&gt;PERDREU TOTS ELS VOSTRES BITCOINS&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Esteu segur que voleu encriptar el vostre moneder?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>IMPORTANT: Tota copia de seguretat que hagis realitzat hauria de ser reemplaçada pel, recentment generat, arxiu encriptat del moneder.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Advertència: Les lletres majúscules estàn activades!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Moneder encriptat</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin es tancarà ara per acabar el procés d&apos;encriptació. Recorda que encriptar el teu moneder no protegeix completament els teus bitcoins de ser robades per programari maliciós instal·lat al teu ordinador.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>L&apos;encriptació del moneder ha fallat</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>L&apos;encriptació del moneder ha fallat per un error intern. El seu moneder no ha estat encriptat.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>La contrasenya introduïda no coincideix.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>El desbloqueig del moneder ha fallat</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contrasenya introduïda per a desencriptar el moneder és incorrecte.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>La desencriptació del moneder ha fallat</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>La contrasenya del moneder ha estat modificada correctament.</translation>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Signar &amp;missatge...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sincronitzant amb la xarxa ...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Panorama general</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation>Node</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Mostra panorama general del moneder</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transaccions</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Cerca a l&apos;historial de transaccions</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>S&amp;ortir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Sortir de l&apos;aplicació</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Mostra informació sobre Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Sobre &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Mostra informació sobre Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opcions...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Xifrar moneder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Realitzant copia de seguretat del moneder...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Canviar contrasenya...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Important blocs del disc..</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Re-indexant blocs al disc...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Enviar monedes a una adreça Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modificar les opcions de configuració per bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Realitzar còpia de seguretat del moneder a un altre directori</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Canviar la constrasenya d&apos;encriptació del moneder</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Finestra de debug</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Obrir la consola de diagnòstic i debugging</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verifica el missatge..</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Moneder</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Rebre</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Mostrar / Amagar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Mostrar o amagar la finestra principal</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Xifrar les claus privades pertanyents al seu moneder</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Signa el missatges amb la seva adreça de Bitcoin per provar que les poseeixes</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verificar els missatges per assegurar-te que han estat signades amb una adreça Bitcoin específica.</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Arxiu</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuració</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Ajuda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra d&apos;eines de seccions</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Nucli de Bitcoin</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Client Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n connexió activa a la xarxa Bitcoin</numerusform><numerusform>%n connexions actives a la xarxa Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Processat el %1 de %2 (estimat) dels blocs del històric de transaccions.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Proccessats %1 blocs del històric de transaccions.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hora</numerusform><numerusform>%n hores</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n dia</numerusform><numerusform>%n dies</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n setmana</numerusform><numerusform>%n setmanes</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 radera</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Lúltim bloc rebut ha estat generat fa %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Les transaccions a partir d&apos;això no seràn visibles.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Avís</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informació</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Al dia</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Posar-se al dia ...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transacció enviada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transacció entrant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation>Data: %1\nQuantitat %2\n Tipus: %3\n Adreça: %4\n</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>El moneder està &lt;b&gt;encriptat&lt;/b&gt; i actualment &lt;b&gt;desbloquejat&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>El moneder està &lt;b&gt;encriptat&lt;/b&gt; i actualment &lt;b&gt;bloquejat&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Ha tingut lloc un error fatal. Bitcoin no pot continuar executant-se de manera segura i es tancará.</translation>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Alerta de xarxa</translation>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Quantitat:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Quantitat:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioritat:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Quota:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Quota posterior:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Canvi:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Mode arbre</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Mode llista</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Quantitat</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adreça</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Confirmacions</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioritat</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Copiar adreça </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copiar quantitat</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID de transacció</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation>El més alt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>Més alt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>Alt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>mig-alt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>mig</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>baix-mig</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>baix</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>més baix</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>el més baix</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Pols</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>si</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>no</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Aquesta etiqueta es posa de color vermell si la mida de la transacció és més gran de 1000 bytes.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(canviar)</translation>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editar Adreça</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Direcció</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nova adreça de recepció.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nova adreça d&apos;enviament</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editar adreces de recepció</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editar adreces d&apos;enviament</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>L&apos;adreça introduïda &quot;%1&quot; ja és present a la llibreta d&apos;adreces.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>L&apos;adreça introduida &quot;%1&quot; no és una adreça Bitcoin valida.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>No s&apos;ha pogut desbloquejar el moneder.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Ha fallat la generació d&apos;una nova clau.</translation>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nom</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>El directori ja existeix. Afegeix %1 si vols crear un nou directori en aquesta ubicació.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Nucli de Bitcoin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versió</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Ús:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>Opcions de la línia d&apos;ordres</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Opcions de IU</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Definir llenguatge, per exemple &quot;de_DE&quot; (per defecte: Preferències locals de sistema)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Iniciar minimitzat</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Mostrar finestra de benvinguda a l&apos;inici (per defecte: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Benvingut</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Benvingut a Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB d&apos;espai lliure disponible</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(d&apos; %1GB necessari)</translation>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opcions</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Principal</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Pagar &amp;comisió de transacció</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Iniciar automàticament Bitcoin després de l&apos;inici de sessió del sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Iniciar Bitcoin al inici de sessió del sistema.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Reestablir totes les opcions del client.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Reestablir Opcions</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Xarxa</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Obrir el port del client de Bitcoin al router de forma automàtica. Això només funciona quan el teu router implementa UPnP i l&apos;opció està activada.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Port obert amb &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP del proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Port del proxy (per exemple 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Versió de SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Versió SOCKS del proxy (per exemple 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Finestra</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Mostrar només l&apos;icona de la barra al minimitzar l&apos;aplicació.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimitzar a la barra d&apos;aplicacions</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimitza en comptes de sortir de la aplicació al tancar la finestra. Quan aquesta opció està activa, la aplicació només es tancarà al seleccionar Sortir al menú.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimitzar al tancar</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Pantalla</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Llenguatge de la Interfície d&apos;Usuari:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Aquí pots definir el llenguatge de l&apos;aplicatiu. Aquesta configuració tindrà efecte un cop es reiniciï Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unitats per mostrar les quantitats en:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Sel·lecciona la unitat de subdivisió per defecte per mostrar en la interficie quan s&apos;envien monedes.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Mostrar adreces Bitcoin als llistats de transaccions o no.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Mostrar adreces al llistat de transaccions</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancel·la</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>Per defecte</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Confirmi el reestabliment de les opcions</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>L&apos;adreça proxy introduïda és invalida.</translation>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulari</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>La informació mostrada pot no estar al día. El teu moneder es sincronitza automàticament amb la xarxa Bitcoin un cop s&apos;ha establert connexió, però aquest proces no s&apos;ha completat encara.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Moneder</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Immatur:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Balanç minat que encara no ha madurat</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transaccions recents&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>Fora de sincronia</translation>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Manejant URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>la URI no pot ser processada! Això es pot ser causat per una adreça Bitcoin invalida o paràmetres URI malformats.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Error en la sol·licitud de pagament</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>No es pot iniciar bitcoin: manejador clicla-per-pagar</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Reemborsament de %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Pagament notificat</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Error en la sol·licitud de xarxa</translation>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Error: El directori de dades específiques &quot;%1! no existeix.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introdueixi una adreça de Bitcoin (per exemple 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Desar codi QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>Imatge PNG (*.png)</translation>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nom del client</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versió del client</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informació</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Depura finestra</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Utilitzant OpenSSL versió</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>&amp;Temps d&apos;inici</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Xarxa</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Nombre de connexions</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Bloquejar cadena</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Nombre de blocs actuals</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Total estimat de blocs</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Últim temps de bloc</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Obrir</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Consola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totals</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>Dins:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>Fora:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Data de compilació</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Dietàri de debug</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Obrir el dietari de debug de Bitcoin del directori de dades actual. Aixó pot trigar uns quants segons per a dietàris grossos.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Netejar consola</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Benvingut a la consola RPC de Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Utilitza les fletxes d&apos;amunt i avall per navegar per l&apos;històric, i &lt;b&gt;Ctrl-L&lt;\b&gt; per netejar la pantalla.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Escriu &lt;b&gt;help&lt;\b&gt; per a obtenir una llistat de les ordres disponibles.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Quantitat:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Missatge:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Esborra tots els camps del formuari.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Esborra</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Sol·licitud de pagament</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Mostra</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation>Esborra les entrades seleccionades de la llista</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Esborra</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar quantitat</translation>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation> Codi QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Copiar &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Copiar &amp;Adress</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Informació de pagament</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adreça</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Quantitat</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Missatge</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI resultant massa llarga, intenta reduir el text per a la etiqueta / missatge</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Error codificant la URI en un codi QR.</translation>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Missatge</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Quantitat</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(sense missatge)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Enviar monedes</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>(Opcions del control del Coin)</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Entrades</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>Seleccionat automàticament</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Fons insuficient</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Quantitat:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Quantitat:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioritat:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Quota:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Quota posterior:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Canvi:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Enviar a multiples destinataris al mateix temps</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Affegir &amp;Destinatari</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Netejar tots els camps del formulari.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Esborrar &amp;Tot</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Balanç:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Confirmi l&apos;acció d&apos;enviament</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>E&amp;nviar</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirmar l&apos;enviament de monedes</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar quantitat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>o</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>L&apos;adreça remetent no és vàlida, si us plau comprovi-la.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>La quantitat a pagar ha de ser major que 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Import superi el saldo de la seva compte.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>El total excedeix el teu balanç quan s&apos;afegeix la comisió a la transacció %1.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>S&apos;ha trobat una adreça duplicada, tan sols es pot enviar a cada adreça un cop per ordre de enviament.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sense etiqueta)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Estàs segur que ho vols enviar?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>S&apos;ha afegit una taxa de transacció</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>La sol·licitud de pagament ha caducat</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Q&amp;uantitat:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Pagar &amp;A:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La adreça a on envia el pagament (per exemple: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Introdueixi una etiquera per a aquesta adreça per afegir-la a la llibreta d&apos;adreces</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Escull una adreça feta servir anteriorment</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alta+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Enganxar adreça del porta-retalls</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Missatge:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Paga a:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Signatures .Signar/Verificar un Missatge</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Signar Missatge</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Pots signar missatges amb la teva adreça per provar que són teus. Sigues cautelòs al signar qualsevol cosa, ja que els atacs phising poden intentar confondre&apos;t per a que els hi signis amb la teva identitat. Tan sols signa als documents completament detallats amb els que hi estàs d&apos;acord.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La adreça amb la que signat els missatges (per exemple 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Escull adreces fetes servir amb anterioritat</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alta+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Enganxar adreça del porta-retalls</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Introdueix aqui el missatge que vols signar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Signatura</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copiar la signatura actual al porta-retalls del sistema</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Signa el missatge per provar que ets propietari d&apos;aquesta adreça Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Signar &amp;Missatge</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Neteja tots els camps de clau</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Esborrar &amp;Tot</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verificar el missatge</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Introdueixi l&apos;adreça signant, missatge (assegura&apos;t que copies salts de línia, espais, tabuladors, etc excactament tot el text) i la signatura a sota per verificar el missatge. Per evitar ser enganyat per un atac home-entre-mig, vés amb compte de no llegir més en la signatura del que hi ha al missatge signat mateix.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La adreça amb el que el missatge va ser signat (per exemple 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verificar el missatge per assegurar-se que ha estat signat amb una adreça Bitcoin específica</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verificar &amp;Missatge</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Neteja tots els camps de verificació de missatge</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introdueixi una adreça de Bitcoin (per exemple 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Clica &quot;Signar Missatge&quot; per a generar una signatura</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>L&apos;adreça intoduïda és invàlida.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Siu us plau, comprovi l&apos;adreça i provi de nou.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>L&apos;adreça introduïda no referencia a cap clau.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>El desbloqueig del moneder ha estat cancelat.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La clau privada per a la adreça introduïda no està disponible.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>El signat del missatge ha fallat.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Missatge signat.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>La signatura no s&apos;ha pogut decodificar .</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Su us plau, comprovi la signatura i provi de nou.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>La signatura no coincideix amb el resum del missatge.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Ha fallat la verificació del missatge.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Missatge verificat.</translation>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Nucli de Bitcoin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Obert fins %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/sense confirmar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confrimacions</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Estat</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, difusió a través de %n node</numerusform><numerusform>, difusió a través de %n nodes</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Font</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generat</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Des de</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>Adreça pròpia</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Crèdit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>disponible en %n bloc més</numerusform><numerusform>disponibles en %n blocs més</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>no acceptat</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Dèbit</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Comissió de transacció</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Quantitat neta</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Missatge</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Comentar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID de transacció</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Mercader</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Informació de debug</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transacció</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Entrades</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Quantitat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>cert</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>fals</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, encara no ha estat emès correctement</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Obre per %n bloc més</numerusform><numerusform>Obre per %n blocs més</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>desconegut</translation>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detall de la transacció</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Aquest panell mostra una descripció detallada de la transacció</translation>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Direcció</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Quantitat</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Obre per %n bloc més</numerusform><numerusform>Obre per %n blocs més</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Obert fins %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmat (%1 confirmacions)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Aquest bloc no ha estat rebut per cap altre node i probablement no serà acceptat!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generat però no acceptat</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Rebut amb</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Rebut de</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Enviat a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pagament a un mateix</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minat</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estat de la transacció. Desplaça&apos;t per aquí sobre per mostrar el nombre de confirmacions.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Data i hora en que la transacció va ser rebuda.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipus de transacció.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Adreça del destinatari de la transacció.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Quantitat extreta o afegida del balanç.</translation>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Tot</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Avui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Aquesta setmana</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Aquest mes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>El mes passat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Enguany</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Rang...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Rebut amb</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Enviat a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>A tu mateix</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Altres</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Introdueix una adreça o una etiqueta per cercar</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Quantitat mínima</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copiar adreça </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar quantitat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID de transacció</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Editar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Mostra detalls de la transacció</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Arxiu de separació per comes (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Direcció</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Quantitat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Rang:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>a</translation>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Enviar monedes</translation>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar les dades de la pestanya actual a un arxiu</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Realitzar còpia de seguretat del moneder</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Dades del moneder (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Còpia de seguretat faillida</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Copia de seguretat realitzada correctament</translation>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Ús:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Llista d&apos;ordres</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Obtenir ajuda per a un ordre.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Opcions:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Especificat arxiu de configuració (per defecte: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Especificar arxiu pid (per defecte: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Especificar directori de dades</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Establir tamany de la memoria cau en megabytes (per defecte: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Escoltar connexions a &lt;port&gt; (per defecte: 8333 o testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Mantenir com a molt &lt;n&gt; connexions a peers (per defecte: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Connectar al node per obtenir les adreces de les connexions, i desconectar</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Especificar la teva adreça pública</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Límit per a desconectar connexions errònies (per defecte: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Nombre de segons abans de reconectar amb connexions errònies (per defecte: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Ha sorgit un error al configurar el port RPC %u escoltant a IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Escoltar connexions JSON-RPC al port &lt;port&gt; (per defecte: 8332 o testnet:18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Acceptar línia d&apos;ordres i ordres JSON-RPC </translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Executar en segon pla com a programa dimoni i acceptar ordres</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Usar la xarxa de prova</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Aceptar connexions d&apos;afora (per defecte: 1 si no -proxy o -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation>%s has de establir una contrasenya RPC a l&apos;arxiu de configuració:\n%s\nEs recomana que useu la següent constrasenya aleatòria:\nrpcuser=bitcoinrpc\nrpcpassword=%s\n(no necesiteu recordar aquesta contrsenya)\nEl nom d&apos;usuari i contrasenya NO HAN de ser els mateixos.\nSi l&apos;arxiu no existeix, crea&apos;l amb els permisos d&apos;arxiu de només lectura per al propietari.\nTambé es recomana establir la notificació d&apos;alertes i així seràs notificat de les incidències;\nper exemple: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.com</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ha sorgit un error al configurar el port RPC %u escoltant a IPv6, retrocedint a IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Vincular a una adreça específica i sempre escoltar-hi. Utilitza la notació [host]:port per IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>No es pot bloquejar el directori de dades %s. Probablement Bitcoin ja estigui en execució.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Error: La transacció ha estat rebutjada. Això pot passar si alguna de les monedes del teu moneder ja s&apos;han gastat, com si haguesis usat una copia de l&apos;arxiu wallet.dat i s&apos;haguessin gastat monedes de la copia però sense marcar com gastades en aquest.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Error: Aquesta transacció requereix una comissió d&apos;almenys %s degut al seu import, complexitat o per l&apos;ús de fons recentment rebuts!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Executar una ordre quan una transacció del moneder canviï (%s in cmd es canvia per TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Aquesta és una versió de pre-llançament - utilitza-la sota la teva responsabilitat - No usar per a minería o aplicacions de compra-venda</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Advertència: el -paytxfee és molt elevat! Aquesta és la comissió de transacció que pagaràs quan enviis una transacció.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Advertència: Si us plau comprovi que la data i hora del seu computador siguin correctes! Si el seu rellotge està mal configurat, Bitcoin no funcionará de manera apropiada.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Advertència: Error llegint l&apos;arxiu wallet.dat!! Totes les claus es llegeixen correctament, però hi ha dades de transaccions o entrades del llibre d&apos;adreces absents o bé son incorrectes.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Advertència: L&apos;arxiu wallet.dat és corrupte, dades rescatades! L&apos;arxiu wallet.dat original ha estat desat com wallet.{estampa_temporal}.bak al directori %s; si el teu balanç o transaccions son incorrectes hauries de restaurar-lo de un backup.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Intentar recuperar les claus privades d&apos;un arxiu wallet.dat corrupte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Versió RPC del client Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Opcions de la creació de blocs:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Connectar només al(s) node(s) especificats</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>S&apos;ha detectat una base de dades de blocs corrupta</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Descobrir la pròpia adreça IP (per defecte: 1 quan escoltant i no -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Vols reconstruir la base de dades de blocs ara?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Error carregant la base de dades de blocs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Error inicialitzant l&apos;entorn de la base de dades del moneder %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Error carregant la base de dades del bloc</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Error obrint la base de dades de blocs</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Error: Espai al disc baix!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Error: El moneder està blocat, no és possible crear la transacció!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Error: error de sistema:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Error al escoltar a qualsevol port. Utilitza -listen=0 si vols això.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Ha fallat la lectura de la informació del bloc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Ha fallat la lectura del bloc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Ha fallat la sincronització de l&apos;índex de bloc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Ha fallat la escriptura de l&apos;índex de blocs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Ha fallat la escriptura de la informació de bloc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Ha fallat l&apos;escriptura del bloc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Ha fallat l&apos;escriptura de l&apos;arxiu info</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Ha fallat l&apos;escriptura de la basse de dades de monedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Ha fallat l&apos;escriptura de l&apos;índex de transaccions</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Ha fallat el desfer de dades</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Cerca punts de connexió usant rastreig de DNS (per defecte: 1 tret d&apos;usar -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generar monedes (estàndard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Quants blocs s&apos;han de confirmar a l&apos;inici (per defecte: 288, 0 = tots)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Com verificar el bloc (0-4, per defecte 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Reconstruir l&apos;índex de la cadena de blocs dels arxius actuals blk000??.dat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Enviar comandament al servidor de Bitcoin</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Estableix el nombre de fils per atendre trucades RPC (per defecte: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Especifica un arxiu de moneder (dintre del directori de les dades)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Arranca el servidor de Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verificant blocs...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Verificant moneder...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importa blocs de un fitxer blk000??.dat extern</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>&amp;Informació</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Mantenir tot l&apos;índex de transaccions (per defecte: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Mida màxima del buffer de recepció per a cada connexió, &lt;n&gt;*1000 bytes (default: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Mida màxima del buffer d&apos;enviament per a cada connexió, &lt;n&gt;*1000 bytes (default: 5000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Tan sols acceptar cadenes de blocs que coincideixin amb els punts de prova (per defecte: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Només connectar als nodes de la xarxa &lt;net&gt; (IPv4, IPv6 o Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Opcions SSL: (veure la Wiki de Bitcoin per a instruccions de configuració SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Enviar informació de traça/debug a la consola en comptes del arxiu debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Establir una mida mínima de bloc en bytes (per defecte: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Reduir l&apos;arxiu debug.log al iniciar el client (per defecte 1 quan no -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Especificar el temps limit per a un intent de connexió en milisegons (per defecte: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Error de sistema:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Utilitza UPnP per a mapejar els ports d&apos;escolta (per defecte: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Utilitza UPnP per a mapejar els ports d&apos;escolta (per defecte: 1 quan s&apos;escolta)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nom d&apos;usuari per a connexions JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Avís</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Advertència: Aquetsa versió està obsoleta, és necessari actualitzar!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>versió</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>L&apos;arxiu wallet.data és corrupte, el rescat de les dades ha fallat</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Contrasenya per a connexions JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permetre connexions JSON-RPC d&apos;adreces IP específiques</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Enviar ordre al node en execució a &lt;ip&gt; (per defecte: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Executar orde quan el millor bloc canviï (%s al cmd es reemplaça per un bloc de hash)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Actualitzar moneder a l&apos;últim format</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Establir límit de nombre de claus a &lt;n&gt; (per defecte: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Re-escanejar cadena de blocs en cerca de transaccions de moneder perdudes</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Utilitzar OpenSSL (https) per a connexions JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Arxiu del certificat de servidor (per defecte: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Clau privada del servidor (per defecte: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Aquest misatge d&apos;ajuda</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Impossible d&apos;unir %s a aquest ordinador (s&apos;ha retornat l&apos;error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permetre consultes DNS per a -addnode, -seednode i -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Carregant adreces...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Error carregant wallet.dat: Moneder corrupte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Error carregant wallet.dat: El moneder requereix una versió de Bitcoin més moderna</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>El moneder necesita ser re-escrit: re-inicia Bitcoin per a completar la tasca</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Error carregant wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Adreça -proxy invalida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Xarxa desconeguda especificada a -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>S&apos;ha demanat una versió desconeguda de -socks proxy: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>No es pot resoldre l&apos;adreça -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>No es pot resoldre l&apos;adreça -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantitat invalida per a -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Quanitat invalida</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Balanç insuficient</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Carregant índex de blocs...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Afegir un node per a connectar&apos;s-hi i intentar mantenir la connexió oberta</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Impossible d&apos;unir %s en aquest ordinador. Probablement Bitcoin ja estigui en execució.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Carregant moneder...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>No es pot reduir la versió del moneder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>No es pot escriure l&apos;adreça per defecte</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Re-escanejant...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Càrrega acabada</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Utilitza la opció %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_cmn.ts
+++ b/src/qt/locale/bitcoin_cmn.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,18 +19,14 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -41,122 +34,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,363 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -688,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -706,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -714,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1006,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1074,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1102,57 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1160,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1218,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1246,258 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1505,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1575,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1669,29 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1699,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1722,194 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1917,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2023,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2091,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2129,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2377,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2476,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2489,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2676,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2694,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2702,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2887,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2900,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3028,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3207,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3215,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3223,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3266,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,852 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_cs.ts
+++ b/src/qt/locale/bitcoin_cs.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Tohle je experimentální program.
 Tento produkt zahrnuje programy vyvinuté OpenSSL Projektem pro použití v OpenSSL Toolkitu (http://www.openssl.org/) a kryptografický program od Erika Younga (eay@cryptsoft.com) a program UPnP od Thomase Bernarda.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dvojklikem myši začneš upravovat označení adresy</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Vytvoř novou adresu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Zkopíruj aktuálně vybranou adresu do systémové schránky</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopíruj adresu</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Smaž zvolenou adresu ze seznamu</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportuj data z tohoto panelu do souboru</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Export</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>S&amp;maž</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Tohle jsou tvé Bitcoinové adresy pro posílání plateb. Před odesláním mincí si vždy zkontroluj částku a cílovou adresu.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopíruj &amp;označení</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Uprav</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>CSV formát (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ Tento produkt zahrnuje programy vyvinuté OpenSSL Projektem pro použití v Open
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Označení</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(bez označení)</translation>
     </message>
@@ -187,140 +153,106 @@ Tento produkt zahrnuje programy vyvinuté OpenSSL Projektem pro použití v Open
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Změna hesla</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Zadej platné heslo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Zadej nové heslo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Totéž heslo ještě jednou</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Zadej nové heslo k peněžence.&lt;br/&gt;Použij &lt;b&gt;alespoň 10 náhodných znaků&lt;/b&gt; nebo &lt;b&gt;alespoň osm slov&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Zašifruj peněženku</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>K provedení této operace musíš zadat heslo k peněžence, aby se mohla odemknout.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Odemkni peněženku</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>K provedení této operace musíš zadat heslo k peněžence, aby se mohla dešifrovat.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dešifruj peněženku</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Změň heslo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Zadej staré a nové heslo k peněžence.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Potvrď zašifrování peněženky</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Varování: Pokud si zašifruješ peněženku a ztratíš či zapomeneš heslo, &lt;b&gt;PŘIJDEŠ O VŠECHNY BITCOINY&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Jsi si jistý, že chceš peněženku zašifrovat?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>DŮLEŽITÉ: Všechny předchozí zálohy peněženky by měly být nahrazeny nově vygenerovanou, zašifrovanou peněženkou. Z bezpečnostních důvodů budou předchozí zálohy nešifrované peněženky nepoužitelné, jakmile začneš používat novou zašifrovanou peněženku.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Upozornění: Caps Lock je zapnutý!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Peněženka je zašifrována</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin se teď ukončí, aby dokončil zašifrování. Pamatuj však, že pouhé zašifrování peněženky úplně nezabraňuje krádeži tvých bitcoinů malwarem, kterým se může počítač nakazit.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Zašifrování peněženky selhalo</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Zašifrování peněženky selhalo kvůli vnitřní chybě. Tvá peněženka tedy nebyla zašifrována.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Zadaná hesla nejsou shodná.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Odemčení peněženky selhalo</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Nezadal jsi správné heslo pro dešifrování peněženky.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Dešifrování peněženky selhalo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Heslo k peněžence bylo v pořádku změněno.</translation>
     </message>
@@ -328,362 +260,286 @@ Tento produkt zahrnuje programy vyvinuté OpenSSL Projektem pro použití v Open
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Po&amp;depiš zprávu...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synchronizuji se se sítí...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Přehled</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Zobraz celkový přehled peněženky</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transakce</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Procházej historii transakcí</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Konec</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Ukonči aplikaci</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Zobraz informace o Bitcoinu</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Zobraz informace o Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Možnosti...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>Zaši&amp;fruj peněženku...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Zazálohuj peněženku...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>Změň &amp;heslo...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importuji bloky z disku...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Vytvářím nový index bloků na disku...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Pošli mince na Bitcoinovou adresu</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Uprav nastavení Bitcoinu</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Zazálohuj peněženku na jiné místo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Změň heslo k šifrování peněženky</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Ladicí okno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Otevři ladicí a diagnostickou konzoli</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Ověř zprávu...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Peněženka</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Pošli</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>Při&amp;jmi</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Zobraz/Skryj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Zobraz nebo skryj hlavní okno</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Zašifruj soukromé klíče ve své peněžence</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Podepiš zprávy svými Bitcoinovými adresami, čímž prokážeš, že jsi jejich vlastníkem</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Ověř zprávy, aby ses ujistil, že byly podepsány danými Bitcoinovými adresami</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Soubor</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Nastavení</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>Ná&amp;pověda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Panel s listy</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Jádro Bitcoinu</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin klient</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktivní spojení do Bitcoinové sítě</numerusform><numerusform>%n aktivní spojení do Bitcoinové sítě</numerusform><numerusform>%n aktivních spojení do Bitcoinové sítě</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Není dostupný žádný zdroj bloků...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Zpracováno %1 z přibližně %2 bloků transakční historie.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Zpracováno %1 bloků transakční historie.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>hodinu</numerusform><numerusform>%n hodiny</numerusform><numerusform>%n hodin</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>den</numerusform><numerusform>%n dny</numerusform><numerusform>%n dnů</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>týden</numerusform><numerusform>%n týdny</numerusform><numerusform>%n týdnů</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>Stahuji ještě bloky transakcí za poslední %1</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Poslední stažený blok byl vygenerován %1 zpátky.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Následné transakce ještě nebudou vidět.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Upozornění</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informace</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Aktuální</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Stahuji...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Odeslané transakce</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Příchozí transakce</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +552,14 @@ Adresa: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Peněženka je &lt;b&gt;zašifrovaná&lt;/b&gt; a momentálně &lt;b&gt;odemčená&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Peněženka je &lt;b&gt;zašifrovaná&lt;/b&gt; a momentálně &lt;b&gt;zamčená&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Stala se fatální chyba. Bitcoin nemůže bezpečně pokračovat v činnosti, a proto skončí.</translation>
     </message>
@@ -714,7 +567,6 @@ Adresa: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Upozornění sítě</translation>
     </message>
@@ -722,291 +574,230 @@ Adresa: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Částka:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Potvrzeno</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopírovat sdresu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopírovat popis</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopíruj částku</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopíruj ID transakce</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1014,67 +805,54 @@ Adresa: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Uprav adresu</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Označení</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adresa</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nová přijímací adresa</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nová odesílací adresa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Uprav přijímací adresu</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Uprav odesílací adresu</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Zadaná adresa &quot;%1&quot; už v adresáři je.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Zadaná adresa &quot;%1&quot; není platná Bitcoinová adresa.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Nemohu odemknout peněženku.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Nepodařilo se mi vygenerovat nový klíč.</translation>
     </message>
@@ -1082,27 +860,22 @@ Adresa: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Vytvoří se nový adresář pro data.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>název</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Adresář už existuje. Přidej %1, pokud tady chceš vytvořit nový adresář.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Taková cesta už existuje, ale není adresářem.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Tady nemůžu vytvořit adresář pro data.</translation>
     </message>
@@ -1110,52 +883,46 @@ Adresa: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Jádro Bitcoinu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>verze</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Užití:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>možnosti příkazové řádky</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Možnosti UI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Nastavit jazyk, například &quot;de_DE&quot; (výchozí: systémové nastavení)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Nastartovat minimalizovaně</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Zobrazit startovací obrazovku (výchozí: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Zvolit adresář pro data při startu (výchozí: 0)</translation>
     </message>
@@ -1163,57 +930,46 @@ Adresa: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Vítej</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Použij výchozí adresář pro data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Použij tento adresář pro data:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Chyba: Nejde vytvořit požadovaný adresář pro data „%1“.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB volného místa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(z potřebných %1 GB)</translation>
     </message>
@@ -1221,27 +977,22 @@ Adresa: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1249,253 +1000,206 @@ Adresa: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Hlavní</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Dobrovolný transakční poplatek za každý započatý kB dopomáhá k rychlému zpracování tvých transakcí. Většina transakcí má do 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Platit &amp;transakční poplatek</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Automaticky spustí Bitcoin po přihlášení do systému.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>S&amp;pustit Bitcoin po přihlášení do systému</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Nastavení počtu vláken pro verifikaci skriptů (max. 16, 0 = automaticky, &lt;0 = nechat daný počet jader volný, výchozí: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Vrátí všechny volby na výchozí hodnoty.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Obnovit nastavení</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Síť</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Automaticky otevře potřebný port na routeru. Tohle funguje jen za předpokladu, že tvůj router podporuje UPnP a že je UPnP povolené.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Namapovat port přes &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP adresa proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>Por&amp;t:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Port proxy (např. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Verze SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Verze SOCKS proxy (např. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>O&amp;kno</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Po minimalizaci okna zobrazí pouze ikonu v panelu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimalizovávat do ikony v panelu</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Zavřením se aplikace minimalizuje. Pokud je tato volba zaškrtnuta, tak se aplikace ukončí pouze zvolením Konec v menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>Za&amp;vřením minimalizovat</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>Zobr&amp;azení</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Jazyk uživatelského rozhraní:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Tady lze nastavit jazyk uživatelského rozhraní. Nastavení se projeví až po restartování Bitcoinu.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>J&amp;ednotka pro částky: </translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Zvol výchozí podjednotku, která se bude zobrazovat v programu a při posílání mincí.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Zda ukazovat bitcoinové adresy ve výpisu transakcí nebo ne.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>Ukazo&amp;vat adresy ve výpisu transakcí</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;Budiž</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Zrušit</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>výchozí</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Potvrzení obnovení nastavení</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Zadaná adresa proxy je neplatná.</translation>
     </message>
@@ -1503,69 +1207,54 @@ Adresa: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulář</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Zobrazené informace nemusí být aktuální. Tvá peněženka se automaticky sesynchronizuje s Bitcoinovou sítí, jakmile se s ní spojí. Zatím ale ještě není synchronizace dokončena.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Peněženka</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Aktuální disponibilní stav tvého účtu</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Celkem z transakcí, které ještě nejsou potvrzené a které se ještě nezapočítávají do celkového disponibilního stavu účtu</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Nedozráno:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Vytěžené mince, které ještě nejsou zralé</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Celkem:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Celkový stav tvého účtu</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Poslední transakce&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>nesynchronizováno</translation>
     </message>
@@ -1573,93 +1262,70 @@ Adresa: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Zpracování URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>Nepodařilo se analyzovat URI! Důvodem může být neplatná Bitcoinová adresa nebo poškozené parametry URI.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Požadovaná platební částka ve výši %1 je příliš malá (požadovaná za prach).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Nemůžu spustit bitcoin: obsluha click-to-pay</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Vrácení peněz od %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Chyba komunikující s %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Špatná reakce serveru %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Platba potvrzena</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1667,23 +1333,22 @@ Adresa: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Chyba: Zadaný adresář pro data „%1“ neexistuje.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Zadej Bitcoinovou adresu (např. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1691,22 +1356,18 @@ Adresa: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Ulož Obrázek...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Kopíruj Obraz</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Ulož QR kód</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1714,192 +1375,146 @@ Adresa: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Název klienta</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Verze klienta</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informace</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Používaná verze OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Čas spuštění</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Síť</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Počet spojení</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Řetězec bloků</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Aktuální počet bloků</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Odhad celkového počtu bloků</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Čas posledního bloku</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Otevřít</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konzole</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Provoz na síti</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Datum kompilace</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Soubor s ladicími záznamy</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Otevři soubor s ladicími záznamy Bitcoinu z aktuálního datového adresáře. U velkých logů to může pár vteřin zabrat.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Vyčistit konzoli</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Vítej v Bitcoinové RPC konzoli.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>V historii se pohybuješ šipkami nahoru a dolů a pomocí &lt;b&gt;Ctrl-L&lt;/b&gt; čistíš obrazovku.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Napsáním &lt;b&gt;help&lt;/b&gt; si vypíšeš přehled dostupných příkazů.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1907,105 +1522,82 @@ Adresa: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>O&amp;značení:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopírovat popis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopíruj částku</translation>
     </message>
@@ -2013,67 +1605,54 @@ Adresa: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Ulož Obrázek...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Zpráva</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Výsledná URI je příliš dlouhá, zkus zkrátit text označení / zprávy.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Chyba při kódování URI do QR kódu.</translation>
     </message>
@@ -2081,37 +1660,30 @@ Adresa: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Zpráva</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2119,247 +1691,194 @@ Adresa: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Pošli mince</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Částka:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Pošli více příjemcům naráz</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Při&amp;dej příjemce</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Všechno s&amp;maž</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Stav účtu:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Potvrď odeslání</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>P&amp;ošli</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Potvrď odeslání mincí</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopíruj částku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresa příjemce je neplatná, překontroluj ji prosím.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Odesílaná částka musí být větší než 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Částka překračuje stav účtu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Celková částka při připočítání poplatku %1 překročí stav účtu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Zaznamenána duplikovaná adresa; každá adresa může být v odesílané platbě pouze jednou.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2367,98 +1886,74 @@ Adresa: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Čás&amp;tka:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Komu:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adresa příjemce (např. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Zadej označení této adresy; obojí se ti pak uloží do adresáře</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>O&amp;značení:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Vlož adresu ze schránky</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Zpráva:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2466,12 +1961,10 @@ Adresa: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2479,186 +1972,142 @@ Adresa: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Podpisy - podepsat/ověřit zprávu</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Podepiš zprávu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Podepsáním zprávy svými adresami můžeš prokázat, že je skutečně vlastníš. Buď opatrný a nepodepisuj nic vágního; například při phishingových útocích můžeš být lákán, abys něco takového podepsal. Podepisuj pouze zcela úplná a detailní prohlášení, se kterými souhlasíš.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adresa, kterou se zpráva podepíše (např. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Vlož adresu ze schránky</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Sem vepiš zprávu, kterou chceš podepsat</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Podpis</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Zkopíruj aktuálně vybraný podpis do systémové schránky</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Podepiš zprávu, čímž prokážeš, že jsi vlastníkem této Bitcoinové adresy</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Po&amp;depiš zprávu</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Vymaž všechna pole formuláře pro podepsání zrávy</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Všechno &amp;smaž</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Ověř zprávu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>K ověření podpisu zprávy zadej podepisující adresu, zprávu (ověř si, že správně kopíruješ zalomení řádků, mezery, tabulátory apod.) a podpis. Dávej pozor na to, abys nezkopíroval do podpisu víc, než co je v samotné podepsané zprávě, abys nebyl napálen man-in-the-middle útokem.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adresa, kterou je zpráva podepsána (např. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Ověř zprávu, aby ses ujistil, že byla podepsána danou Bitcoinovou adresou</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>O&amp;věř zprávu</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Vymaž všechna pole formuláře pro ověření zrávy</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Zadej Bitcoinovou adresu (např. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Kliknutím na &quot;Podepiš zprávu&quot; vygeneruješ podpis</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Zadaná adresa je neplatná.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Zkontroluj ji prosím a zkus to pak znovu.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Zadaná adresa nepasuje ke klíči.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Odemčení peněženky bylo zrušeno.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Soukromý klíč pro zadanou adresu není dostupný.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Podepisování zprávy selhalo.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Zpráv podepsána.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Podpis nejde dekódovat.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Zkontroluj ho prosím a zkus to pak znovu.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Podpis se neshoduje s hašem zprávy.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Ověřování zprávy selhalo.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Zpráva ověřena.</translation>
     </message>
@@ -2666,17 +2115,14 @@ Adresa: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Jádro Bitcoinu</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2684,7 +2130,6 @@ Adresa: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2692,184 +2137,138 @@ Adresa: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Otřevřeno dokud %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepotvrzeno</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potvrzení</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Stav</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, rozesláno přes 1 uzel</numerusform><numerusform>, rozesláno přes %n uzly</numerusform><numerusform>, rozesláno přes %n uzlů</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Zdroj</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Vygenerováno</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Pro</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>vlastní adresa</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>označení</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Příjem</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>dozraje po jednom bloku</numerusform><numerusform>dozraje po %n blocích</numerusform><numerusform>dozraje po %n blocích</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>neakceptováno</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Výdaj</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Transakční poplatek</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Čistá částka</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Zpráva</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Komentář</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID transakce</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Ladicí informace</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transakce</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Vstupy</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>true</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>false</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, ještě nebylo rozesláno</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Otevřeno pro 1 další blok</numerusform><numerusform>Otevřeno pro %n další bloky</numerusform><numerusform>Otevřeno pro %n dalších bloků</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>neznámo</translation>
     </message>
@@ -2877,12 +2276,10 @@ Adresa: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detaily transakce</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Toto okno zobrazuje detailní popis transakce</translation>
     </message>
@@ -2890,127 +2287,102 @@ Adresa: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Otevřeno pro 1 další blok</numerusform><numerusform>Otevřeno pro %n další bloky</numerusform><numerusform>Otevřeno pro %n dalších bloků</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Otřevřeno dokud %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Potvrzeno (%1 potvrzení)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Tento blok nedostal žádný jiný uzel a pravděpodobně nebude akceptován!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Vygenerováno, ale neakceptováno</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Přijato do</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Přijato od</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Posláno na</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Platba sama sobě</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Vytěženo</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Stav transakce. Najetím myši na toto políčko si zobrazíš počet potvrzení.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Datum a čas přijetí transakce.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Druh transakce.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Cílová adresa transakce.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Částka odečtená z nebo přičtená k účtu.</translation>
     </message>
@@ -3018,178 +2390,142 @@ Adresa: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Vše</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Dnes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Tento týden</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Tento měsíc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Minulý měsíc</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Letos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Rozsah...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Přijato</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Posláno</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Sám sobě</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Vytěženo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Ostatní</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Zadej adresu nebo označení pro její vyhledání</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimální částka</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopíruj adresu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopíruj její označení</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopíruj částku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopíruj ID transakce</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Uprav označení</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Zobraz detaily transakce</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>CSV formát (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Potvrzeno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Označení</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Částka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Rozsah:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>až</translation>
     </message>
@@ -3197,7 +2533,6 @@ Adresa: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3205,7 +2540,6 @@ Adresa: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Pošli mince</translation>
     </message>
@@ -3213,42 +2547,34 @@ Adresa: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Export</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportuj data z tohoto panelu do souboru</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Záloha peněženky</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Data peněženky (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Zálohování selhalo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Úspěšně zazálohováno</translation>
     </message>
@@ -3256,107 +2582,86 @@ Adresa: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Užití:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Výpis příkazů</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Získat nápovědu pro příkaz</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Možnosti:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Konfigurační soubor (výchozí: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>PID soubor (výchozí: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Adresář pro data</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Nastavit velikost databázové vyrovnávací paměti v megabajtech (výchozí: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Čekat na spojení na &lt;portu&gt; (výchozí: 8333 nebo testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Povolit nejvýše &lt;n&gt; připojení k uzlům (výchozí: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Připojit se k uzlu, získat adresy jeho protějšků a odpojit se</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Specifikuj svou veřejnou adresu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Práh pro odpojování zlobivých uzlů (výchozí: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Doba ve vteřinách, po kterou se nebudou moci zlobivé uzly znovu připojit (výchozí: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Při nastavování naslouchacího RPC portu %i pro IPv4 nastala chyba: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Čekat na JSON RPC spojení na &lt;portu&gt; (výchozí: 8332 nebo testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Akceptovat příkazy z příkazové řádky a přes JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Běžet na pozadí jako démon a akceptovat příkazy</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Použít testovací síť (testnet)</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Přijímat spojení zvenčí (výchozí: 1, pokud není zadáno -proxy nebo -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,722 +2686,682 @@ například: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Při nastavování naslouchacího RPC portu %u pro IPv6 nastala chyba, vracím se k IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Poslouchat na zadané adrese. Pro zápis IPv6 adresy použij notaci [adresa]:port</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Nedaří se mi získat zámek na datový adresář %s. Bitcoin pravděpodobně už jednou běží.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Přepnout do módu testování regresí, který používá speciální řetěz, ve kterém jsou mohou být bloky okamžitě vyřešeny. Je to určeno pro nástroje pro regresní testování a vyvíjení aplikací.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Chyba: Transakce byla odmítnuta! Tohle může nastat, pokud nějaké mince z tvé peněženky už jednou byly utraceny, například pokud používáš kopii souboru wallet.dat a mince byly utraceny v druhé kopii, ale nebyly označeny jako utracené v této.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Chyba: Tahle transakce vyžaduje transakční poplatek nejméně %s kvůli velikosti zasílané částky, komplexnosti nebo použití nedávno přijatých mincí!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Spustit příkaz, když se objeví transakce týkající se peněženky (%s se v příkazu nahradí za TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Tohle je testovací verze – používej ji jen na vlastní riziko, ale rozhodně ji nepoužívej k těžbě nebo pro obchodní aplikace</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Upozornění: -paytxfee je nastaveno velmi vysoko! Toto je transakční poplatek, který zaplatíš za každou poslanou transakci.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Upozornění: Zkontroluj, že máš v počítači správně nastavený datum a čas! Pokud jsou nastaveny špatně, Bitcoin nebude fungovat správně.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Upozornění: nastala chyba při čtení souboru wallet.dat! Všechny klíče se přečetly správně, ale data o transakcích nebo záznamy v adresáři mohou chybět či být nesprávné.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Upozornění: soubor wallet.dat je poškozený, data jsou však zachráněna! Původní soubor wallet.dat je uložený jako wallet.{timestamp}.bak v %s. Pokud je stav tvého účtu nebo transakce nesprávné, zřejmě bys měl obnovit zálohu.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Pokusit se zachránit soukromé klíče z poškozeného souboru wallet.dat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Možnosti vytvoření bloku:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Připojit se pouze k zadanému uzlu (příp. zadaným uzlům)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Bylo zjištěno poškození databáze bloků</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Zjistit vlastní IP adresu (výchozí: 1, pokud naslouchá a není zadáno -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Chceš přestavět databázi bloků hned teď?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Chyba při zakládání databáze bloků</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Chyba při vytváření databázového prostředí %s pro peněženku!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Chyba při načítání databáze bloků</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Chyba při otevírání databáze bloků</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Problém: Na disku je málo místa!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Chyba: Peněženka je zamčená, nemohu vytvořit transakci!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Chyba: systémová chyba: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Nepodařilo se naslouchat na žádném portu. Použij -listen=0, pokud to byl tvůj záměr.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Nepodařilo se přečíst informace o bloku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Nepodařilo se přečíst blok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Nepodařilo se sesynchronizovat index bloků</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Nepodařilo se zapsat index bloků</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Nepodařilo se zapsat informace o bloku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Nepodařilo se zapsat blok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Nepodařilo se zapsat informace o souboru</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Selhal zápis do databáze mincí</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Nepodařilo se zapsat index transakcí</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Nepodařilo se zapsat data o vracení změn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Hledat uzly přes DNS (výchozí: 1, pokud není zadáno -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generovat mince (výchozí: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Kolik bloků při startu zkontrolovat (výchozí: 288, 0 = všechny)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Jak moc důkladná má být verifikace bloků (0-4, výchozí: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Nemám žádný nebo jen špatný genesis blok. Není špatně nastavený datadir?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Je nedostatek deskriptorů souborů.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Znovu vytvořit index řetězce bloků z aktuálních blk000??.dat souborů</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Nastavení počtu vláken pro servisní RPC volání (výchozí: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Udej název souboru s peněženkou (v rámci datového adresáře)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Ověřuji bloky...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Kontroluji peněženku...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Peněženka %s se nachází mimo datový adresář %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Je třeba přestavět databázi použitím -reindex, aby bylo možné změnit -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importovat bloky z externího souboru blk000??.dat</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Nastavení počtu vláken pro verifikaci skriptů (max. 16, 0 = automaticky, &lt;0 = nechat daný počet jader volný, výchozí: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informace</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Neplatná částka pro -minrelaytxfee=&lt;částka&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Neplatná částka pro -mintxfee=&lt;částka&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Spravovat úplný index transakcí (výchozí: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maximální velikost přijímacího bufferu pro každé spojení, &lt;n&gt;*1000 bajtů (výchozí: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maximální velikost odesílacího bufferu pro každé spojení, &lt;n&gt;*1000 bajtů (výchozí: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Uznávat pouze řetěz bloků, který odpovídá vnitřním kontrolním bodům (výchozí: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Připojit se pouze k uzlům v &lt;net&gt; síti (IPv4, IPv6 nebo Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Možnosti SSL: (viz instrukce nastavení SSL v Bitcoin Wiki)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Posílat stopovací/ladicí informace do konzole místo do souboru debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Nastavit minimální velikost bloku v bajtech (výchozí: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Při spuštění klienta zmenšit soubor debug.log (výchozí: 1, pokud není zadáno -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Podepisování transakce selhalo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Zadej časový limit spojení v milisekundách (výchozí: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Systémová chyba: </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Částka v transakci je příliš malá</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Částky v transakci musí být kladné</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transace je příliš velká</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Použít UPnP k namapování naslouchacího portu (výchozí: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Použít UPnP k namapování naslouchacího portu (výchozí: 1, pokud naslouchá)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Uživatelské jméno pro JSON-RPC spojení</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Upozornění</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Upozornění: tahle verze je zastaralá, měl bys ji aktualizovat!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>verze</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>Soubor wallet.dat je poškozen, jeho záchrana se nezdařila</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Heslo pro JSON-RPC spojení</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Povolit JSON-RPC spojení ze specifikované IP adresy</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Posílat příkazy uzlu běžícím na &lt;ip&gt; (výchozí: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Spustit příkaz, když se změní nejlepší blok (%s se v příkazu nahradí hashem bloku)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Převést peněženku na nejnovější formát</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Nastavit zásobník klíčů na velikost &lt;n&gt; (výchozí: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Přeskenovat řetězec bloků na chybějící transakce tvé pěněženky</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Použít OpenSSL (https) pro JSON-RPC spojení</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Soubor se serverovým certifikátem (výchozí: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Soubor se serverovým soukromým klíčem (výchozí: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Tato nápověda</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Nedaří se mi připojit na %s na tomhle počítači (operace bind vrátila chybu %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Povolit DNS dotazy pro -addnode (přidání uzlu), -seednode a -connect (připojení)</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Načítám adresy...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Chyba při načítání wallet.dat: peněženka je poškozená</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Chyba při načítání wallet.dat: peněženka vyžaduje novější verzi Bitcoinu</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Soubor s peněženkou potřeboval přepsat: restartuj Bitcoin, aby se operace dokončila</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Chyba při načítání wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Neplatná -proxy adresa: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>V -onlynet byla uvedena neznámá síť: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>V -socks byla požadována neznámá verze proxy: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Nemohu přeložit -bind adresu: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Nemohu přeložit -externalip adresu: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Neplatná částka pro -paytxfee=&lt;částka&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Neplatná částka</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Nedostatek prostředků</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Načítám index bloků...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Přidat uzel, ke kterému se připojit a snažit se spojení udržet</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Nedaří se mi připojit na %s na tomhle počítači. Bitcoin už pravděpodobně jednou běží.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Načítám peněženku...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Nemohu převést peněženku do staršího formátu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Nemohu napsat výchozí adresu</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Přeskenovávám...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Načítání dokončeno</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>K použití volby %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_cy.ts
+++ b/src/qt/locale/bitcoin_cy.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Clicio dwywaith i olygu cyfeiriad neu label</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Creu cyfeiriad newydd</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copio&apos;r cyfeiriad sydd wedi&apos;i ddewis i&apos;r clipfwrdd system</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Dileu</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Cyfeiriad</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(heb label)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Teipiwch gyfrinymadrodd</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Cyfrinymadrodd newydd</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Ailadroddwch gyfrinymadrodd newydd</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Dewiswch gyfrinymadrodd newydd ar gyfer y waled. &lt;br/&gt; Defnyddiwch cyfrinymadrodd o &lt;b&gt;10 neu fwy o lythyrennau hapgyrch&lt;/b&gt;, neu &lt;b&gt; wyth neu fwy o eiriau.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Amgryptio&apos;r waled</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Mae angen i&apos;r gweithred hon ddefnyddio&apos;ch cyfrinymadrodd er mwyn datgloi&apos;r waled.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Datgloi&apos;r waled</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Mae angen i&apos;r gweithred hon ddefnyddio&apos;ch cyfrinymadrodd er mwyn dadgryptio&apos;r waled.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dadgryptio&apos;r waled</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Newid cyfrinymadrodd</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Teipiwch yr hen cyfrinymadrodd a chyfrinymadrodd newydd i mewn i&apos;r waled.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Cadarnau amgryptiad y waled</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Waled wedi&apos;i amgryptio</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Amgryptiad waled wedi methu</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Methodd amgryptiad y waled oherwydd gwall mewnol. Ni amgryptwyd eich waled.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Dydy&apos;r cyfrinymadroddion a ddarparwyd ddim yn cyd-fynd â&apos;u gilydd.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Methodd ddatgloi&apos;r waled</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Methodd dadgryptiad y waled</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Cysoni â&apos;r rhwydwaith...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Trosolwg</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Dangos trosolwg cyffredinol y waled</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Trafodion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Pori hanes trafodion</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Gadael rhaglen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Dangos gwybodaeth am Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opsiynau</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Newid y cyfrinymadrodd a ddefnyddiwyd ar gyfer amgryptio&apos;r waled</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Ffeil</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Gosodiadau</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Cymorth</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Bar offer tabiau</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Gwall</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Rhybudd</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Gwybodaeth</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Cyfamserol</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Dal i fyny</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Trafodiad a anfonwyd</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Trafodiad sy&apos;n cyrraedd</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Mae&apos;r waled &lt;b&gt;wedi&apos;i amgryptio&lt;/b&gt; ac &lt;b&gt;heb ei gloi&lt;/b&gt; ar hyn o bryd</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Mae&apos;r waled &lt;b&gt;wedi&apos;i amgryptio&lt;/b&gt; ac &lt;b&gt;ar glo&lt;/b&gt; ar hyn o bryd</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Cyfeiriad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Dyddiad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(heb label)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Golygu&apos;r cyfeiriad</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Label</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Cyfeiriad</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Cyfeiriad derbyn newydd</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Cyfeiriad anfon newydd</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Golygu&apos;r cyfeiriad derbyn</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Golygu&apos;r cyfeiriad anfon</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Mae&apos;r cyfeiriad &quot;%1&quot; sydd newydd gael ei geisio gennych yn y llyfr cyfeiriad yn barod.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Methodd ddatgloi&apos;r waled.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Methodd gynhyrchu allwedd newydd.</translation>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Gwall</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opsiynau</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Ffurflen</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Trafodion diweddar&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Label:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Cyfeiriad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Neges</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Dyddiad</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Neges</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(heb label)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Anfon arian</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Anfon at pobl lluosog ar yr un pryd</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Gweddill:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Cadarnhau&apos;r gweithrediad anfon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 i %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(heb label)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Maint</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Label:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Gludo cyfeiriad o&apos;r glipfwrdd</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Gludo cyfeiriad o&apos;r glipfwrdd</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Agor tan %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Dyddiad</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Neges</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Dyddiad</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Math</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Cyfeiriad</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Agor tan %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Heddiw</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Eleni</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Dyddiad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Math</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Cyfeiriad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Gwybodaeth</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Rhybudd</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Gwall</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_da.ts
+++ b/src/qt/locale/bitcoin_da.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Det er gjort tilgængeligt under MIT/X11-softwarelicensen. Se den medfølgende f
 Produktet indeholder software som er udviklet af OpenSSL Project til brug i OpenSSL Toolkit (http://www.openssl.org/), kryptografisk software skrevet af Eric Young (eay@cryptsoft.com) og UPnP-software skrevet af Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dobbeltklik for at redigere adresse eller mærkat</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Opret en ny adresse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Ny</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopier den valgte adresse til systemets udklipsholder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopiér</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>Kopier adresse</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Slet den markerede adresse fra listen</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Eksportér den aktuelle visning til en fil</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>Eksporter</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>Slet</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Disse er dine Bitcoin-adresser for at sende betalinger. Tjek altid beløb og modtageradresse, inden du sender bitcoins.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopier mærkat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>Rediger</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommasepareret fil (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ Produktet indeholder software som er udviklet af OpenSSL Project til brug i Open
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Mærkat</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(ingen mærkat)</translation>
     </message>
@@ -187,140 +153,106 @@ Produktet indeholder software som er udviklet af OpenSSL Project til brug i Open
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Adgangskodedialog</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Indtast adgangskode</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Ny adgangskode</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Gentag ny adgangskode</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Indtast den nye adgangskode til tegnebogen.&lt;br/&gt;Brug venligst en adgangskode på &lt;b&gt;10 eller flere tilfældige tegn&lt;/b&gt; eller &lt;b&gt;otte eller flere ord&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Krypter tegnebog</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Denne funktion har brug for din tegnebogs adgangskode for at låse tegnebogen op.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Lås tegnebog op</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Denne funktion har brug for din tegnebogs adgangskode for at dekryptere tegnebogen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dekrypter tegnebog</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Skift adgangskode</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Indtast den gamle og den nye adgangskode til tegnebogen.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Bekræft tegnebogskryptering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Advarsel: Hvis du krypterer din tegnebog og mister din adgangskode, vil du &lt;b&gt;MISTE ALLE DINE BITCOINS&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Er du sikker på, at du ønsker at kryptere din tegnebog?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>VIGTIGT: Enhver tidligere sikkerhedskopi, som du har lavet af tegnebogsfilen, bør blive erstattet af den nyligt genererede, krypterede tegnebogsfil. Af sikkerhedsmæssige årsager vil tidligere sikkerhedskopier af den ikke-krypterede tegnebogsfil blive ubrugelig i det øjeblik, du starter med at anvende den nye, krypterede tegnebog.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Advarsel: Caps Lock-tasten er aktiveret!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Tegnebog krypteret</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin vil nu lukke for at gennemføre krypteringsprocessen. Husk på, at kryptering af din tegnebog vil ikke beskytte dine bitcoins fuldt ud mod at blive stjålet af malware på din computer.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Tegnebogskryptering mislykkedes</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Tegnebogskryptering mislykkedes på grund af en intern fejl. Din tegnebog blev ikke krypteret.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>De angivne adgangskoder stemmer ikke overens.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Tegnebogsoplåsning mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Den angivne adgangskode for tegnebogsdekrypteringen er forkert.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Tegnebogsdekryptering mislykkedes</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Tegnebogens adgangskode blev ændret.</translation>
     </message>
@@ -328,362 +260,286 @@ Produktet indeholder software som er udviklet af OpenSSL Project til brug i Open
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Underskriv besked...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synkroniserer med netværk...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>Oversigt</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Vis generel oversigt over tegnebog</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>Transaktioner</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Gennemse transaktionshistorik</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>Luk</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Afslut program</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Vis informationer om Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Om Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Vis informationer om Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>Indstillinger...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>Krypter tegnebog...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>Sikkerhedskopier tegnebog...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>Skift adgangskode...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importerer blokke fra disken...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Genindekserer blokke på disken...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Send bitcoins til en Bitcoin-adresse</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Rediger konfigurationsindstillinger af Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Lav sikkerhedskopi af tegnebogen til et andet sted</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Skift adgangskode anvendt til tegnebogskryptering</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Fejlsøgningsvindue</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Åbn fejlsøgnings- og diagnosticeringskonsollen</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>Verificér besked...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Tegnebog</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>Send</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>Modtag</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>Vis / skjul</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Vis eller skjul hovedvinduet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Krypter de private nøgler, der hører til din tegnebog</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Underskriv beskeder med dine Bitcoin-adresser for at bevise, at de tilhører dig</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verificér beskeder for at sikre, at de er underskrevet med de(n) angivne Bitcoin-adresse(r)</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>Fil</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>Indstillinger</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>Hjælp</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Faneværktøjslinje</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnetværk]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin-klient</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktiv(e) forbindelse(r) til Bitcoin-netværket</numerusform><numerusform>%n aktiv(e) forbindelse(r) til Bitcoin-netværket</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Ingen blokkilde tilgængelig...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Behandlet %1 ud af %2 (estimeret) blokke af transaktionshistorikken.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Behandlet %1 blokke af transaktionshistorikken.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
-        <translation><numerusform>%n time(r)</numerusform><numerusform>%n time(r)</numerusform></translation>
+        <translation><numerusform>%n time</numerusform><numerusform>%n timer</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
-        <translation><numerusform>%n dag(e)</numerusform><numerusform>%n dag(e)</numerusform></translation>
+        <translation><numerusform>%n dag</numerusform><numerusform>%n dage</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
-        <translation><numerusform>%n uge(r)</numerusform><numerusform>%n uge(r)</numerusform></translation>
+        <translation><numerusform>%n uge</numerusform><numerusform>%n uger</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 bagud</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Senest modtagne blok blev genereret for %1 siden.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transaktioner herefter vil endnu ikke være synlige.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Opdateret</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Indhenter...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Afsendt transaktion</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Indgående transaktion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +552,14 @@ Adresse: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Tegnebog er &lt;b&gt;krypteret&lt;/b&gt; og i øjeblikket &lt;b&gt;ulåst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Tegnebog er &lt;b&gt;krypteret&lt;/b&gt; og i øjeblikket &lt;b&gt;låst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Der opstod en fatal fejl. Bitcoin kan ikke længere fortsætte sikkert og vil afslutte.</translation>
     </message>
@@ -714,7 +567,6 @@ Adresse: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Netværksadvarsel</translation>
     </message>
@@ -722,291 +574,230 @@ Adresse: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Beløb:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Bekræftet</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopier adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopier mærkat</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopier beløb</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopier transaktionens ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(ingen mærkat)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1014,67 +805,54 @@ Adresse: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Rediger adresse</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>Mærkat</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Ny modtagelsesadresse</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Ny afsendelsesadresse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Rediger modtagelsesadresse</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Rediger afsendelsesadresse</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Den indtastede adresse &quot;%1&quot; er allerede i adressebogen.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Den indtastede adresse &quot;%1&quot; er ikke en gyldig Bitcoin-adresse.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Kunne ikke låse tegnebog op.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Ny nøglegenerering mislykkedes.</translation>
     </message>
@@ -1082,27 +860,22 @@ Adresse: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>navn</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1110,52 +883,46 @@ Adresse: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>version</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Anvendelse:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>kommandolinjetilvalg</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Brugergrænsefladeindstillinger</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Angiv sprog, f.eks &quot;de_DE&quot; (standard: systemlokalitet)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Start minimeret</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Vis opstartsbillede ved start (standard: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1163,57 +930,46 @@ Adresse: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Velkommen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1221,27 +977,22 @@ Adresse: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1249,253 +1000,206 @@ Adresse: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Indstillinger</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>Generelt</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Valgfrit transaktionsgebyr pr. kB, der hjælper dine transaktioner med at blive behandlet hurtigt. De fleste transaktioner er på 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Betal transaktionsgebyr</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Start Bitcoin automatisk, når der logges ind på systemet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>Start Bitcoin, når systemet startes</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Angiv nummeret af tråde til verificering af script (op til 16, 0 = automatisk, &lt;0 = efterlad det antal kerner tilgængelige, standard: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Nulstil alle klientindstillinger til deres standard.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>Nulstil indstillinger</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>Netværk</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Åbn Bitcoin-klientens port på routeren automatisk. Dette virker kun, når din router understøtter UPnP og UPnP er aktiveret.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Konfigurer port vha. UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy-IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Porten på proxyen (f.eks. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS-version</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS-version af proxyen (f.eks. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>Vindue</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Vis kun et statusikon efter minimering af vinduet.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>Minimer til statusfeltet i stedet for proceslinjen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimer i stedet for at afslutte programmet, når vinduet lukkes. Når denne indstilling er valgt, vil programmet kun blive lukket, når du har valgt Afslut i menuen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>Minimer ved lukning</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>Visning</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Brugergrænsefladesprog:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Brugergrænsefladesproget kan angives her. Denne indstilling træder først i kraft, når Bitcoin genstartes.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Enhed at vise beløb i:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Vælg den standard underopdelingsenhed, som skal vises i brugergrænsefladen og ved afsendelse af bitcoins.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Afgør hvorvidt Bitcoin-adresser skal vises i transaktionslisten eller ej.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>Vis adresser i transaktionsliste</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>Annuller</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>standard</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Bekræft nulstilling af indstillinger</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Ugyldig proxy-adresse</translation>
     </message>
@@ -1503,69 +1207,54 @@ Adresse: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formular</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Den viste information kan være forældet. Din tegnebog synkroniserer automatisk med Bitcoin-netværket, når en forbindelse etableres, men denne proces er ikke gennemført endnu.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Tegnebog</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Din nuværende tilgængelige saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Total transaktioner, som ikke er blevet bekræftet endnu, og som ikke endnu er en del af den nuværende saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Umodne:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Udvunden saldo, som endnu ikke er modnet</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Din nuværende totale saldo</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Nyeste transaktioner&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>ikke synkroniseret</translation>
     </message>
@@ -1573,93 +1262,70 @@ Adresse: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI-håndtering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI kan ikke fortolkes! Dette kan skyldes en ugyldig Bitcoin-adresse eller misdannede URI-parametre.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Fejl i betalingsforespørgelse</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Kan ikke starte bitcoin: click-to-pay-håndtering</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Tilbagebetaling fra %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1667,23 +1333,22 @@ Adresse: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Indtast en Bitcoin-adresse (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1691,22 +1356,18 @@ Adresse: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Gem foto...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Kopiér foto</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Gem QR-kode</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1714,298 +1375,229 @@ Adresse: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Klientnavn</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Klientversion</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Anvender OpenSSL-version</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Opstartstid</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Netværk</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Antal forbindelser</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Blokkæde</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Nuværende antal blokke</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Estimeret antal blokke</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Tidsstempel for seneste blok</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>Åbn</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>Konsol</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>Ud:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Byggedato</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Fejlsøgningslogfil</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Åbn Bitcoin-fejlsøgningslogfilen fra det nuværende datakatalog. Dette kan tage nogle få sekunder for en store logfiler.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Ryd konsol</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Velkommen til Bitcoin RPC-konsollen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Brug op og ned-piletasterne til at navigere historikken og &lt;b&gt;Ctrl-L&lt;/b&gt; til at rydde skærmen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Tast &lt;b&gt;help&lt;/b&gt; for en oversigt over de tilgængelige kommandoer.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
-        <translation type="unfinished"/>
+        <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
-        <translation type="unfinished"/>
+        <translation>%1 t</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
-        <translation type="unfinished"/>
+        <translation>%1 t %2 m</translation>
     </message>
 </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Mængde:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>Mærkat:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Besked:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Ryd alle fælter af formen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Ryd</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Anmod betaling</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopier mærkat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopier beløb</translation>
     </message>
@@ -2013,67 +1605,54 @@ Adresse: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR Kode</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Kopiér &amp;URL</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Kopiér &amp;Adresse</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Gem foto...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Betalingsinformation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Mærkat</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Besked</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Resulterende URI var for lang; prøv at forkorte teksten til mærkaten/beskeden.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Fejl ved kodning fra URI til QR-kode</translation>
     </message>
@@ -2081,37 +1660,30 @@ Adresse: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Mærkat</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Besked</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(ingen mærkat)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2119,247 +1691,194 @@ Adresse: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Send bitcoins</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Beløb:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Send til flere modtagere på en gang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Tilføj modtager</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Ryd alle fælter af formen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Ryd alle</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Bekræft afsendelsen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>Afsend</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Bekræft afsendelse af bitcoins</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopier beløb</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Modtagerens adresse er ikke gyldig. Tjek venligst adressen igen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Beløbet til betaling skal være større end 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Beløbet overstiger din saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Totalen overstiger din saldo, når %1 transaktionsgebyr er inkluderet.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Duplikeret adresse fundet. Du kan kun sende til hver adresse en gang pr. afsendelse.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ingen mærkat)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Er du sikker på at du vil sende?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>tilføjet som transaktionsgebyr</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Betalingsforespørgsel udløb</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2367,98 +1886,74 @@ Adresse: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Beløb:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Betal til:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin-adressen som betalingen skal sendes til (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Indtast en mærkat for denne adresse for at føje den til din adressebog</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>Mærkat:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Indsæt adresse fra udklipsholderen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Besked:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2466,12 +1961,10 @@ Adresse: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2479,186 +1972,142 @@ Adresse: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Signature - Underskriv/verificér en besked</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>Underskriv besked</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Du kan underskrive beskeder med dine Bitcoin-adresser for at bevise, at de tilhører dig. Pas på ikke at underskrive noget vagt, da phisingangreb kan narre dig til at overdrage din identitet. Underskriv kun fuldt detaljerede udsagn, du er enig i.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin-adressen som beskeden skal underskrives med (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Indsæt adresse fra udklipsholderen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Indtast beskeden, du ønsker at underskrive</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Underskrift</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Kopier den nuværende underskrift til systemets udklipsholder</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Underskriv denne besked for at bevise, at Bitcoin-adressen tilhører dig</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Underskriv besked</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Nulstil alle &quot;underskriv besked&quot;-felter</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Ryd alle</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>Verificér besked</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Indtast den underskrevne adresse, beskeden (inkluder linjeskift, mellemrum mv. nøjagtigt, som de fremgår) og underskriften for at verificére beskeden. Vær forsigtig med ikke at lægge mere i underskriften end besked selv, så du undgår at blive narret af et man-in-the-middle-angreb.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin-adressen som beskeden er underskrevet med (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verificér beskeden for at sikre, at den er underskrevet med den angivne Bitcoin-adresse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verificér besked</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Nulstil alle &quot;verificér besked&quot;-felter</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Indtast en Bitcoin-adresse (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Klik &quot;Underskriv besked&quot; for at generere underskriften</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Den indtastede adresse er ugyldig.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Tjek venligst adressen, og forsøg igen.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Den indtastede adresse henviser ikke til en nøgle.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Tegnebogsoplåsning annulleret.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Den private nøgle for den indtastede adresse er ikke tilgængelig.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Underskrivning af besked mislykkedes.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Besked underskrevet.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Underskriften kunne ikke afkodes.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Tjek venligst underskriften, og forsøg igen.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Underskriften matcher ikke beskedens indhold.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Verificéring af besked mislykkedes.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Besked verificéret.</translation>
     </message>
@@ -2666,17 +2115,14 @@ Adresse: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2684,7 +2130,6 @@ Adresse: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2692,184 +2137,138 @@ Adresse: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Åben indtil %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/ubekræftet</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 bekræftelser</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, transmitteret igennem %n knude(r)</numerusform><numerusform>, transmitteret igennem %n knude(r)</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Genereret</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Fra</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Til</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>egen adresse</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>mærkat</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Kredit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>modner efter yderligere %n blok(ke)</numerusform><numerusform>modner efter yderligere %n blok(ke)</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>ikke accepteret</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debet</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Transaktionsgebyr</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Nettobeløb</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Besked</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Transaktionens ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Fejlsøgningsinformation</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transaktion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Input</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>sand</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falsk</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, er ikke blevet transmitteret endnu</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
-        <translation><numerusform>Åben %n blok yderligere</numerusform><numerusform>Åben %n blokke yderligere</numerusform></translation>
+        <translation><numerusform>Åbn yderligere %n blok</numerusform><numerusform>Åbn yderligere %n blokke</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>ukendt</translation>
     </message>
@@ -2877,12 +2276,10 @@ Adresse: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Transaktionsdetaljer</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Denne rude viser en detaljeret beskrivelse af transaktionen</translation>
     </message>
@@ -2890,127 +2287,102 @@ Adresse: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
-        <translation><numerusform>Åben %n blok(ke) yderligere</numerusform><numerusform>Åben %n blok(ke) yderligere</numerusform></translation>
+        <translation><numerusform>Åbn yderligere %n blok</numerusform><numerusform>Åbn yderligere %n blokke</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Åben indtil %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bekræftet (%1 bekræftelser)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Denne blok blev ikke modtaget af nogen andre knuder og vil formentlig ikke blive accepteret!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Genereret, men ikke accepteret</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Modtaget med</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Modtaget fra</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Sendt til</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Betaling til dig selv</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Udvundne</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transaktionsstatus. Hold musen over dette felt for at vise antallet af bekræftelser.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Dato og klokkeslæt for modtagelse af transaktionen.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Transaktionstype.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Destinationsadresse for transaktion.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Beløb fjernet eller tilføjet balance.</translation>
     </message>
@@ -3018,178 +2390,142 @@ Adresse: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>I dag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Denne uge</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Denne måned</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Sidste måned</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Dette år</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Interval...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Modtaget med</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Sendt til</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Til dig selv</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Udvundne</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Andet</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Indtast adresse eller mærkat for at søge</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimumsbeløb</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopier adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopier mærkat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopier beløb</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopier transaktionens ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Rediger mærkat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Vis transaktionsdetaljer</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommasepareret fil (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Bekræftet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Mærkat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Beløb</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Interval:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>til</translation>
     </message>
@@ -3197,7 +2533,6 @@ Adresse: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3205,7 +2540,6 @@ Adresse: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Send bitcoins</translation>
     </message>
@@ -3213,42 +2547,34 @@ Adresse: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>Eksporter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Eksportér den aktuelle visning til en fil</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Sikkerhedskopier tegnebog</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Tegnebogsdata (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Foretagelse af sikkerhedskopi fejlede</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Sikkerhedskopieret problemfri</translation>
     </message>
@@ -3256,107 +2582,86 @@ Adresse: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Anvendelse:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Liste over kommandoer</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Få hjælp til en kommando</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Indstillinger:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Angiv konfigurationsfil (standard: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Angiv pid-fil (default: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Angiv datakatalog</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Angiv databasecachestørrelse i megabytes (standard: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Lyt til forbindelser på &lt;port&gt; (standard: 8333 eller testnetværk: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Oprethold højest &lt;n&gt; forbindelser til andre i netværket (standard: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Forbind til en knude for at modtage adresse, og afbryd</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Angiv din egen offentlige adresse</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Grænse for afbrydelse til dårlige forbindelser (standard: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Antal sekunder dårlige forbindelser skal vente før reetablering (standard: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Der opstod en fejl ved angivelse af RPC-porten %u til at lytte på IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Lyt til JSON-RPC-forbindelser på &lt;port&gt; (standard: 8332 eller testnetværk: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Accepter kommandolinje- og JSON-RPC-kommandoer</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Kør i baggrunden som en service, og accepter kommandoer</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Brug testnetværket</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Accepter forbindelser udefra (standard: 1 hvis hverken -proxy eller -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,722 +2686,682 @@ f.eks.: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.com
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Der opstod en fejl ved angivelse af RPC-porten %u til at lytte på IPv6, falder tilbage til IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Tildel til den givne adresse og lyt altid på den. Brug [vært]:port-notation for IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Kan ikke opnå lås på datakatalog %s. Bitcoin er sandsynligvis allerede startet.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Fejl: Transaktionen blev afvist. Dette kan ske, hvis nogle af dine bitcoins i din tegnebog allerede er brugt, som hvis du brugte en kopi af wallet.dat og dine bitcoins er blevet brugt i kopien, men ikke er markeret som brugt her.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Fejl: Denne transaktion kræver et transaktionsgebyr på minimum %s pga. dens størrelse, kompleksitet eller anvendelse af nyligt modtagne bitcoins!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Udfør kommando, når en transaktion i tegnebogen ændres (%s i kommandoen erstattes med TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Dette er en foreløbig testudgivelse - brug på eget ansvar - brug ikke til udvinding eller handelsprogrammer</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Advarsel: -paytxfee er sat meget højt! Dette er det gebyr du vil betale, hvis du sender en transaktion.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Advarsel: Undersøg venligst, at din computers dato og klokkeslæt er korrekt indstillet! Hvis der er fejl i disse, vil Bitcoin ikke fungere korrekt.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Advarsel: fejl under læsning af wallet.dat! Alle nøgler blev læst korrekt, men transaktionsdata eller adressebogsposter kan mangle eller være forkerte.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Advarsel: wallet.dat ødelagt, data reddet! Oprindelig wallet.net gemt som wallet.{timestamp}.bak i %s; hvis din saldo eller dine transaktioner er forkert, bør du genskabe fra en sikkerhedskopi.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Forsøg at genskabe private nøgler fra ødelagt wallet.dat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Blokoprettelsestilvalg:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Tilslut kun til de(n) angivne knude(r)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Ødelagt blokdatabase opdaget</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Find egen IP-adresse (standard: 1 når lytter og ingen -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Ønsker du at genbygge blokdatabasen nu?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Klargøring af blokdatabase mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Klargøring af tegnebogsdatabasemiljøet %s mislykkedes!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Indlæsning af blokdatabase mislykkedes</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Åbning af blokdatabase mislykkedes</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Fejl: Mangel på ledig diskplads!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Fejl: Tegnebog låst, kan ikke oprette transaktion!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Fejl: systemfejl: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Lytning på enhver port mislykkedes. Brug -listen=0, hvis du ønsker dette.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Læsning af blokinformation mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Læsning af blok mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Synkronisering af blokindeks mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Skrivning af blokindeks mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Skrivning af blokinformation mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Skrivning af blok mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Skriving af filinformation mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Skrivning af bitcoin-database mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Skrivning af transaktionsindeks mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Skrivning af genskabelsesdata mislykkedes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Find ligeværdige ved DNS-opslag (standard: 1 hvis ikke -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generer bitcoins (standard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Antal blokke som tjekkes ved opstart (0=alle, standard: 288)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Grundighed af verificéring af blokke (0-4, standard: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>For få tilgængelige fildeskriptorer.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Genbyg blokkædeindeks fra nuværende blk000??.dat filer</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Angiv antallet af tråde til at håndtere RPC-kald (standard: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Start Bitcoin server</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
-        <translation>Verificere blokke...</translation>
+        <translation>Verificerer blokke...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
-        <translation>Verificere tegnebog...</translation>
+        <translation>Verificerer tegnebog...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importerer blokke fra ekstern blk000??.dat fil</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Angiv nummeret af tråde til verificering af script (op til 16, 0 = automatisk, &lt;0 = efterlad det antal kerner tilgængelige, standard: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ugyldigt beløb til -minrelaytxfee=&lt;beløb&gt;:&apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ugyldigt beløb til -mintxfee=&lt;beløb&gt;:&apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Vedligehold et komplet transaktionsindeks (standard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maksimum for modtagelsesbuffer pr. forbindelse, &lt;n&gt;*1000 bytes (standard: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maksimum for afsendelsesbuffer pr. forbindelse, &lt;n&gt;*1000 bytes (standard: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Accepter kun blokkæde, som matcher indbyggede kontrolposter (standard: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Tilslut kun til knuder i netværk &lt;net&gt; (IPv4, IPv6 eller Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL-indstillinger: (se Bitcoin Wiki for SSL-opsætningsinstruktioner)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Send sporings-/fejlsøgningsinformation til konsollen i stedet for debug.log filen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Angiv minimumsblokstørrelse i bytes (standard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Formindsk debug.log filen ved klientopstart (standard: 1 hvis ikke -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Underskrift af transaktion mislykkedes</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Angiv tilslutningstimeout i millisekunder (standard: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Systemfejl: </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Transaktionsbeløb er for lavt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Transaktionsbeløb skal være positive</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transaktionen er for stor</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Forsøg at bruge UPnP til at konfigurere den lyttende port (standard: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Forsøg at bruge UPnP til at konfigurere den lyttende port (standard: 1 når lytter)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Brugernavn til JSON-RPC-forbindelser</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Advarsel: Denne version er forældet, opgradering påkrævet!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>version</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat ødelagt, redning af data mislykkedes</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Adgangskode til JSON-RPC-forbindelser</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Tillad JSON-RPC-forbindelser fra bestemt IP-adresse</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Send kommandoer til knude, der kører på &lt;ip&gt; (standard: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Udfør kommando, når den bedste blok ændres (%s i kommandoen erstattes med blokhash)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Opgrader tegnebog til seneste format</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Angiv nøglepoolstørrelse til &lt;n&gt; (standard: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Gennemsøg blokkæden for manglende tegnebogstransaktioner</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Brug OpenSSL (https) for JSON-RPC-forbindelser</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Servercertifikat-fil (standard: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Serverens private nøgle (standard: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Denne hjælpebesked</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Kunne ikke tildele %s på denne computer (bind returnerede fejl %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Tillad DNS-opslag for -addnode, -seednode og -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Indlæser adresser...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Fejl ved indlæsning af wallet.dat: Tegnebog ødelagt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Fejl ved indlæsning af wallet.dat: Tegnebog kræver en nyere version af Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Det var nødvendigt at genskrive tegnebogen: genstart Bitcoin for at gennemføre</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Fejl ved indlæsning af wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ugyldig -proxy adresse: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Ukendt netværk anført i -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Ukendt -socks proxy-version: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kan ikke finde -bind adressen: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Kan ikke finde -externalip adressen: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ugyldigt beløb for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Ugyldigt beløb</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Manglende dækning</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Indlæser blokindeks...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Tilføj en knude til at forbinde til og forsøg at holde forbindelsen åben</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Kunne ikke tildele %s på denne computer. Bitcoin kører sikkert allerede.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Indlæser tegnebog...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Kan ikke nedgradere tegnebog</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Kan ikke skrive standardadresse</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Genindlæser...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Indlæsning gennemført</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>For at bruge %s mulighed</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Fejl</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_de.ts
+++ b/src/qt/locale/bitcoin_de.ts
@@ -1,18 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.1">
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.0">
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Über Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;&quot;Bitcoin Core&quot;&lt;/b&gt;-Version</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -24,144 +21,116 @@ Dies ist experimentelle Software.
 
 Veröffentlicht unter der MIT/X11-Softwarelizenz, siehe beiligende Datei COPYING oder http://www.opensource.org/licenses/mit-license.php.
 
-Dieses Produkt enthält Software, die vom OpenSSL-Projekt zur Verwendung im OpenSSL-Toolkit (http://www.openssl.org/) entwickelt wurde, sowie kryptographische Software geschrieben von Eric Young (eay@cryptsoft.com) und UPnP-Software geschrieben von Thomas Bernard.</translation>
+Dieses Produkt enthält Software, die vom OpenSSL-Projekt zur Verwendung im OpenSSL-Toolkit (https://www.openssl.org) entwickelt wird, sowie von Eric Young (eay@cryptsoft.com) geschriebene kryptographische Software und von Thomas Bernard geschriebene UPnP-Software.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
-        <translation>Copyright</translation>
+        <translation>Urheberrecht</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Die &quot;Bitcoin Core&quot;-Entwickler</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
-        <translation> (%1-Bit)</translation>
+        <source>(%1-bit)</source>
+        <translation>(%1-Bit)</translation>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
-        <translation>Doppelklicken, um die Adresse oder die Bezeichnung zu bearbeiten</translation>
+        <translation>Doppelklick zum Bearbeiten der Adresse oder der Bezeichnung</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Eine neue Adresse erstellen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Neu</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Ausgewählte Adresse in die Zwischenablage kopieren</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopieren</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>&amp;Schließen</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>Adresse &amp;kopieren</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Ausgewählte Adresse aus der Liste entfernen</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Daten der aktuellen Ansicht in eine Datei exportieren</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>E&amp;xportieren</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Löschen</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Wählen Sie die Adresse aus, an die Sie Bitcoins überweisen möchten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Wählen Sie die Adresse aus, über die Sie Bitcoins empfangen wollen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Auswählen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Zahlungsadressen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Empfangsadressen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Dies sind ihre Bitcoin-Adressen zum Tätigen von Überweisungen. Bitte prüfen Sie den Betrag und die Empfangsadresse, bevor Sie Bitcoins überweisen.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Dies sind ihre Bitcoin-Adressen zum Empfangen von Zahlungen. Es wird empfohlen für jede Transaktion eine neue Empfangsadresse zu verwenden.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>&amp;Bezeichnung kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editieren</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Addressliste exportieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommagetrennte-Datei (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Exportieren fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Beim Speichern der Adressliste nach %1 ist ein Fehler aufgetreten.</translation>
     </message>
@@ -169,17 +138,14 @@ Dieses Produkt enthält Software, die vom OpenSSL-Projekt zur Verwendung im Open
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(keine Bezeichnung)</translation>
     </message>
@@ -187,140 +153,106 @@ Dieses Produkt enthält Software, die vom OpenSSL-Projekt zur Verwendung im Open
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Passphrasendialog</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Passphrase eingeben</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Neue Passphrase</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Neue Passphrase wiederholen</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Geben Sie die neue Passphrase für die Wallet ein.&lt;br&gt;Bitte benutzen Sie eine Passphrase bestehend aus &lt;b&gt;10 oder mehr zufälligen Zeichen&lt;/b&gt; oder &lt;b&gt;8 oder mehr Wörtern&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Wallet verschlüsseln</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Dieser Vorgang benötigt ihre Passphrase, um die Wallet zu entsperren.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Wallet entsperren</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Dieser Vorgang benötigt ihre Passphrase, um die Wallet zu entschlüsseln.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Wallet entschlüsseln</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Passphrase ändern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Geben Sie die alte und neue Wallet-Passphrase ein.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Wallet-Verschlüsselung bestätigen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Warnung: Wenn Sie ihre Wallet verschlüsseln und ihre Passphrase verlieren, werden Sie &lt;b&gt;alle ihre Bitcoins verlieren&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Sind Sie sich sicher, dass Sie ihre Wallet verschlüsseln möchten?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>WICHTIG: Alle vorherigen Wallet-Sicherungen sollten durch die neu erzeugte, verschlüsselte Wallet ersetzt werden. Aus Sicherheitsgründen werden vorherige Sicherungen der unverschlüsselten Wallet nutzlos, sobald Sie die neue, verschlüsselte Wallet verwenden.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Warnung: Die Feststelltaste ist aktiviert!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Wallet verschlüsselt</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin wird jetzt beendet, um den Verschlüsselungsprozess abzuschließen. Bitte beachten Sie, dass die Wallet-Verschlüsselung nicht vollständig vor Diebstahl ihrer Bitcoins durch Schadsoftware schützt, die ihren Computer befällt.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Wallet-Verschlüsselung fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Die Wallet-Verschlüsselung ist aufgrund eines internen Fehlers fehlgeschlagen. Ihre Wallet wurde nicht verschlüsselt.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Die eingegebenen Passphrasen stimmen nicht überein.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Wallet-Entsperrung fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Die eingegebene Passphrase zur Wallet-Entschlüsselung war nicht korrekt.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Wallet-Entschlüsselung fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Die Wallet-Passphrase wurde erfolgreich geändert.</translation>
     </message>
@@ -328,363 +260,286 @@ Dieses Produkt enthält Software, die vom OpenSSL-Projekt zur Verwendung im Open
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>Nachricht s&amp;ignieren...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synchronisiere mit Netzwerk...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Übersicht</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>Knoten</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Allgemeine Wallet-Übersicht anzeigen</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transaktionen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Transaktionsverlauf durchsehen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Beenden</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Anwendung beenden</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Informationen über Bitcoin anzeigen</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Über &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Informationen über Qt anzeigen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Konfiguration...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>Wallet &amp;verschlüsseln...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>Wallet &amp;sichern...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>Passphrase &amp;ändern...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;Zahlungsadressen...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;Empfangsadressen...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>&amp;URI öffnen...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
-        <translation>Importiere Blöcke von Laufwerk...</translation>
+        <translation>Importiere Blöcke von Datenträger...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
-        <translation>Reindiziere Blöcke auf Laufwerk...</translation>
+        <translation>Reindiziere Blöcke auf Datenträger...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Bitcoins an eine Bitcoin-Adresse überweisen</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Die Konfiguration des Clients bearbeiten</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Eine Wallet-Sicherungskopie erstellen und abspeichern</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Ändert die Passphrase, die für die Wallet-Verschlüsselung benutzt wird</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Debugfenster</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Debugging- und Diagnosekonsole öffnen</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>Nachricht &amp;verifizieren...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
-        <translation>Überweisen</translation>
+        <translation>&amp;Überweisen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Empfangen</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Anzeigen / Verstecken</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Das Hauptfenster anzeigen oder verstecken</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Verschlüsselt die zu ihrer Wallet gehörenden privaten Schlüssel</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Nachrichten signieren, um den Besitz ihrer Bitcoin-Adressen zu beweisen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Nachrichten verifizieren, um sicherzustellen, dass diese mit den angegebenen Bitcoin-Adressen signiert wurden</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Datei</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Einstellungen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Registerkartenleiste</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[Testnetz]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation>Zahlungen anfordern (erzeugt QR-Codes und bitcoin: URIs)</translation>
+        <translation>Zahlungen anfordern (erzeugt QR-Codes und &quot;bitcoin:&quot;-URIs)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;Über Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Liste verwendeter Zahlungsadressen und Bezeichnungen anzeigen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Liste verwendeter Empfangsadressen und Bezeichnungen anzeigen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Eine &quot;bitcoin:&quot;-URI oder Zahlungsanforderung öffnen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Kommandozeilenoptionen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
-        <translation>Zeige die &quot;Bitcoin Core&quot;-Hilfsnachricht, um eine Liste mit möglichen Kommandozeilenoptionen zu erhalten</translation>
+        <translation>Zeige den &quot;Bitcoin Core&quot;-Hilfetext, um eine Liste mit möglichen Kommandozeilenoptionen zu erhalten</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin-Client</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktive Verbindung zum Bitcoin-Netzwerk</numerusform><numerusform>%n aktive Verbindungen zum Bitcoin-Netzwerk</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Keine Blockquelle verfügbar...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>%1 von (geschätzten) %2 Blöcken des Transaktionsverlaufs verarbeitet.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>%1 Blöcke des Transaktionsverlaufs verarbeitet.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n Stunde</numerusform><numerusform>%n Stunden</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n Tag</numerusform><numerusform>%n Tage</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n Woche</numerusform><numerusform>%n Wochen</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 und %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n Jahr</numerusform><numerusform>%n Jahre</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 im Rückstand</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Der letzte empfangene Block ist %1 alt.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transaktionen hiernach werden noch nicht angezeigt.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Hinweis</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Auf aktuellem Stand</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Hole auf...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Gesendete Transaktion</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Eingehende Transaktion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +551,14 @@ Typ: %3
 Adresse: %4</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Wallet ist &lt;b&gt;verschlüsselt&lt;/b&gt; und aktuell &lt;b&gt;entsperrt&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Wallet ist &lt;b&gt;verschlüsselt&lt;/b&gt; und aktuell &lt;b&gt;gesperrt&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+441"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Ein schwerer Fehler ist aufgetreten. Bitcoin kann nicht stabil weiter ausgeführt werden und wird beendet.</translation>
     </message>
@@ -714,7 +566,6 @@ Adresse: %4</translation>
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Netzwerkalarm</translation>
     </message>
@@ -722,291 +573,230 @@ Adresse: %4</translation>
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>&quot;Coin Control&quot;-Adressauswahl</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Anzahl:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Byte:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Betrag:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Priorität:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Gebühr:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Zu geringer Ausgabebetrag:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Abzüglich Gebühr:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Wechselgeld:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>Alles (de)selektieren</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Baumansicht</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Listenansicht</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Bestätigungen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Bestätigt</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Priorität</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Adresse kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Bezeichnung kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Betrag kopieren</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Transaktions-ID kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Nicht ausgegebenen Betrag sperren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Nicht ausgegebenen Betrag entsperren</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Anzahl kopieren</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Gebühr kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Abzüglich Gebühr kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Byte kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Priorität kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Zu geringen Ausgabebetrag kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Wechselgeld kopieren</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>am höchsten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>höher</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>hoch</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>mittel-hoch</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>mittel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>niedrig-mittel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>niedrig</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>niedriger</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>am niedrigsten</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 gesperrt)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>keine</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
-        <translation>Dust</translation>
+        <translation>&quot;Dust&quot;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>ja</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>nein</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Diese Bezeichnung wird rot, wenn die Transaktion größer als 1000 Byte ist.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Das bedeutet, dass eine Gebühr von mindestens %1 pro kB erforderlich ist.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Kann um +/- 1 Byte pro Eingabe variieren.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Transaktionen mit höherer Priorität haben eine größere Chance in einen Block aufgenommen zu werden.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Diese Bezeichnung wird rot, wenn die Priorität niedriger als &quot;mittel&quot; ist.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Diese Bezeichnung wird rot, wenn irgendein Empfänger einen Betrag kleiner als %1 erhält.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Das bedeutet, dass eine Gebühr von mindestens %1 erforderlich ist.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
-        <translation>Beträge kleiner als das 0,546-fache der niedrigsten Vermittlungsgebühr werden als Dust angezeigt.</translation>
+        <translation>Beträge kleiner als das 0,546-fache der niedrigsten Vermittlungsgebühr werden als &quot;Dust&quot; angezeigt.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
-        <translation>Diese Bezeichnung wird rot, wenn das Wechselgeld weniger als %1 beträgt.</translation>
+        <translation>Diese Bezeichnung wird rot, wenn das Wechselgeld weniger als %1 ist.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+63"/>
         <source>(no label)</source>
         <translation>(keine Bezeichnung)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>Wechselgeld von %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(Wechselgeld)</translation>
     </message>
@@ -1014,95 +804,77 @@ Adresse: %4</translation>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Adresse bearbeiten</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Bezeichnung</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>Bezeichnung, die dem Adresslisteneintrag zugeordnet ist.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Adresse, die dem Adresslisteneintrag zugeordnet ist. Diese kann nur bei Zahlungsadressen verändert werden.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adresse</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Neue Empfangsadresse</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Neue Zahlungsadresse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Empfangsadresse bearbeiten</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Zahlungsadresse bearbeiten</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Die eingegebene Adresse &quot;%1&quot; befindet sich bereits im Adressbuch.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Die eingegebene Adresse &quot;%1&quot; ist keine gültige Bitcoin-Adresse.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Wallet konnte nicht entsperrt werden.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
-        <translation>Generierung eines neuen Schlüssels fehlgeschlagen.</translation>
+        <translation>Erzeugung eines neuen Schlüssels fehlgeschlagen.</translation>
     </message>
 </context>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Es wird ein neues Datenverzeichnis angelegt.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Verzeichnis existiert bereits. Fügen Sie %1 an, wenn Sie beabsichtigen hier ein neues Verzeichnis anzulegen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Pfad existiert bereits und ist kein Verzeichnis.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Datenverzeichnis kann hier nicht angelegt werden.</translation>
     </message>
@@ -1110,52 +882,46 @@ Adresse: %4</translation>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - Kommandozeilenoptionen</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Benutzung:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>Kommandozeilenoptionen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI-Optionen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
-        <translation>Sprache festlegen, z.B. &quot;de_DE&quot; (Standard: System Locale)</translation>
+        <translation>Sprache festlegen, z.B. &quot;de_DE&quot; (Standard: Systemstandard)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Minimiert starten</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>SSL-Wurzelzertifikate für Zahlungsanforderungen festlegen (Standard: Systemstandard)</translation>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Startbildschirm beim Starten anzeigen (Standard: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Datenverzeichnis beim Starten auswählen (Standard: 0)</translation>
     </message>
@@ -1163,57 +929,46 @@ Adresse: %4</translation>
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Willkommen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Willkommen zu Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
-        <translation>Da Sie das Programm gerade zum ersten Mal starten, können Sie nun auswählen wo Bitcoin Core seine Daten ablegen wird.</translation>
+        <translation>Da Sie das Programm gerade zum ersten Mal starten, können Sie nun auswählen wo Bitcoin Core seine Daten ablegen soll.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core wird eine Kopie der Blockkette herunterladen und speichern. Mindestens %1GB Daten werden in diesem Verzeichnis abgelegt und die Datenmenge wächst über die Zeit an. Auch die Wallet wird in diesem Verzeichnis abgelegt.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Standard-Datenverzeichnis verwenden</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Ein benutzerdefiniertes Datenverzeichnis verwenden:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Fehler: Angegebenes Datenverzeichnis &quot;%1&quot; kann nicht angelegt werden.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB freier Speicherplatz verfügbar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(von benötigten %1GB)</translation>
     </message>
@@ -1221,27 +976,22 @@ Adresse: %4</translation>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>URI öffnen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Zahlungsanforderung über URI oder aus Datei öffnen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Zahlungsanforderungsdatei auswählen</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Zu öffnende Zahlungsanforderungsdatei auswählen</translation>
     </message>
@@ -1249,258 +999,206 @@ Adresse: %4</translation>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
-        <translation>Erweiterte Einstellungen</translation>
+        <translation>Konfiguration</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Allgemein</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Optionale Transaktionsgebühr pro kB, die sicherstellt, dass ihre Transaktionen schnell bearbeitet werden. Die meisten Transaktionen sind 1 kB groß.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Transaktions&amp;gebühr bezahlen</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Bitcoin nach der Anmeldung am System automatisch ausführen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Starte Bitcoin nach Systemanmeldung</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>Größe des &amp;Datenbankcaches</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>Anzahl an Skript-&amp;Verifizierungs-Threads</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Maximale Anzahl an Skript-Verifizierungs-Threads festlegen (bis zu 16, 0 = automatisch, &lt;0 = so viele Kerne frei lassen, Standard: 0)</translation>
-    </message>
-    <message>
-        <location line="+153"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Über einen SOCKS-Proxy mit dem Bitcoin-Netzwerk verbinden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>Über einen SOCKS-Proxy &amp;verbinden (Standardproxy):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>IP-Adresse des Proxies (z.B. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation>Aktive Kommandozeilenoptionen, die obige Konfiguration überschreiben:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Setzt die Clientkonfiguration auf Standardwerte zurück.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>Konfiguration &amp;zurücksetzen</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Netzwerk</translation>
     </message>
     <message>
-        <location line="-95"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation>(0 = automatisch, &lt;0 = so viele Kerne frei lassen)</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation>W&amp;allet</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>Erweiterte Wallet-Optionen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation>&quot;&amp;Coin Control&quot;-Funktionen aktivieren</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>Wenn Sie das Ausgeben von unbestätigtem Wechselgeld deaktivieren, kann das Wechselgeld einer Transaktion nicht verwendet werden, bis es mindestens eine Bestätigung erhalten hat. Dies wirkt sich auf die Berechnung des Kontostands aus.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation>&amp;Unbestätigtes Wechselgeld darf ausgegeben werden</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Automatisch den Bitcoin-Clientport auf dem Router öffnen. Dies funktioniert nur, wenn ihr Router UPnP unterstützt und dies aktiviert ist.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Portweiterleitung via &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy-&amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Port des Proxies (z.B. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS-&amp;Version:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS-Version des Proxies (z.B. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Programmfenster</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Nur ein Symbol im Infobereich anzeigen, nachdem das Programmfenster minimiert wurde.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>In den Infobereich anstatt in die Taskleiste &amp;minimieren</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimiert die Anwendung anstatt sie zu beenden wenn das Fenster geschlossen wird. Wenn dies aktiviert ist, müssen Sie das Programm über &quot;Beenden&quot; im Menü schließen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>Beim Schließen m&amp;inimieren</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>Anzei&amp;ge</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Sprache der Benutzeroberfläche:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Legt die Sprache der Benutzeroberfläche fest. Diese Einstellung wird erst nach einem Neustart von Bitcoin aktiv.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Einheit der Beträge:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation>Wählen Sie die Standarduntereinheit, die in der Benutzeroberfläche und beim Überweisen von Bitcoins angezeigt werden soll.</translation>
+        <translation>Wählen Sie die standardmäßige Untereinheit, die in der Benutzeroberfläche und beim Überweisen von Bitcoins angezeigt werden soll.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
-        <translation>Legt fest, ob Bitcoin-Adressen in der Transaktionsliste angezeigt werden.</translation>
+        <translation>Legt fest, ob Bitcoin-Adressen im Transaktionsverlauf angezeigt werden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
-        <translation>Adressen in der Transaktionsliste &amp;anzeigen</translation>
+        <translation>Adressen im Transaktionsverlauf &amp;anzeigen</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Legt fest, ob die &quot;Coin Control&quot;-Funktionen angezeigt werden.</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>A&amp;bbrechen</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>keine</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Zurücksetzen der Konfiguration bestätigen</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Clientneustart nötig, um die Änderungen zu aktivieren.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>Client wird beendet, wollen Sie fortfahren?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Diese Änderung würde einen Clientneustart benötigen.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Die eingegebene Proxyadresse ist ungültig.</translation>
     </message>
@@ -1508,69 +1206,54 @@ Adresse: %4</translation>
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formular</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Die angezeigten Informationen sind möglicherweise nicht mehr aktuell. Ihre Wallet wird automatisch synchronisiert, nachdem eine Verbindung zum Bitcoin-Netzwerk hergestellt wurde. Dieser Prozess ist jedoch derzeit noch nicht abgeschlossen.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Verfügbar:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Ihr aktuell verfügbarer Kontostand</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>Ausstehend:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Betrag aus unbestätigten Transaktionen, der noch nicht im aktuell verfügbaren Kontostand enthalten ist</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Unreif:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Erarbeiteter Betrag der noch nicht gereift ist</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Gesamtbetrag:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Aktueller Gesamtbetrag aus obigen Kategorien</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Letzte Transaktionen&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>nicht synchron</translation>
     </message>
@@ -1578,93 +1261,70 @@ Adresse: %4</translation>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
-        <translation>URI Verarbeitung</translation>
+        <translation>URI-Verarbeitung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI kann nicht analysiert werden! Dies kann durch eine ungültige Bitcoin-Adresse oder fehlerhafte URI-Parameter verursacht werden.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation>Angeforderter Zahlungsbetrag in Höhe von %1 ist zu niedrig (als Dust eingestuft).</translation>
+        <translation>Angeforderter Zahlungsbetrag in Höhe von %1 ist zu niedrig und wurde als &quot;Dust&quot; eingestuft.</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>fehlerhafte Zahlungsanforderung</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>&quot;bitcoin: Klicken-zum-Bezahlen&quot;-Handler konnte nicht gestartet werden</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Netzwerkmanager-Warnung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>Ihr aktiver Proxy unterstützt kein SOCKS5, dies wird jedoch für Zahlungsanforderungen über einen Proxy benötigt.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>Abruf-URL der Zahlungsanforderung ist ungültig: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Zahlungsanforderungsdatei-Verarbeitung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>Zahlungsanforderungsdatei kann nicht gelesen oder verarbeitet werden! Dies kann durch eine ungültige Zahlungsanforderungsdatei verursacht werden.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Unverifizierte Zahlungsanforderungen an benutzerdefinierte Zahlungsskripte werden nicht unterstützt.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Rücküberweisung von %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Kommunikationsfehler mit %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>Zahlungsanforderung kann nicht analysiert oder verarbeitet werden!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Fehlerhafte Antwort vom Server: %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Zahlung bestätigt</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>fehlerhafte Netzwerkanfrage</translation>
     </message>
@@ -1672,23 +1332,22 @@ Adresse: %4</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+14"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Fehler: Angegebenes Datenverzeichnis &quot;%1&quot; existiert nicht.</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Fehler: Konfigurationsdatei kann nicht analysiert werden: %1. Bitte nur &quot;Schlüssel=Wert&quot;-Syntax verwenden.</translation>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Fehler: Ungültige Kombination von -regtest und -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin-Adresse eingeben (z.B. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1696,22 +1355,18 @@ Adresse: %4</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>Grafik &amp;speichern...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>Grafik &amp;kopieren</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
-        <translation>QR-Code abspeichern</translation>
+        <translation>QR-Code speichern</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG-Grafik (*.png)</translation>
     </message>
@@ -1719,194 +1374,146 @@ Adresse: %4</translation>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Clientname</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>k.A.</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Clientversion</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Information</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Debugfenster</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Verwendete OpenSSL-Version</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Startzeit</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Netzwerk</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Name</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Anzahl Verbindungen</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Blockkette</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Aktuelle Anzahl Blöcke</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Geschätzte Gesamtzahl Blöcke</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Letzte Blockzeit</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Öffnen</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsole</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Netzwerkauslastung</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Zurücksetzen</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Summen</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>eingehend:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>ausgehend:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Erstellungsdatum</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Debugprotokolldatei</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Öffnet die Bitcoin-Debugprotokolldatei aus dem aktuellen Datenverzeichnis. Dies kann bei großen Protokolldateien einige Sekunden dauern.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Konsole zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Willkommen in der Bitcoin-RPC-Konsole.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Pfeiltaste hoch und runter, um den Verlauf durchzublättern und &lt;b&gt;Strg-L&lt;/b&gt;, um die Konsole zurückzusetzen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Bitte &lt;b&gt;help&lt;/b&gt; eingeben, um eine Übersicht verfügbarer Befehle zu erhalten.</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1914,105 +1521,82 @@ Adresse: %4</translation>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Betrag:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Bezeichnung:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Nachricht:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Eine der bereits verwendeten Empfangsadressen wiederverwenden. Addressen wiederzuverwenden birgt Sicherheits- und Datenschutzrisiken. Außer zum Neuerstellen einer bereits erzeugten Zahlungsanforderung sollten Sie dies nicht nutzen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>Vorhandene Empfangsadresse &amp;wiederverwenden (nicht empfohlen)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>Eine optionale Nachricht, die an die Zahlungsanforderung angehängt wird. Sie wird angezeigt, wenn die Anforderung geöffnet wird. Hinweis: Diese Nachricht wird nicht mit der Zahlung über das Bitcoin-Netzwerk gesendet.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Eine optionale Bezeichnung, die der neuen Empfangsadresse zugeordnet wird.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation>Verwenden Sie dieses Formular um Zahlungen anzufordern. Alle Felder sind &lt;b&gt;optional&lt;/b&gt;.</translation>
+        <translation>Verwenden Sie dieses Formular, um Zahlungen anzufordern. Alle Felder sind &lt;b&gt;optional&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Ein optional angeforderte Betrag. Lassen Sie dieses Feld leer oder setzen Sie es auf 0, um keinen spezifischen Betrag anzufordern.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Alle Formularfelder zurücksetzen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Zurücksetzen</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Verlauf der angeforderten Zahlungen</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Zahlung anfordern</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation>Die ausgewählten Anforderungen anzeigen (entspricht einem Doppelklick auf einen Eintrag)</translation>
+        <translation>Ausgewählte Zahlungsanforderungen anzeigen (entspricht einem Doppelklick auf einen Eintrag)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Anzeigen</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
-        <translation>Die ausgewählten Einträge aus der Liste entfernen</translation>
+        <translation>Ausgewählte Einträge aus der Liste entfernen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Entfernen</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Bezeichnung kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Nachricht kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Betrag kopieren</translation>
     </message>
@@ -2020,105 +1604,85 @@ Adresse: %4</translation>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>&amp;URI kopieren</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>&amp;Addresse kopieren</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>Grafik &amp;speichern...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Zahlung anfordern an %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Zahlungsinformationen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Nachricht</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation>Resultierende URI zu lang, bitte den Text für Bezeichnung / Nachricht kürzen.</translation>
+        <translation>Resultierende URI ist zu lang, bitte den Text für Bezeichnung/Nachricht kürzen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
-        <translation>Fehler beim Kodieren der URI in den QR-Code.</translation>
+        <translation>Beim Enkodieren der URI in den QR-Code ist ein Fehler aufgetreten.</translation>
     </message>
 </context>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Nachricht</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(keine Bezeichnung)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(keine Nachricht)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(kein Betrag)</translation>
     </message>
@@ -2126,247 +1690,194 @@ Adresse: %4</translation>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Bitcoins überweisen</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>&quot;Coin Control&quot;-Funktionen</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Eingaben...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>automatisch ausgewählt</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Unzureichender Kontostand!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Anzahl:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Byte:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Betrag:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Priorität:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Gebühr:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Zu geringer Ausgabebetrag:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Abzüglich Gebühr:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Wechselgeld:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation>Wenn dies aktivert ist und die Wechselgeld-Adresse leer oder ungültig ist, wird das Wechselgeld an eine neu erzeugte Adresse überwiesen.</translation>
+        <translation>Wenn dies aktivert, und die Wechselgeld-Adresse leer oder ungültig ist, wird das Wechselgeld einer neu erzeugten Adresse gutgeschrieben.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Benutzerdefinierte Wechselgeld-Adresse</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
-        <translation>In einer Transaktion an mehrere Empfänger auf einmal überweisen</translation>
+        <translation>An mehrere Empfänger auf einmal überweisen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Empfänger &amp;hinzufügen</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Alle Formularfelder zurücksetzen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Zurücksetzen</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Kontostand:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Überweisung bestätigen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Überweisen</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Überweisung bestätigen</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 an %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Anzahl kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Betrag kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Gebühr kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Abzüglich Gebühr kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Byte kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Priorität kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Zu geringen Ausgabebetrag kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Wechselgeld kopieren</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Gesamtbetrag %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>oder</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Die Zahlungsadresse ist ungültig, bitte nochmals überprüfen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Der zu zahlende Betrag muss größer als 0 sein.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Der angegebene Betrag übersteigt ihren Kontostand.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Der angegebene Betrag übersteigt aufgrund der Transaktionsgebühr in Höhe von %1 ihren Kontostand.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
-        <translation>Doppelte Adresse gefunden, pro Überweisung kann an jede Adresse nur einmalig etwas überwiesen werden.</translation>
+        <translation>Doppelte Zahlungsadresse gefunden, pro Überweisung kann an jede Adresse nur einmalig etwas überwiesen werden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Transaktionserstellung fehlgeschlagen!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Die Transaktion wurde abgelehnt! Dies kann passieren, wenn einige Bitcoins aus ihrer Wallet bereits ausgegeben wurden. Beispielsweise weil Sie eine Kopie ihrer wallet.dat genutzt, die Bitcoins dort ausgegeben haben und dies daher in der derzeit aktiven Wallet nicht vermerkt ist.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Warnung: Ungültige Bitcoin-Adresse</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(keine Bezeichnung)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Warnung: Unbekannte Wechselgeld-Adresse</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Wollen Sie die Überweisung ausführen?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>als Transaktionsgebühr hinzugefügt</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Zahlungsanforderung abgelaufen</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Ungültige Zahlungsadresse %1</translation>
     </message>
@@ -2374,98 +1885,74 @@ Adresse: %4</translation>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
-        <translation>&amp;Betrag:</translation>
+        <translation>Betra&amp;g:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
-        <translation>&amp;Empfänger:</translation>
+        <translation>E&amp;mpfänger:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Die Zahlungsadresse der Überweisung (z.B. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Adressbezeichnung eingeben (diese wird zusammen mit der Adresse dem Adressbuch hinzugefügt)</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Bezeichnung:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
-        <translation>Bereits verwendeten Adresse auswählen</translation>
+        <translation>Bereits verwendete Adresse auswählen</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Dies ist eine normale Überweisung.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Adresse aus der Zwischenablage einfügen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Diesen Eintrag entfernen</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Nachricht:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Dies is eine verifizierte Zahlungsanforderung.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Adressbezeichnung eingeben, die dann zusammen mit der Adresse der Liste bereits verwendeter Adressen hinzugefügt wird.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>Eine an die &quot;bitcoin:&quot;-URI angefügte Nachricht, die zusammen mit der Transaktion gespeichert wird. Hinweis: Diese Nachricht wird nicht über das Bitcoin-Netzwerk gesendet.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Dies is eine unverifizierte Zahlungsanforderung.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Empfänger:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memo:</translation>
     </message>
@@ -2473,12 +1960,10 @@ Adresse: %4</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Core wird beendet...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Fahren Sie den Computer nicht herunter, bevor dieses Fenster verschwindet.</translation>
     </message>
@@ -2486,186 +1971,142 @@ Adresse: %4</translation>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Signaturen - eine Nachricht signieren / verifizieren</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>Nachricht &amp;signieren</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Sie können Nachrichten mit ihren Adressen signieren, um den Besitz dieser Adressen zu beweisen. Bitte nutzen Sie diese Funktion mit Vorsicht und nehmen Sie sich vor Phishingangriffen in Acht. Signieren Sie nur Nachrichten, mit denen Sie vollständig einverstanden sind.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Die Adresse mit der die Nachricht signiert wird (z.B. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Bereits verwendete Adresse auswählen</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Adresse aus der Zwischenablage einfügen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Zu signierende Nachricht hier eingeben</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Signatur</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Aktuelle Signatur in die Zwischenablage kopieren</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Die Nachricht signieren, um den Besitz dieser Bitcoin-Adresse zu beweisen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>&amp;Nachricht signieren</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Alle &quot;Nachricht signieren&quot;-Felder zurücksetzen</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Zurücksetzen</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>Nachricht &amp;verifizieren</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
-        <translation>Geben Sie die signierende Adresse, Nachricht (achten Sie darauf Zeilenumbrüche, Leerzeichen, Tabulatoren usw. exakt zu kopieren) und Signatur unten ein, um die Nachricht zu verifizieren. Vorsicht, interpretieren Sie nicht mehr in die Signatur, als in der signierten Nachricht selber enthalten ist, um nicht von einem Man-in-the-middle-Angriff hinters Licht geführt zu werden.</translation>
+        <translation>Geben Sie die signierende Adresse, Nachricht (achten Sie darauf Zeilenumbrüche, Leerzeichen, Tabulatoren usw. exakt zu kopieren) und Signatur unten ein, um die Nachricht zu verifizieren. Vorsicht, interpretieren Sie nicht mehr in die Signatur hinein, als in der signierten Nachricht selber enthalten ist, um nicht von einem Man-in-the-middle-Angriff hinters Licht geführt zu werden.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Die Adresse mit der die Nachricht signiert wurde (z.B. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Die Nachricht verifizieren, um sicherzustellen, dass diese mit der angegebenen Bitcoin-Adresse signiert wurde</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>&amp;Nachricht verifizieren</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Alle &quot;Nachricht verifizieren&quot;-Felder zurücksetzen</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin-Adresse eingeben (z.B. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Auf &quot;Nachricht signieren&quot; klicken, um die Signatur zu erzeugen</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Die eingegebene Adresse ist ungültig.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Bitte überprüfen Sie die Adresse und versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Die eingegebene Adresse verweist nicht auf einen Schlüssel.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Wallet-Entsperrung wurde abgebrochen.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Privater Schlüssel zur eingegebenen Adresse ist nicht verfügbar.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Signierung der Nachricht fehlgeschlagen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Nachricht signiert.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Die Signatur konnte nicht dekodiert werden.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Bitte überprüfen Sie die Signatur und versuchen Sie es erneut.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
-        <translation>Die Signatur entspricht nicht dem Message Digest.</translation>
+        <translation>Die Signatur entspricht nicht dem &quot;Message Digest&quot;.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Verifikation der Nachricht fehlgeschlagen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Nachricht verifiziert.</translation>
     </message>
@@ -2673,17 +2114,14 @@ Adresse: %4</translation>
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Die &quot;Bitcoin Core&quot;-Entwickler</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[Testnetz]</translation>
     </message>
@@ -2691,7 +2129,6 @@ Adresse: %4</translation>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2699,184 +2136,138 @@ Adresse: %4</translation>
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Offen bis %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>in Konflikt stehend</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/unbestätigt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 Bestätigungen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, über %n Knoten übertragen</numerusform><numerusform>, über %n Knoten übertragen</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Quelle</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
-        <translation>Generiert</translation>
+        <translation>Erzeugt</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Von</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>An</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>eigene Adresse</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Gutschrift</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>reift noch %n weiteren Block</numerusform><numerusform>reift noch %n weitere Blöcke</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>nicht angenommen</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Belastung</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Transaktionsgebühr</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Nettobetrag</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Nachricht</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Transaktions-ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Händler</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation>Generierte Bitcoins müssen %1 Blöcke lang reifen, bevor sie ausgegeben werden können. Als Sie diesen Block generierten, wurde er an das Netzwerk übertragen, um ihn der Blockkette hinzuzufügen. Falls dies fehlschlägt wird der Status in &quot;nicht angenommen&quot; geändert und der Betrag wird nicht verfügbar werden. Das kann gelegentlich passieren, wenn ein anderer Knoten einen Block fast zeitgleich generiert.</translation>
+        <translation>Erzeugte Bitcoins müssen %1 Blöcke lang reifen, bevor sie ausgegeben werden können. Als Sie diesen Block erzeugten, wurde er an das Netzwerk übertragen, um ihn der Blockkette hinzuzufügen. Falls dies fehlschlägt wird der Status in &quot;nicht angenommen&quot; geändert und Sie werden keine Bitcoins gutgeschrieben bekommen. Das kann gelegentlich passieren, wenn ein anderer Knoten einen Block fast zeitgleich erzeugt.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Debuginformationen</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transaktion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Eingaben</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>wahr</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falsch</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, wurde noch nicht erfolgreich übertragen</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Offen für %n weiteren Block</numerusform><numerusform>Offen für %n weitere Blöcke</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>unbekannt</translation>
     </message>
@@ -2884,12 +2275,10 @@ Adresse: %4</translation>
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Transaktionsdetails</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Dieser Bereich zeigt eine detaillierte Beschreibung der Transaktion an</translation>
     </message>
@@ -2897,127 +2286,102 @@ Adresse: %4</translation>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>Unreif (%1 Bestätigungen, wird verfügbar sein nach %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Offen für %n weiteren Block</numerusform><numerusform>Offen für %n weitere Blöcke</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Offen bis %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bestätigt (%1 Bestätigungen)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Dieser Block wurde von keinem anderen Knoten empfangen und wird wahrscheinlich nicht angenommen werden!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
-        <translation>Generiert, jedoch nicht angenommen</translation>
+        <translation>Erzeugt, jedoch nicht angenommen</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Offline</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Unbestätigt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation>Bestätige (%1 von %2 empfohlenen Bestätigungen)</translation>
+        <translation>Wird bestätigt (%1 von %2 empfohlenen Bestätigungen)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>in Konflikt stehend</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Empfangen über</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Empfangen von</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Überwiesen an</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Eigenüberweisung</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Erarbeitet</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(k.A.)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
-        <translation>Transaktionsstatus. Fahren Sie mit der Maus über dieses Feld, um die Anzahl der Bestätigungen zu sehen.</translation>
+        <translation>Transaktionsstatus, fahren Sie mit der Maus über dieses Feld, um die Anzahl der Bestätigungen zu sehen.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
-        <translation>Datum und Uhrzeit als die Transaktion empfangen wurde.</translation>
+        <translation>Datum und Uhrzeit zu der die Transaktion empfangen wurde.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Art der Transaktion</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Zieladresse der Transaktion</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Der Betrag, der dem Kontostand abgezogen oder hinzugefügt wurde.</translation>
     </message>
@@ -3025,178 +2389,142 @@ Adresse: %4</translation>
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Heute</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Diese Woche</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Diesen Monat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Letzten Monat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Dieses Jahr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Zeitraum...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Empfangen über</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Überwiesen an</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Eigenüberweisung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Erarbeitet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Andere</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Zu suchende Adresse oder Bezeichnung eingeben</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimaler Betrag</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Adresse kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Bezeichnung kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Betrag kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Transaktions-ID kopieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Bezeichnung bearbeiten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Transaktionsdetails anzeigen</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Transaktionsverlauf exportieren</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Exportieren fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Beim Speichern des Transaktionsverlaufs nach %1 ist ein Fehler aufgetreten.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Exportieren erfolgreich</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>Speichern des Transaktionsverlaufs nach %1 war erfolgreich.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommagetrennte-Datei (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Bestätigt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Bezeichnung</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Betrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Zeitraum:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>bis</translation>
     </message>
@@ -3204,7 +2532,6 @@ Adresse: %4</translation>
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Es wurde keine Wallet geladen.</translation>
     </message>
@@ -3212,7 +2539,6 @@ Adresse: %4</translation>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Bitcoins überweisen</translation>
     </message>
@@ -3220,42 +2546,34 @@ Adresse: %4</translation>
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>E&amp;xportieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Daten der aktuellen Ansicht in eine Datei exportieren</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Wallet sichern</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Wallet-Daten (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Sicherung fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Beim Speichern der Wallet-Daten nach %1 ist ein Fehler aufgetreten.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Speichern der Wallet-Daten nach %1 war erfolgreich.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Sicherung erfolgreich</translation>
     </message>
@@ -3263,102 +2581,86 @@ Adresse: %4</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+226"/>
         <source>Usage:</source>
         <translation>Benutzung:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Befehle auflisten</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Hilfe zu einem Befehl erhalten</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Optionen:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Konfigurationsdatei festlegen (Standard: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>PID-Datei festlegen (Standard: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Datenverzeichnis festlegen</translation>
     </message>
     <message>
-        <location line="-35"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>&lt;port&gt; nach Verbindungen abhören (Standard: 8333 oder Testnetz: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Maximal &lt;n&gt; Verbindungen zu Gegenstellen aufrechterhalten (Standard: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
-        <translation>Mit dem Knoten verbinden um Adressen von Gegenstellen abzufragen, danach trennen</translation>
+        <translation>Mit dem angegebenen Knoten verbinden, um Adressen von Gegenstellen abzufragen, danach trennen</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Die eigene öffentliche Adresse angeben</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Schwellenwert, um Verbindungen zu sich nicht konform verhaltenden Gegenstellen zu beenden (Standard: 100)</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Anzahl Sekunden, während denen sich nicht konform verhaltenden Gegenstellen die Wiederverbindung verweigert wird (Standard: 86400)</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
-        <translation>Beim Einrichten des abzuhörenden RPC-Ports %u für IPv4 ist ein Fehler aufgetreten: %s</translation>
+        <translation>Beim Einrichten des RPC-Ports %u zum Abhören von IPv4 ist ein Fehler aufgetreten: %s</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>&lt;port&gt; nach JSON-RPC-Verbindungen abhören (Standard: 8332 oder Testnetz: 18332)</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Accept command line and JSON-RPC commands</source>
-        <translation>Kommandozeilenbefehle und JSON-RPC-Befehle annehmen</translation>
+        <translation>Kommandozeilen- und JSON-RPC-Befehle annehmen</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation>&quot;Bitcoin Core&quot;-RPC-Client-Version</translation>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
-        <translation>Als Hintergrunddienst starten und Befehle annehmen</translation>
+        <translation>Als Hintergrunddienst ausführen und Befehle annehmen</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Das Testnetz verwenden</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Eingehende Verbindungen annehmen (Standard: 1, wenn nicht -proxy oder -connect)</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3383,732 +2685,682 @@ zum Beispiel: alertnotify=echo %%s | mail -s \&quot;Bitcoin Alert\&quot; admin@f
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
-        <translation>Akzeptierte Chiffren (Standard: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
+        <translation>Zulässige Chiffren (Standard: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
-        <translation>Beim Einrichten des abzuhörenden RPC-Ports %u für IPv6 ist ein Fehler aufgetreten, es wird auf IPv4 zurückgegriffen: %s</translation>
+        <translation>Beim Einrichten des RPC-Ports %u zum Abhören von IPv6 ist ein Fehler aufgetreten, es wird auf IPv4 zurückgegriffen: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
-        <translation>An die angegebene Adresse binden und immer abhören. Für IPv6 [Host]:Port-Schreibweise verwenden</translation>
+        <translation>An die angegebene Adresse binden und immer abhören. Für IPv6 &quot;[Host]:Port&quot;-Schreibweise verwenden</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation>Anzahl der freien Transaktionen auf &lt;n&gt; * 1000 Byte pro Minute begrenzen (Standard: 15)</translation>
+    </message>
+    <message>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
-        <translation>Regressionstest-Modus aktivieren, welcher eine spezielle Kette nutzt, in der Blöcke sofort gelöst werden. Dies ist für Regressionstest-Tools und Anwendungsentwicklung gedacht.</translation>
+        <translation>Regressionstest-Modus aktivieren, der eine spezielle Blockkette nutzt, in der Blöcke sofort gelöst werden können. Dies ist für Regressionstest-Tools und Anwendungsentwicklung gedacht.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
-        <translation>Regressionstest-Modus aktivieren, welcher eine spezielle Kette nutzt, in der Blöcke sofort gelöst werden.</translation>
+        <translation>Regressionstest-Modus aktivieren, der eine spezielle Blockkette nutzt, in der Blöcke sofort gelöst werden können.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation>Fehler: Abhören nach eingehenden Verbindungen fehlgeschlagen (Fehler %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Fehler: Die Transaktion wurde abgelehnt! Dies kann passieren, wenn einige Bitcoins aus ihrer Wallet bereits ausgegeben wurden. Beispielsweise weil Sie eine Kopie ihrer wallet.dat genutzt, die Bitcoins dort ausgegeben haben und dies daher in der derzeit aktiven Wallet nicht vermerkt ist.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
-        <translation>Fehler: Diese Transaktion benötigt aufgrund ihres Betrags, ihrer Komplexität oder der Nutzung kürzlich erhaltener Zahlungen eine Transaktionsgebühr in Höhe von mindestens %s!</translation>
+        <translation>Fehler: Diese Transaktion benötigt aufgrund ihres Betrags, ihrer Komplexität oder der Nutzung erst kürzlich erhaltener Zahlungen eine Transaktionsgebühr in Höhe von mindestens %s!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>Kommando ausführen wenn sich eine Wallet-Transaktion verändert (%s im Kommando wird durch die TxID ersetzt)</translation>
+        <translation>Befehl ausführen wenn sich eine Wallet-Transaktion verändert (%s im Befehl wird durch die TxID ersetzt)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation>Niedrigere Gebühren als diese werden als gebührenfrei angesehen (bei der Transaktionserstellung) (Standard:</translation>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation>Datenbankaktivitäten vom Arbeitsspeicher-Pool alle &lt;n&gt; Megabyte auf den Datenträger schreiben (Standard: 100)</translation>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation>Legt fest, wie gründlich die Blockverifikation von -checkblocks ist (0-4, Standard: 3)</translation>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation>In diesem Modus legt -genproclimit fest, wie viele Blöcke sofort erzeugt werden.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation>Maximale Anzahl an Skript-Verifizierungs-Threads festlegen (%u bis %d, 0 = automatisch, &lt;0 = so viele Kerne frei lassen, Standard: %d)</translation>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation>Legt ein Prozessor-/CPU-Kernlimit fest, wenn CPU-Mining aktiviert ist (-1 = unbegrenzt, Standard: -1)</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Dies ist eine Vorab-Testversion - Verwendung auf eigene Gefahr - nicht für Mining- oder Handelsanwendungen nutzen!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
-        <translation>Kann auf diesem Computer nicht an %s binden. Evtl. wurde Bitcoin Core bereits gestartet.</translation>
+        <translation>Kann auf diesem Computer nicht an %s binden, da Bitcoin Core wahrscheinlich bereits gestartet wurde.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Separaten SOCKS5-Proxy verwenden, um Gegenstellen über versteckte Tor-Dienste zu erreichen (Standard: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Warnung: -paytxfee ist auf einen sehr hohen Wert festgelegt! Dies ist die Gebühr die beim Senden einer Transaktion fällig wird.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Warnung: Bitte korrigieren Sie die Datums- und Uhrzeiteinstellungen ihres Computers, da Bitcoin ansonsten nicht ordnungsgemäß funktionieren wird!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Warnung: Das Netzwerk scheint nicht vollständig übereinzustimmen! Einige Miner scheinen Probleme zu haben.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation>Warnung: Wir scheinen nicht vollständig mit unseren Gegenstellen übereinzustimmen! Sie oder die anderen Knoten müssen unter Umständen (den Client) aktualisieren.</translation>
+        <translation>Warnung: Wir scheinen nicht vollständig mit unseren Gegenstellen übereinzustimmen! Sie oder die anderen Knoten müssen unter Umständen ihre Client-Software aktualisieren.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Warnung: Lesen von wallet.dat fehlgeschlagen! Alle Schlüssel wurden korrekt gelesen, Transaktionsdaten bzw. Adressbucheinträge fehlen aber möglicherweise oder sind inkorrekt.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
-        <translation>Warnung: wallet.dat beschädigt, Rettung erfolgreich! Original wallet.dat wurde als wallet.{Zeitstempel}.dat in %s gespeichert. Falls ihr Kontostand oder Transaktionen nicht korrekt sind, sollten Sie von einer Datensicherung wiederherstellen.</translation>
+        <translation>Warnung: wallet.dat beschädigt, Datenrettung erfolgreich! Original wallet.dat wurde als wallet.{Zeitstempel}.dat in %s gespeichert. Falls ihr Kontostand oder Transaktionen nicht korrekt sind, sollten Sie von einer Datensicherung wiederherstellen.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation>(Standard: 1)</translation>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation>(Standard: wallet.dat)</translation>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; kann sein:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
-        <translation>Versucht private Schlüssel aus einer beschädigten wallet.dat wiederherzustellen</translation>
+        <translation>Versuchen, private Schlüssel aus einer beschädigten wallet.dat wiederherzustellen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>&quot;Bitcoin Core&quot;-Hintergrunddienst</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Bitcoin-RPC-Clientversion</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Blockerzeugungsoptionen:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Liste der Wallet-Transaktionen zurücksetzen (Diagnosetool; beinhaltet -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
-        <translation>Nur mit dem/den angegebenen Knoten verbinden</translation>
+        <translation>Mit nur dem oder den angegebenen Knoten verbinden</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Über einen SOCKS-Proxy verbinden</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
-        <translation>Mit JSON-RPC über &lt;port&gt; verbinden (Standard: 8332 oder Testnetz: 18332)</translation>
+        <translation>Mit JSON-RPC auf &lt;port&gt; verbinden (Standard: 8332 oder Testnetz: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>Verbindungsoptionen:</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Beschädigte Blockdatenbank erkannt</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation>Debugging-/Testoptionen:</translation>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation>Sicherheitsmodus deaktivieren, übergeht ein echtes Sicherheitsmodusereignis (Standard: 0)</translation>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Eigene IP-Adresse erkennen (Standard: 1, wenn abgehört wird und nicht -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Die Wallet nicht laden und Wallet-RPC-Aufrufe deaktivieren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
-        <translation>Möchten Sie die Blockdatenbank nun neu aufbauen?</translation>
+        <translation>Möchten Sie die Blockdatenbank jetzt neu aufbauen?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Fehler beim Initialisieren der Blockdatenbank</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Fehler beim Initialisieren der Wallet-Datenbankumgebung %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Fehler beim Laden der Blockdatenbank</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Fehler beim Öffnen der Blockdatenbank</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
-        <translation>Fehler: Zu wenig freier Laufwerksspeicherplatz!</translation>
+        <translation>Fehler: Zu wenig freier Speicherplatz auf dem Datenträger!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Fehler: Wallet gesperrt, Transaktion kann nicht erstellt werden!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Fehler: Systemfehler: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Fehler, es konnte kein Port abgehört werden. Wenn dies so gewünscht wird -listen=0 verwenden.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Lesen der Blockinformationen fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Lesen des Blocks fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Synchronisation des Blockindex fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Schreiben des Blockindex fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Schreiben der Blockinformationen fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Schreiben des Blocks fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Schreiben der Dateiinformationen fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Schreiben in die Münzendatenbank fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Schreiben des Transaktionsindex fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Schreiben der Rücksetzdaten fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Gebühr pro kB, die gesendeten Transaktionen hinzugefügt wird</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation>Niedrigere Gebühren als diese werden als gebührenfrei angesehen (bei der Vermittlung) (Standard:</translation>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
-        <translation>Gegenstellen via DNS-Namensauflösung finden (Standard: 1, außer bei -connect)</translation>
+        <translation>Gegenstellen via DNS-Abfrage finden (Standard: 1, außer bei -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation>Sicherheitsmodus erzwingen (Standard: 0)</translation>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
-        <translation>Bitcoins generieren (Standard: 0)</translation>
+        <translation>Bitcoins erzeugen (Standard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
-        <translation>Wieviele Blöcke sollen beim Starten geprüft werden (Standard: 288, 0 = alle)</translation>
+        <translation>Wieviele Blöcke beim Starten geprüft werden sollen (Standard: 288, 0 = alle)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Wie gründlich soll die Blockprüfung sein (0-4, Standard: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>Wenn &lt;category&gt; nicht angegeben wird, jegliche Debugginginformationen ausgeben.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Fehlerhafter oder kein Genesis-Block gefunden. Falsches Datenverzeichnis für das Netzwerk?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Ungültige &quot;-onion&quot;-Adresse: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
-        <translation>Nicht genügend File-Deskriptoren verfügbar.</translation>
+        <translation>Nicht genügend Datei-Deskriptoren verfügbar.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
-        <translation>Der Debugausgabe einen Zeitstempel voranstellen (Standard: 1)</translation>
+        <translation>Debugausgaben einen Zeitstempel voranstellen (Standard: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>RPC-Client-Optionen:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Blockkettenindex aus aktuellen Dateien blk000??.dat wiederaufbauen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>SOCKS-Version des Proxies wählen (4 oder 5, Standard: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Befehl an Bitcoin-Server senden</translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
-        <translation>Größe des Datenbankcaches in MB festlegen (%d bis %d, Standard: %d)</translation>
+        <translation>Größe des Datenbankcaches in Megabyte festlegen (%d bis %d, Standard: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Maximale Blockgröße in Byte festlegen (Standard: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Maximale Anzahl an Threads zur Verarbeitung von RPC-Anfragen festlegen (Standard: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
-        <translation>Wallet-Datei festlegen (innerhalb des Datenverzeichnisses)</translation>
+        <translation>Wallet-Datei angeben (innerhalb des Datenverzeichnisses)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Unbestätigtes Wechselgeld beim Senden von Transaktionen ausgeben (Standard: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Bitcoin-Server starten</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>Dies ist für Regressionstest-Tools und Anwendungsentwicklung gedacht.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Benutzung (veraltet, bitte bitcoin-cli verwenden):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verifiziere Blöcke...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Verifiziere Wallet...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Warten, bis der RPC-Server gestartet ist</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Wallet %s liegt außerhalb des Datenverzeichnisses %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Wallet-Optionen:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Warnung: Veraltetes Argument -debugnet gefunden, bitte -debug=net verwenden</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Sie müssen die Datenbank mit Hilfe von -reindex neu aufbauen, um -txindex zu verändern</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Blöcke aus externer Datei blk000??.dat importieren</translation>
     </message>
     <message>
-        <location line="-126"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
-        <translation>Datenverzeichnis %s kann nicht gesperrt werden. Evtl. wurde Bitcoin Core bereits gestartet.</translation>
+        <translation>Datenverzeichnis %s kann nicht gesperrt werden, da Bitcoin Core wahrscheinlich bereits gestartet wurde.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
-        <translation>Kommando ausführen wenn ein relevanter Alarm empfangen wird oder wir einen wirklich langen Fork entdecken (%s im Kommando wird durch die Nachricht ersetzt)</translation>
+        <translation>Befehl ausführen wenn ein relevanter Alarm empfangen wird oder wir einen wirklich langen Fork entdecken (%s im Befehl wird durch die Nachricht ersetzt)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Debugginginformationen ausgeben (Standard: 0, &lt;category&gt; anzugeben ist optional)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
-        <translation>Maximale Größe von &quot;high-priority/low-fee&quot;-Transaktionen in Byte festlegen (Standard: %d)</translation>
+        <translation>Maximale Größe in Byte von Transaktionen hoher Priorität/mit niedrigen Gebühren festlegen (Standard: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Maximale Anzahl an Skript-Verifizierungs-Threads festlegen (bis zu 16, 0 = automatisch, &lt;0 = so viele Kerne frei lassen, Standard: 0)</translation>
-    </message>
-    <message>
-        <location line="+91"/>
         <source>Information</source>
         <translation>Hinweis</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ungültiger Betrag für -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ungültiger Betrag für -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation>Größe des Signaturcaches auf &lt;n&gt; Einträge begrenzen (Standard: 50000)</translation>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation>Transaktionspriorität und Gebühr pro kB beim Erzeugen von Blöcken protokollieren (Standard: 0)</translation>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
-        <translation>Einen vollständigen Transaktionsindex pflegen (Standard: 0)</translation>
+        <translation>Einen vollständigen Transaktionsindex führen (Standard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
-        <translation>Maximale Größe, &lt;n&gt; * 1000 Byte, des Empfangspuffers pro Verbindung (Standard: 5000)</translation>
+        <translation>Maximale Größe des Empfangspuffers pro Verbindung, &lt;n&gt; * 1000 Byte (Standard: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
-        <translation>Maximale Größe, &lt;n&gt; * 1000 Byte, des Sendepuffers pro Verbindung (Standard: 1000)</translation>
+        <translation>Maximale Größe des Sendepuffers pro Verbindung, &lt;n&gt; * 1000 Byte (Standard: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
-        <translation>Blockkette nur akzeptieren, wenn sie mit den integrierten Prüfpunkten übereinstimmt (Standard: 1)</translation>
+        <translation>Blockkette nur als gültig ansehen, wenn sie mit den integrierten Prüfpunkten übereinstimmt (Standard: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Verbinde nur zu Knoten des Netztyps &lt;net&gt; (IPv4, IPv6 oder Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation>Block beim Starten ausgeben, wenn dieser im Blockindex gefunden wurde.</translation>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation>Blockbaum beim Starten ausgeben (Standard: 0)</translation>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>RPC-SSL-Optionen (siehe Bitcoin-Wiki für SSL-Einrichtung):</translation>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>RPC-Serveroptionen:</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation>Zufällig eine von &lt;n&gt; Netzwerknachrichten verwerfen</translation>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation>Zufällig eine von &lt;n&gt; Netzwerknachrichten verwürfeln</translation>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation>Einen Thread starten, der periodisch die Wallet sicher auf den Datenträger schreibt (Standard: 1)</translation>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
-        <translation>SSL-Optionen: (siehe Bitcoin-Wiki für SSL-Installationsanweisungen)</translation>
+        <translation>SSL-Optionen (siehe Bitcoin-Wiki für SSL-Einrichtungssanweisungen):</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation>Befehl an Bitcoin Core senden</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
-        <translation>Rückverfolgungs- und Debuginformationen an die Konsole senden anstatt sie in die Datei debug.log zu schreiben</translation>
+        <translation>Rückverfolgungs- und Debuginformationen an die Konsole senden, anstatt sie in debug.log zu schreiben</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Minimale Blockgröße in Byte festlegen (Standard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
-        <translation>Verkleinere Datei debug.log beim Starten des Clients (Standard: 1, wenn kein -debug)</translation>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation>DB_PRIVATE-Flag in der Wallet-Datenbankumgebung setzen (Standard: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>Zeige alle Debuggingoptionen (Benutzung: --help -help-debug)</translation>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation>Zeige Benchmarkinformationen (Standard: 0)</translation>
+    </message>
+    <message>
+        <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
+        <translation>Protokolldatei debug.log beim Starten des Clients kürzen (Standard: 1, wenn kein -debug)</translation>
+    </message>
+    <message>
         <source>Signing transaction failed</source>
         <translation>Signierung der Transaktion fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
-        <translation>Verbindungstimeout in Millisekunden festlegen (Standard: 5000)</translation>
+        <translation>Verbindungzeitüberschreitung in Millisekunden festlegen (Standard: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation>&quot;Bitcoin Core&quot;-Hintergrunddienst starten</translation>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Systemfehler: </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Transaktionsbetrag zu niedrig</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Transaktionsbeträge müssen positiv sein</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transaktion zu groß</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
-        <translation>UPnP verwenden, um die Portweiterleitung einzurichten (Standard: 0)</translation>
+        <translation>UPnP verwenden, um eine Portweiterleitung einzurichten (Standard: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
-        <translation>UPnP verwenden, um die Portweiterleitung einzurichten (Standard: 1, wenn abgehört wird)</translation>
+        <translation>UPnP verwenden, um eine Portweiterleitung einzurichten (Standard: 1, wenn abgehört wird)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Benutzername für JSON-RPC-Verbindungen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Warnung: Diese Version is veraltet, Aktualisierung erforderlich!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Lösche alle Transaktionen aus Wallet...</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>beim Starten</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>Version</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
-        <translation>wallet.dat beschädigt, Rettung fehlgeschlagen</translation>
+        <translation>wallet.dat beschädigt, Datenrettung fehlgeschlagen</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Passwort für JSON-RPC-Verbindungen</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>JSON-RPC-Verbindungen von der angegebenen IP-Adresse erlauben</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Sende Befehle an Knoten &lt;ip&gt; (Standard: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-134"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>Kommando ausführen wenn der beste Block wechselt (%s im Kommando wird durch den Hash des Blocks ersetzt)</translation>
+        <translation>Befehl ausführen wenn der beste Block wechselt (%s im Befehl wird durch den Hash des Blocks ersetzt)</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Wallet auf das neueste Format aktualisieren</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Größe des Schlüsselpools festlegen auf &lt;n&gt; (Standard: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Blockkette erneut nach fehlenden Wallet-Transaktionen durchsuchen</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>OpenSSL (https) für JSON-RPC-Verbindungen verwenden</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Serverzertifikat (Standard: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Privater Serverschlüssel (Standard: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Dieser Hilfetext</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Kann auf diesem Computer nicht an %s binden (von bind zurückgegebener Fehler %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
-        <translation>Erlaube DNS-Namensauflösung für -addnode, -seednode und -connect</translation>
+        <translation>Erlaube DNS-Abfragen für -addnode, -seednode und -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Lade Adressen...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Fehler beim Laden von wallet.dat: Wallet beschädigt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Fehler beim Laden von wallet.dat: Wallet benötigt neuere Version von Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Wallet musste neu geschrieben werden: starten Sie Bitcoin zur Fertigstellung neu</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Fehler beim Laden von wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ungültige Adresse in -proxy: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Unbekannter Netztyp in -onlynet angegeben: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Unbekannte Proxyversion in -socks angefordert: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kann Adresse in -bind nicht auflösen: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Kann Adresse in -externalip nicht auflösen: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ungültiger Betrag für -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Ungültiger Betrag</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Unzureichender Kontostand</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Lade Blockindex...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
-        <translation>Mit dem Knoten verbinden und versuchen die Verbindung aufrecht zu halten</translation>
+        <translation>Mit dem angegebenen Knoten verbinden und versuchen die Verbindung aufrecht zu erhalten</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Loading wallet...</source>
         <translation>Lade Wallet...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Wallet kann nicht auf eine ältere Version herabgestuft werden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Standardadresse kann nicht geschrieben werden</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Durchsuche erneut...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Laden abgeschlossen</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
-        <translation>Zur Nutzung der %s Option</translation>
+        <translation>Zur Nutzung der %s-Option</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_el_GR.ts
+++ b/src/qt/locale/bitcoin_el_GR.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Distributed under the MIT/X11 software license, see the accompanying file COPYIN
 This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/) and cryptographic software written by Eric Young (eay@cryptsoft.com) and UPnP software written by Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Πνευματική ιδιοκτησία </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Διπλό-κλικ για επεξεργασία της διεύθυνσης ή της ετικέτας</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Δημιούργησε νέα διεύθυνση</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Νέα</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Αντέγραψε την επιλεγμένη διεύθυνση στο πρόχειρο του συστήματος</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Αντιγραφή</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>Κ&amp;λείσιμο</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Αντιγραφή διεύθυνσης</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Αντιγραφη της επιλεγμενης διεύθυνσης στο πρόχειρο του συστηματος</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Εξαγωγή δεδομένων καρτέλας σε αρχείο</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Εξαγωγή</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Διαγραφή</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Επιλογή διεύθυνσης όπου θα σταλθούν νομίσματα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Επιλογή διεύθυνσης απ&apos; όπου θα ληφθούν νομίσματα</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Διευθύνσεις αποστολής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Διευθύνσεις λήψης</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Αυτές είναι οι Bitcoin διευθύνσεις σας για να λαμβάνετε πληρωμές. Δίνοντας μία ξεχωριστή διεύθυνση σε κάθε αποστολέα, θα μπορείτε να ελέγχετε ποιος σας πληρώνει.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Αντιγραφή &amp;επιγραφής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Επεξεργασία</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Εξαγωγή της λίστας διευθύνσεων</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Αρχείο οριοθετημένο με κόμματα (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Ετικέτα</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Διεύθυνση</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(χωρίς ετικέτα)</translation>
     </message>
@@ -187,141 +153,107 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Φράση πρόσβασης </translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Βάλτε κωδικό πρόσβασης</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Νέος κωδικός πρόσβασης</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Επανέλαβε τον νέο κωδικό πρόσβασης</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Εισάγετε τον νέο κωδικό πρόσβασης στον πορτοφόλι &lt;br/&gt; Παρακαλώ χρησιμοποιείστε ένα κωδικό με &lt;b&gt; 10 ή περισσότερους τυχαίους χαρακτήρες&lt;/b&gt; ή &lt;b&gt; οχτώ ή παραπάνω λέξεις&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Κρυπτογράφησε το πορτοφόλι</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Αυτη η ενεργεία χρειάζεται τον κωδικό του πορτοφολιού  για να ξεκλειδώσει το πορτοφόλι.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Ξεκλειδωσε το πορτοφολι</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Αυτη η ενεργεια χρειάζεται τον κωδικο του πορτοφολιου  για να αποκρυπτογραφησειι το πορτοφολι.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Αποκρυπτογράφησε το πορτοφολι</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Άλλαξε κωδικο πρόσβασης</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Εισάγετε τον παλιό και τον νεο κωδικο στο πορτοφολι.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Επιβεβαίωσε την κρυπτογραφηση του πορτοφολιού</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Προσοχη: Εαν κρυπτογραφησεις το πορτοφολι σου και χάσεις τον κωδικο σου θα χάσεις &lt;b&gt; ΟΛΑ ΣΟΥ ΤΑ BITCOINS&lt;/b&gt;!
 Είσαι σίγουρος ότι θέλεις να κρυπτογραφησεις το πορτοφολι;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Είστε σίγουροι ότι θέλετε να κρυπτογραφήσετε το πορτοφόλι σας;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>ΣΗΜΑΝΤΙΚΟ: Τα προηγούμενα αντίγραφα ασφαλείας που έχετε κάνει από το αρχείο του πορτοφόλιου σας θα πρέπει να αντικατασταθουν με το νέο που δημιουργείται, κρυπτογραφημένο αρχείο πορτοφόλιου. Για λόγους ασφαλείας, τα προηγούμενα αντίγραφα ασφαλείας του μη κρυπτογραφημένου αρχείου πορτοφόλιου θα καταστουν άχρηστα μόλις αρχίσετε να χρησιμοποιείτε το νέο κρυπτογραφημένο πορτοφόλι. </translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Προσοχη: το πλήκτρο Caps Lock είναι ενεργο.</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Κρυπτογραφημενο πορτοφολι</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Το Bitcoin θα κλεισει τώρα για να τελειώσει την διαδικασία κρυπτογραφησης. Θυμησου ότι κρυπτογραφώντας το πορτοφολι σου δεν μπορείς να προστατέψεις πλήρως τα bitcoins σου από κλοπή στην περίπτωση όπου μολυνθεί ο υπολογιστής σου με κακόβουλο λογισμικό.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Η κρυπτογραφηση του πορτοφολιού απέτυχε</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Η κρυπτογράφηση του πορτοφολιού απέτυχε λογω εσωτερικού σφάλματος. Το πορτοφολι δεν κρυπτογραφηθηκε.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Οι εισαχθέντες κωδικοί δεν ταιριάζουν.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>το ξεκλείδωμα του πορτοφολιού απέτυχε</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Ο κωδικος που εισήχθη για την αποκρυπτογραφηση του πορτοφολιού ήταν λαθος.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Η αποκρυπτογραφηση του πορτοφολιού απέτυχε</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Ο κωδικος του πορτοφολιού άλλαξε με επιτυχία.</translation>
     </message>
@@ -329,362 +261,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Υπογραφή &amp;Μηνύματος...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Συγχρονισμός με το δίκτυο...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Επισκόπηση</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Εμφάνισε τη γενική εικόνα του πορτοφολιού</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Συναλλαγές</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Περιήγηση στο ιστορικό συναλλαγών</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>Έ&amp;ξοδος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Εξοδος από την εφαρμογή</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Εμφάνιση πληροφοριών σχετικά με το Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Σχετικά με &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Εμφάνισε πληροφορίες σχετικά με Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Επιλογές...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Κρυπτογράφησε το πορτοφόλι</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Αντίγραφο ασφαλείας του πορτοφολιού</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Άλλαξε κωδικο πρόσβασης</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Εισαγωγή μπλοκ από τον σκληρο δίσκο ... </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Φόρτωση ευρετηρίου μπλοκ στον σκληρο δισκο...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Στείλε νομίσματα σε μια διεύθυνση bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Επεργασία  ρυθμισεων επιλογών για το Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Δημιουργία αντιγράφου ασφαλείας πορτοφολιού σε άλλη τοποθεσία</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Αλλαγή του κωδικού κρυπτογράφησης του πορτοφολιού</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Παράθυρο αποσφαλμάτωσης</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Άνοιγμα κονσόλας αποσφαλμάτωσης και διαγνωστικών</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Επιβεβαίωση μηνύματος</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Πορτοφόλι</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Αποστολή</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Παραλαβή </translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Εμφάνισε/Κρύψε</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Εμφάνιση ή αποκρύψη του κεντρικου παράθυρου </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Κρυπτογραφήστε τα ιδιωτικά κλειδιά που ανήκουν στο πορτοφόλι σας </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Υπογράψτε ένα μήνυμα για να βεβαιώσετε πως είστε ο κάτοχος αυτής της διεύθυνσης</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Υπογράψτε ένα μήνυμα για ν&apos; αποδείξετε πως ανήκει μια συγκεκριμένη διεύθυνση Bitcoin</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Αρχείο</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ρυθμίσεις</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Βοήθεια</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Εργαλειοθήκη καρτελών</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Αίτηση πληρωμών (δημιουργεί QR codes και διευθύνσεις bitcoin: )</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Προβολή της λίστας των χρησιμοποιημένων διευθύνσεων και ετικετών αποστολής</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Προβολή της λίστας των χρησιμοποιημένων διευθύνσεων και ετικετών λήψεως</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Πελάτης Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n ενεργή σύνδεση στο δίκτυο Bitcoin</numerusform><numerusform>%n ενεργές συνδέσεις στο δίκτυο Βitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Η πηγή του μπλοκ δεν ειναι διαθέσιμη... </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Μεταποιημένα %1 απο %2 (κατ &apos;εκτίμηση) μπλοκ της ιστορίας της συναλλαγής. </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Έγινε λήψη %1 μπλοκ ιστορικού συναλλαγών</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n ώρες </numerusform><numerusform>%n ώρες </numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n ημέρες </numerusform><numerusform>%n ημέρες </numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n εβδομαδες</numerusform><numerusform>%n εβδομαδες</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 πίσω</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Το τελευταίο μπλοκ που ελήφθη δημιουργήθηκε %1 πριν.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Οι συναλλαγές μετά από αυτό δεν θα είναι ακόμη ορατες.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Προειδοποίηση</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Πληροφορία</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Ενημερωμένο</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Ενημέρωση...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Η συναλλαγή απεστάλη</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Εισερχόμενη συναλλαγή</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +553,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Το πορτοφόλι είναι &lt;b&gt;κρυπτογραφημένο&lt;/b&gt; και &lt;b&gt;ξεκλείδωτο&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Το πορτοφόλι είναι &lt;b&gt;κρυπτογραφημένο&lt;/b&gt; και &lt;b&gt;κλειδωμένο&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Παρουσιάστηκε ανεπανόρθωτο σφάλμα. Το Bitcoin δεν μπορεί πλέον να συνεχίσει με ασφάλεια και θα τερματισθει.</translation>
     </message>
@@ -715,7 +568,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Ειδοποίηση Δικτύου</translation>
     </message>
@@ -723,291 +575,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Ποσό:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Ποσό</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Διεύθυνση</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Ημερομηνία</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Επικυρωμένες</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Αντιγραφή διεύθυνσης</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Αντιγραφή επιγραφής</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Αντιγραφή ποσού</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Αντιγραφη του ID Συναλλαγής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(χωρίς ετικέτα)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1015,67 +806,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Επεξεργασία Διεύθυνσης</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Επιγραφή</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Διεύθυνση</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Νέα διεύθυνση λήψης</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Νέα διεύθυνση αποστολής</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Επεξεργασία διεύθυνσης λήψης</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Επεξεργασία διεύθυνσης αποστολής</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Η διεύθυνση &quot;%1&quot; βρίσκεται ήδη στο βιβλίο διευθύνσεων.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Η διεύθυνση &quot;%1&quot; δεν είναι έγκυρη Bitcoin διεύθυνση.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Δεν είναι δυνατό το ξεκλείδωμα του πορτοφολιού.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Η δημιουργία νέου κλειδιού απέτυχε.</translation>
     </message>
@@ -1083,27 +861,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Θα δημιουργηθεί ένας νέος φάκελος δεδομένων.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>όνομα</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Δεν μπορεί να δημιουργηθεί φάκελος δεδομένων εδώ.</translation>
     </message>
@@ -1111,52 +884,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>έκδοση</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Χρήση:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>επιλογής γραμμής εντολών</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>επιλογές UI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Όρισε γλώσσα, για παράδειγμα &quot;de_DE&quot;(προεπιλογή:τοπικές ρυθμίσεις)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Έναρξη ελαχιστοποιημένο</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Εμφάνισε την οθόνη εκκίνησης κατά την εκκίνηση(προεπιλογή:1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1164,57 +931,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Καλώς ήρθατε</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Χρήση του προεπιλεγμένου φακέλου δεδομένων</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Προσαρμογή του φακέλου δεδομένων: </translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Σφάλμα: Ο καθορισμένος φάκελος δεδομένων &quot;%1&quot; δεν μπορεί να δημιουργηθεί.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB ελεύθερου χώρου διαθέσιμα</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(από τα %1GB που χρειάζονται)</translation>
     </message>
@@ -1222,27 +978,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1250,253 +1001,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Κύριο</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Η προαιρετική αμοιβή για κάθε kB επισπεύδει την επεξεργασία των συναλλαγών σας. Οι περισσότερες συναλλαγές είναι 1 kB. </translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Αμοιβή &amp;συναλλαγής</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Αυτόματη εκκίνηση του Bitcoin μετά την εισαγωγή στο σύστημα</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Έναρξη του Βιtcoin κατά την εκκίνηση του συστήματος</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Ορίσμος του αριθμό των νημάτων ελέγχου σεναρίου (μέχρι 16, 0 = auto, &lt;0 = αφήνουν τους πολλους πυρήνες δωρεάν, default: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Επαναφορα όλων των επιλογων του πελάτη σε default.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>Επαναφορα ρυθμίσεων</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Δίκτυο</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Αυτόματο άνοιγμα των θυρών Bitcoin στον δρομολογητή. Λειτουργεί μόνο αν ο δρομολογητής σας υποστηρίζει τη λειτουργία UPnP.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Απόδοση θυρών με χρήστη &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP διαμεσολαβητή:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Θύρα:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Θύρα διαμεσολαβητή</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Έκδοση:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS εκδοση του διαμεσολαβητη (e.g. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Παράθυρο</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Εμφάνιση  μόνο εικονιδίου στην περιοχή ειδοποιήσεων κατά την ελαχιστοποίηση</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Ελαχιστοποίηση στην περιοχή ειδοποιήσεων αντί της γραμμής εργασιών</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Ελαχιστοποίηση αντί για έξοδο κατά το κλείσιμο του παραθύρου</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>Ε&amp;λαχιστοποίηση κατά το κλείσιμο</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Απεικόνιση</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Γλώσσα περιβάλλοντος εργασίας: </translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Εδώ μπορεί να ρυθμιστεί η γλώσσα διεπαφής χρήστη. Αυτή η ρύθμιση θα ισχύσει μετά την επανεκκίνηση του Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Μονάδα μέτρησης:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Διαλέξτε την προεπιλεγμένη υποδιαίρεση που θα εμφανίζεται όταν στέλνετε νομίσματα.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Επιλέξτε αν θέλετε να εμφανίζονται οι διευθύνσεις Bitcoin στη λίστα συναλλαγών.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>Εμφάνιση διευθύνσεων στη λίστα συναλλαγών</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;ΟΚ</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>προεπιλογή</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Επιβεβαιώση των επιλογων επαναφοράς </translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Δεν είναι έγκυρη η διεύθυνση διαμεσολαβητή</translation>
     </message>
@@ -1504,69 +1208,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Φόρμα</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Οι πληροφορίες που εμφανίζονται μπορεί να είναι ξεπερασμένες. Το πορτοφόλι σας συγχρονίζεται αυτόματα με το δίκτυο Bitcoin μετά από μια σύνδεση, αλλά αυτή η διαδικασία δεν έχει ακόμη ολοκληρωθεί. </translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Πορτοφόλι</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Το τρέχον διαθέσιμο υπόλοιπο</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Το άθροισμα των συναλλαγών που δεν έχουν ακόμα επιβεβαιωθεί και δεν προσμετρώνται στο τρέχον διαθέσιμο υπόλοιπό σας</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Ανώριμος</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Εξορυγμενο υπόλοιπο που δεν έχει ακόμα ωριμάσει </translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Σύνολο:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Το τρέχον συνολικό υπόλοιπο</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Πρόσφατες συναλλαγές&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>εκτός συγχρονισμού</translation>
     </message>
@@ -1574,93 +1263,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Χειρισμός URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>Το URI δεν μπορεί να αναλυθεί! Αυτό μπορεί να προκληθεί από μια μη έγκυρη διεύθυνση Bitcoin ή ακατάλληλη παραμέτρο URI.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Σφάλμα αιτήματος πληρωμής</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Δεν είναι δυνατή η εκκίνηση του Bitcoin: click-to-pay handler</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Πληρωμή αναγνωρίστηκε</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Σφάλμα αιτήματος δικτύου</translation>
     </message>
@@ -1668,23 +1334,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Σφάλμα: Ο καθορισμένος φάκελος δεδομένων &quot;%1&quot; δεν υπάρχει.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Σφάλμα: Άκυρος συνδυασμός των -regtest και -testnet</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Εισάγετε μια διεύθυνση Bitcoin (π.χ. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1692,22 +1357,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Αποθήκευση κώδικα QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1715,192 +1376,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Όνομα Πελάτη</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>Μη διαθέσιμο</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Έκδοση Πελάτη</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Πληροφορία</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Χρησιμοποιηση της OpenSSL εκδοσης</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Χρόνος εκκίνησης</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Δίκτυο</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Αριθμός συνδέσεων</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Αλυσίδα μπλοκ</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Τρέχον αριθμός μπλοκ</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Κατ&apos; εκτίμηση συνολικά μπλοκς</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Χρόνος τελευταίου μπλοκ</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Άνοιγμα</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Κονσόλα</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Σύνολα</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>Εισερχόμενα:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>Εξερχόμενα:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Ημερομηνία κατασκευής</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Αρχείο καταγραφής εντοπισμού σφαλμάτων </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Ανοίξτε το αρχείο καταγραφής εντοπισμού σφαλμάτων από τον τρέχοντα κατάλογο δεδομένων. Αυτό μπορεί να πάρει μερικά δευτερόλεπτα για τα μεγάλα αρχεία καταγραφής. </translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Καθαρισμός κονσόλας</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Καλώς ήρθατε στην Bitcoin RPC κονσόλα.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Χρησιμοποιήστε το πάνω και κάτω βέλος για να περιηγηθείτε στο ιστορικο, και &lt;b&gt;Ctrl-L&lt;/b&gt; για εκκαθαριση οθονης.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Γράψτε &lt;b&gt;help&lt;/b&gt; για μια επισκόπηση των διαθέσιμων εντολών</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 λ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 ώ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 ώ %2 λ</translation>
     </message>
@@ -1908,105 +1523,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Επιγραφή</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Καθαρισμός όλων των πεδίων της φόρμας.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Καθαρισμός</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Αντιγραφή επιγραφής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Αντιγραφή ποσού</translation>
     </message>
@@ -2014,67 +1606,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Κώδικας QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Πληροφορίες πληρωμής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Διεύθυνση</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Ποσό</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Ετικέτα</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Μήνυμα</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Το αποτέλεσμα της διεύθυνσης είναι πολύ μεγάλο. Μειώστε το μέγεθος για το κείμενο της ετικέτας/ μηνύματος.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Σφάλμα κατά την κωδικοποίηση του URI σε κώδικα QR</translation>
     </message>
@@ -2082,37 +1661,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Ημερομηνία</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Ετικέτα</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Μήνυμα</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Ποσό</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(χωρίς ετικέτα)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2120,247 +1692,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Αποστολή νομισμάτων</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Ποσό:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Αποστολή σε πολλούς αποδέκτες ταυτόχρονα</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;Προσθήκη αποδέκτη</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Καθαρισμός όλων των πεδίων της φόρμας.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Καθαρισμός &amp;Όλων</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Υπόλοιπο:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Επιβεβαίωση αποστολής</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>Αποστολη</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Επιβεβαίωση αποστολής νομισμάτων</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 σε %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Αντιγραφή ποσού</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Η διεύθυνση του αποδέκτη δεν είναι σωστή. Παρακαλώ ελέγξτε ξανά.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Το ποσό πληρωμής πρέπει να είναι μεγαλύτερο από 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Το ποσό ξεπερνάει το διαθέσιμο υπόλοιπο</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Το σύνολο υπερβαίνει το υπόλοιπό σας όταν συμπεριληφθεί και η αμοιβή %1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Βρέθηκε η ίδια διεύθυνση δύο φορές. Επιτρέπεται μία μόνο εγγραφή για κάθε διεύθυνση, σε κάθε διαδικασία αποστολής.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(χωρίς ετικέτα)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Είστε βέβαιοι για την αποστολή;</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>προστέθηκαν ως αμοιβή συναλλαγής</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Έληξε η αίτηση πληρωμής</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Μη έγκυρη διεύθυνση πληρωμής %1</translation>
     </message>
@@ -2368,111 +1887,85 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Ποσό:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Πληρωμή &amp;σε:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Διεύθυνση αποστολής της πληρωμής  (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Εισάγετε μια επιγραφή για αυτή τη διεύθυνση ώστε να καταχωρηθεί στο βιβλίο διευθύνσεων</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Επιγραφή</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Επιλογή διεύθυνσης που έχει ήδη χρησιμοποιηθεί</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Επικόλληση διεύθυνσης από το πρόχειρο</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Μήνυμα:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
-        <translation type="unfinished"/>
+        <translation>Σημείωση:</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2480,186 +1973,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Υπογραφές - Είσοδος / Επαλήθευση μήνυματος </translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Υπογραφή Μηνύματος</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Μπορείτε να υπογράφετε μηνύματα με τις διευθύνσεις σας, ώστε ν&apos; αποδεικνύετε πως αυτές σας ανήκουν. Αποφεύγετε να υπογράφετε κάτι αόριστο καθώς ενδέχεται να εξαπατηθείτε. Υπογράφετε μόνο πλήρης δηλώσεις με τις οποίες συμφωνείτε.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Εισάγετε μια διεύθυνση Bitcoin (π.χ. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Επιλογή διεύθυνσης που έχει ήδη χρησιμοποιηθεί</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Επικόλληση διεύθυνσης από το βιβλίο διευθύνσεων</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Εισάγετε εδώ το μήνυμα που θέλετε να υπογράψετε</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Υπογραφή</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Αντέγραφη της επιλεγμενης διεύθυνσης στο πρόχειρο του συστηματος</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Υπογράψτε ένα μήνυμα για ν&apos; αποδείξετε πως σας ανήκει μια συγκεκριμένη διεύθυνση Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Υπογραφη μήνυματος</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Επαναφορά όλων των πεδίων μήνυματος</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Καθαρισμός &amp;Όλων</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Επιβεβαίωση μηνύματος</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Πληκτρολογήστε την υπογραφή διεύθυνσης, μήνυμα (βεβαιωθείτε ότι έχετε αντιγράψει τις αλλαγές γραμμής, κενά, tabs, κ.λπ. ακριβώς) και την υπογραφή παρακάτω, για να ελέγξει το μήνυμα. Να είστε προσεκτικοί για να μην διαβάσετε περισσότερα στην υπογραφή ό, τι είναι στην υπογραφή ίδιο το μήνυμα , για να μην εξαπατηθούν από έναν άνθρωπο -in - the-middle επίθεση.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Εισάγετε μια διεύθυνση Bitcoin (π.χ. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Υπογράψτε ένα μήνυμα για ν&apos; αποδείξετε πως υπογραφθηκε απο μια συγκεκριμένη διεύθυνση Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Επιβεβαίωση μηνύματος</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Επαναφορά όλων επαλήθευμενων πεδίων μήνυματος </translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Εισάγετε μια διεύθυνση Bitcoin (π.χ. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Κάντε κλικ στο &quot;Υπογραφή Μηνύματος&quot; για να λάβετε την υπογραφή</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Η διεύθυνση που εισήχθη είναι λάθος.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Παρακαλούμε ελέγξτε την διεύθυνση και δοκιμάστε ξανά.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Η διεύθυνση που έχει εισαχθεί δεν αναφέρεται σε ένα πλήκτρο.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>το ξεκλείδωμα του πορτοφολιού απέτυχε</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Το προσωπικό κλειδί εισαγμενης διευθυνσης δεν είναι διαθέσιμο.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Η υπογραφή του μηνύματος απέτυχε.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Μήνυμα υπεγράφη.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Η υπογραφή δεν μπόρεσε να αποκρυπτογραφηθεί.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Παρακαλούμε ελέγξτε την υπογραφή και δοκιμάστε ξανά.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Η υπογραφή δεν ταιριάζει με το μήνυμα. </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Η επιβεβαίωση του μηνύματος απέτυχε</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Μήνυμα επιβεβαιώθηκε.</translation>
     </message>
@@ -2667,17 +2116,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2685,7 +2131,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2693,184 +2138,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Ανοιχτό μέχρι %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/χωρίς σύνδεση;</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/χωρίς επιβεβαίωση</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 επιβεβαιώσεις</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Κατάσταση</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, έχει μεταδοθεί μέσω %n κόμβων</numerusform><numerusform>, έχει μεταδοθεί μέσω %n κόμβων</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Ημερομηνία</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Πηγή</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Δημιουργία </translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Από</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Προς</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation> δική σας διεύθυνση </translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>eπιγραφή</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Πίστωση </translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>ωρίμανση σε %n επιπλέον μπλοκ</numerusform><numerusform>ωρίμανση σε %n επιπλέον μπλοκ</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>μη αποδεκτό</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debit</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Τέλος συναλλαγής </translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Καθαρό ποσό</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Μήνυμα</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Σχόλιο:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID Συναλλαγής:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Έμπορος</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Πληροφορίες αποσφαλμάτωσης</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Συναλλαγή</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>εισροές </translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Ποσό</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>αληθής</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>αναληθής </translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, δεν έχει ακόμα μεταδοθεί μ&apos; επιτυχία</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Ανοιχτό για %n μπλοκ</numerusform><numerusform>Ανοιχτό για %n μπλοκ</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>άγνωστο</translation>
     </message>
@@ -2878,12 +2277,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Λεπτομέρειες συναλλαγής</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Αυτό το παράθυρο δείχνει μια λεπτομερή περιγραφή της συναλλαγής</translation>
     </message>
@@ -2891,127 +2288,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Ημερομηνία</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Τύπος</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Διεύθυνση</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Ποσό</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Ανοιχτό για %n μπλοκ</numerusform><numerusform>Ανοιχτό για %n μπλοκ</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Ανοιχτό μέχρι %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Επικυρωμένη (%1 επικυρώσεις)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Αυτό το μπλοκ δεν έχει παραληφθεί από κανέναν άλλο κόμβο και κατά πάσα πιθανότητα θα απορριφθεί!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Δημιουργήθηκε αλλά απορρίφθηκε</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Παραλαβή με</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Ελήφθη από</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Αποστολή προς</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Πληρωμή προς εσάς</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Εξόρυξη</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(δ/α)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Κατάσταση συναλλαγής. Πηγαίνετε το ποντίκι πάνω από αυτό το πεδίο για να δείτε τον αριθμό των επικυρώσεων</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Ημερομηνία κι ώρα λήψης της συναλλαγής.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Είδος συναλλαγής.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Διεύθυνση αποστολής της συναλλαγής.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Ποσό που αφαιρέθηκε ή προστέθηκε στο υπόλοιπο.</translation>
     </message>
@@ -3019,178 +2391,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Όλα</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Σήμερα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Αυτή την εβδομάδα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Αυτόν τον μήνα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Τον προηγούμενο μήνα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Αυτό το έτος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Έκταση...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Ελήφθη με</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Απεστάλη προς</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Προς εσάς</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Εξόρυξη</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Άλλο</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Αναζήτηση με βάση τη διεύθυνση ή την επιγραφή</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Ελάχιστο ποσό</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Αντιγραφή διεύθυνσης</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Αντιγραφή επιγραφής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Αντιγραφή ποσού</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Αντιγραφη του ID Συναλλαγής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Επεξεργασία επιγραφής</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Εμφάνιση λεπτομερειών συναλλαγής</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Αρχείο οριοθετημένο με κόμματα (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Επικυρωμένες</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Ημερομηνία</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Τύπος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Επιγραφή</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Διεύθυνση</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Ποσό</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Έκταση:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>έως</translation>
     </message>
@@ -3198,7 +2534,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3206,7 +2541,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Αποστολή νομισμάτων</translation>
     </message>
@@ -3214,42 +2548,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Εξαγωγή</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Εξαγωγή δεδομένων καρτέλας σε αρχείο</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Αντίγραφο ασφαλείας του πορτοφολιού</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Αρχεία δεδομένων πορτοφολιού (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Αποτυχία κατά τη δημιουργία αντιγράφου</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Η δημιουργια αντιγραφου ασφαλειας πετυχε</translation>
     </message>
@@ -3257,107 +2583,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Χρήση:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Λίστα εντολών</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Επεξήγηση εντολής</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Επιλογές:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Ορίστε αρχείο ρυθμίσεων (προεπιλογή: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Ορίστε αρχείο pid (προεπιλογή: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Ορισμός φακέλου δεδομένων</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Όρισε το μέγεθος της βάσης προσωρινής αποθήκευσης σε megabytes(προεπιλογή:25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Εισερχόμενες συνδέσεις στη θύρα &lt;port&gt; (προεπιλογή: 8333 ή στο testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Μέγιστες αριθμός συνδέσεων με τους peers &lt;n&gt; (προεπιλογή: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Σύνδεση σε έναν κόμβο για την ανάκτηση διευθύνσεων από ομοτίμους, και αποσυνδέσh</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Διευκρινίστε τη δικιά σας δημόσια διεύθυνση.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Όριο αποσύνδεσης προβληματικών peers (προεπιλογή: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Δευτερόλεπτα πριν επιτραπεί ξανά η σύνδεση των προβληματικών peers (προεπιλογή: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Ένα σφάλμα συνέβη καθώς προετοιμαζόταν η πόρτα RPC %u για αναμονή IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Εισερχόμενες συνδέσεις JSON-RPC στη θύρα &lt;port&gt; (προεπιλογή: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Αποδοχή εντολών κονσόλας και JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Εκτέλεση στο παρασκήνιο κι αποδοχή εντολών</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Χρήση του δοκιμαστικού δικτύου</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Να δέχεσαι συνδέσεις από έξω(προεπιλογή:1)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3382,723 +2687,683 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ένα σφάλμα συνέβη καθώς προετοιμαζόταν η υποδοχη RPC %u για αναμονη του IPv6, επεσε πισω στο IPv4:%s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Αποθηκευση σε συγκεκριμένη διεύθυνση. Χρησιμοποιήστε τα πλήκτρα [Host] : συμβολισμός θύρα για IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Αδυναμία κλειδώματος του φακέλου δεδομένων %s. Πιθανώς το Bitcoin να είναι ήδη ενεργό.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Σφάλμα: Η συναλλαγή απορρίφθηκε.
 Αυτό ίσως οφείλεται στο ότι τα νομίσματά σας έχουν ήδη ξοδευτεί, π.χ. με την αντιγραφή του wallet.dat σε άλλο σύστημα και την χρήση τους εκεί, χωρίς η συναλλαγή να έχει καταγραφεί στο παρόν σύστημα.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Σφάλμα: Αυτή η συναλλαγή απαιτεί αμοιβή συναλλαγής τουλάχιστον %s λόγω του μεγέθους, πολυπλοκότητας ή της χρήσης πρόσφατης παραλαβής κεφαλαίου</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Εκτέλεσε την εντολή όταν το καλύτερο μπλοκ αλλάξει(%s στην εντολή αντικαθίσταται από το hash του μπλοκ)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Αυτό είναι ένα προ-τεστ κυκλοφορίας - χρησιμοποιήστε το με δική σας ευθύνη - δεν χρησιμοποιείτε για εξόρυξη ή για αλλες εφαρμογές</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Προειδοποίηση: Η παράμετρος -paytxfee είναι πολύ υψηλή. Πρόκειται για την αμοιβή που θα πληρώνετε για κάθε συναλλαγή που θα στέλνετε.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Προειδοποίηση: Παρακαλώ βεβαιωθείτε πως η ημερομηνία κι ώρα του συστήματός σας είναι σωστές. Αν το ρολόι του υπολογιστή σας πάει λάθος, ενδέχεται να μη λειτουργεί σωστά το Bitcoin.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Προειδοποίηση : Σφάλμα wallet.dat κατα την ανάγνωση ! Όλα τα κλειδιά αναγνωρισθηκαν σωστά, αλλά τα δεδομένα των συναλλαγών ή καταχωρήσεις στο βιβλίο διευθύνσεων μπορεί να είναι ελλιπείς ή λανθασμένα. </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Προειδοποίηση : το αρχειο wallet.dat ειναι διεφθαρμένο, τα δεδομένα σώζονται ! Original wallet.dat αποθηκεύονται ως wallet.{timestamp}.bak στο %s . Αν το υπόλοιπο του ή τις συναλλαγές σας, είναι λάθος θα πρέπει να επαναφέρετε από ένα αντίγραφο ασφαλείας</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Προσπάθεια για ανακτησει ιδιωτικων κλειδιων από ενα διεφθαρμένο αρχειο wallet.dat </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Αποκλεισμός επιλογων δημιουργίας: </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Σύνδεση μόνο με ορισμένους κόμβους</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Εντοπισθηκε διεφθαρμενη βαση δεδομενων των μπλοκ</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Ανακαλύψτε την δικη σας IP διεύθυνση (προεπιλογή: 1 όταν ακούει και δεν - externalip) </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Θελετε να δημιουργηθει τωρα η βαση δεδομενων του μπλοκ? </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Σφάλμα κατά την ενεργοποίηση της βάσης δεδομένων μπλοκ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Σφάλμα κατά την ενεργοποίηση της βάσης δεδομένων πορτοφόλιου %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Σφάλμα φορτωσης της βασης δεδομενων των μπλοκ</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Σφάλμα φορτωσης της βασης δεδομενων των μπλοκ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Προειδοποίηση: Χαμηλός χώρος στο δίσκο  </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Σφάλμα: το πορτοφόλι είναι κλειδωμένο, δεν μπορεί να δημιουργηθεί συναλλαγή</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Λάθος: λάθος συστήματος:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>ταλαιπωρηθειτε για να ακούσετε σε οποιαδήποτε θύρα. Χρήση - ακούστε = 0 , αν θέλετε αυτό.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Αποτυχία αναγνωσης των block πληροφοριων</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Η αναγνωση του μπλοκ απετυχε</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Ο συγχρονισμος του μπλοκ ευρετηριου απετυχε</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Η δημιουργια του μπλοκ ευρετηριου απετυχε</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Η δημιουργια των μπλοκ πληροφοριων απετυχε</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Η δημιουργια του μπλοκ απετυχε</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Αδυναμία εγγραφής πληροφοριων αρχειου</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Αποτυχία εγγραφής στη βάση δεδομένων νομίσματος</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Αποτυχία εγγραφής δείκτη συναλλαγών </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Αποτυχία εγγραφής αναίρεσης δεδομένων </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Προσθήκη αμοιβής ανά kB στις συναλλαγές που στέλνετε</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Βρες ομότιμους υπολογιστές χρησιμοποιώντας αναζήτηση DNS(προεπιλογή:1)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Δημιουργία νομισμάτων (προκαθορισμος: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Πόσα μπλοκ να ελέγχθουν κατά την εκκίνηση (προεπιλογή:288,0=όλα)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Πόσο εξονυχιστική να είναι η επιβεβαίωση του μπλοκ(0-4, προεπιλογή:3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Άκυρη διεύθυνση -onion : &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Δεν ειναι αρκετες περιγραφες αρχείων διαθέσιμες.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Εισαγωγή μπλοκ από εξωτερικό αρχείο blk000?.dat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Ορίσμος του αριθμόυ θεματων στην υπηρεσία κλήσεων RPC (προεπιλογή: 4) </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Επαλήθευση των μπλοκ... </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Επαλήθευση πορτοφολιου... </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Εισαγωγή μπλοκ από εξωτερικό αρχείο blk000?.dat</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Ορίσμος του αριθμό των νημάτων ελέγχου σεναρίου (μέχρι 16, 0 = auto, &lt;0 = αφήνουν τους πολλους πυρήνες δωρεάν, default: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Πληροφορία</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Μη έγκυρο ποσό για την παράμετρο -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Μη έγκυρο ποσό για την παράμετρο -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Διατηρήση ένος πλήρες ευρετήριου συναλλαγών (προεπιλογή: 0) </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Μέγιστος buffer λήψης ανά σύνδεση, &lt;n&gt;*1000 bytes (προεπιλογή: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Μέγιστος buffer αποστολής ανά σύνδεση, &lt;n&gt;*1000 bytes (προεπιλογή: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Μονο αποδοχη αλυσίδας μπλοκ που ταιριάζει με τα ενσωματωμένα σημεία ελέγχου (προεπιλογή: 1) </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation> Συνδέση μόνο σε κόμβους του δικτύου &lt;net&gt; (IPv4, IPv6 ή Tor) </translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Ρυθμίσεις SSL: (ανατρέξτε στο Bitcoin Wiki για οδηγίες ρυθμίσεων SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Αποστολή πληροφοριών εντοπισμού σφαλμάτων στην κονσόλα αντί του αρχείου debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Ορίστε το μέγιστο μέγεθος μπλοκ σε bytes (προεπιλογή: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Συρρίκνωση του αρχείο debug.log κατα την εκκίνηση του πελάτη (προεπιλογή: 1 όταν δεν-debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Η υπογραφή συναλλαγής απέτυχε </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Ορισμός λήξης χρονικού ορίου σε χιλιοστά του δευτερολέπτου(προεπιλογή:5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Λάθος Συστήματος:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Το ποσό της συναλλαγής είναι πολύ μικρο </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Τα ποσά των συναλλαγών πρέπει να είναι θετικα</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Η συναλλαγή ειναι πολύ μεγάλη </translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Χρησιμοποίηση του  UPnP για την χρήση της πόρτας αναμονής (προεπιλογή:0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Χρησιμοποίηση του  UPnP για την χρήση της πόρτας αναμονής (προεπιλογή:1)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Όνομα χρήστη για τις συνδέσεις JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Προειδοποίηση</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Προειδοποίηση: Αυτή η έκδοση είναι ξεπερασμένη, απαιτείται αναβάθμιση </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>έκδοση</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>Το αρχειο wallet.dat ειναι διεφθαρμένο, η διάσωση απέτυχε</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Κωδικός για τις συνδέσεις JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Αποδοχή συνδέσεων JSON-RPC από συγκεκριμένη διεύθυνση IP</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Αποστολή εντολών στον κόμβο &lt;ip&gt; (προεπιλογή: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Εκτέλεσε την εντολή όταν το καλύτερο μπλοκ αλλάξει(%s στην εντολή αντικαθίσταται από το hash του μπλοκ)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Αναβάθμισε το πορτοφόλι στην τελευταία έκδοση</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Όριο πλήθους κλειδιών pool &lt;n&gt; (προεπιλογή: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Επανέλεγχος της αλυσίδας μπλοκ για απούσες συναλλαγές</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Χρήση του OpenSSL (https) για συνδέσεις JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Αρχείο πιστοποιητικού του διακομιστή  (προεπιλογή: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Προσωπικό κλειδί του διακομιστή (προεπιλογή: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Αυτό το κείμενο βοήθειας</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Αδύνατη η σύνδεση με τη θύρα %s αυτού του υπολογιστή (bind returned error %d, %s) </translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Να επιτρέπονται οι έλεγχοι DNS για προσθήκη και σύνδεση κόμβων</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Φόρτωση διευθύνσεων...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Σφάλμα φόρτωσης wallet.dat: Κατεστραμμένο Πορτοφόλι</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Σφάλμα φόρτωσης wallet.dat: Το Πορτοφόλι απαιτεί μια νεότερη έκδοση του Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Απαιτείται η επανεγγραφή του Πορτοφολιού, η οποία θα ολοκληρωθεί στην επανεκκίνηση του Bitcoin</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Σφάλμα φόρτωσης αρχείου wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Δεν είναι έγκυρη η διεύθυνση διαμεσολαβητή: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Άγνωστo δίκτυο ορίζεται σε onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Άγνωστo δίκτυο ορίζεται: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Δεν μπορώ να γράψω την προεπιλεγμένη διεύθυνση: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Δεν μπορώ να γράψω την προεπιλεγμένη διεύθυνση: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Μη έγκυρο ποσό για την παράμετρο -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Λάθος ποσότητα</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Ανεπαρκές κεφάλαιο</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Φόρτωση ευρετηρίου μπλοκ...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Προσέθεσε ένα κόμβο για σύνδεση και προσπάθησε να κρατήσεις την σύνδεση ανοιχτή</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Αδύνατη η σύνδεση με τη θύρα %s αυτού του υπολογιστή. Το Bitcoin είναι πιθανώς ήδη ενεργό.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Φόρτωση πορτοφολιού...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Δεν μπορώ να υποβαθμίσω το πορτοφόλι</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Δεν μπορώ να γράψω την προεπιλεγμένη διεύθυνση</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Ανίχνευση...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Η φόρτωση ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Χρήση της %s επιλογής</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Σφάλμα</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_eo.ts
+++ b/src/qt/locale/bitcoin_eo.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Pri la Bitmona Kerno</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>Versio de &lt;b&gt;Bitmona Kerno&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Eldonita laŭ la permesilo MIT/X11. Vidu la kunan dosieron COPYING aŭ http://ww
 Tiu ĉi produkto enhavas erojn kreitajn de la &quot;OpenSSL Project&quot; por uzo en la &quot;OpenSSL Toolkit&quot; (http://www.openssl.org/) kaj ĉifrajn erojn kreitajn de Eric Young (eay@cryptsoft.com) kaj UPnP-erojn kreitajn de Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Kopirajto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>La programistoj de Bitmona Kerno</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Duoble-klaku por redakti adreson aŭ etikedon</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Krei novan adreson</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nova</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopii elektitan adreson al la tondejo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopii</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>&amp;Fermi</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopii Adreson</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Forigi la elektitan adreson el la listo</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Eksporti al dosiero la datumojn el la aktuala langeto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Eksporti</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Forigi</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Elektu la alsendotan adreson</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Elektu la ricevontan adreson</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Elekti</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Sendaj adresoj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Ricevaj adresoj</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Jen viaj Bitmon-adresoj por sendi pagojn. Zorge kontrolu la sumon kaj la alsendan adreson antaŭ ol sendi.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Jen viaj bitmonaj adresoj por ricevi pagojn. Estas konsilinde uzi apartan ricevan adreson por ĉiu transakcio.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopii &amp;Etikedon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Redakti</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Eksporti Adresliston</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Perkome disigita dosiero (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ Tiu ĉi produkto enhavas erojn kreitajn de la &quot;OpenSSL Project&quot; por uz
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etikedo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(neniu etikedo)</translation>
     </message>
@@ -187,140 +153,106 @@ Tiu ĉi produkto enhavas erojn kreitajn de la &quot;OpenSSL Project&quot; por uz
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Dialogo pri pasfrazo</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Enigu pasfrazon</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nova pasfrazo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Ripetu la novan pasfrazon</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Enigu novan pasfrazon por la monujo.&lt;br/&gt;Bonvolu uzi pasfrazon kun &lt;b&gt;almenaŭ 10 hazardaj signoj&lt;/b&gt;, aŭ &lt;b&gt;almenaŭ ok vortoj&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Ĉifri la monujon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Ĉi tiu operacio bezonas vian monujan pasfrazon, por malŝlosi la monujon.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Malŝlosi la monujon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Ĉi tiu operacio bezonas vian monujan pasfrazon, por malĉifri la monujon.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Malĉifri la monujon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Ŝanĝi la pasfrazon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Tajpu la malnovan kaj novan monujajn pasfrazojn.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Konfirmo de ĉifrado de la monujo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Atentu! Se vi ĉifras vian monujon kaj perdas la pasfrazon, vi &lt;b&gt;PERDOS LA TUTON DE VIA BITMONO&lt;b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Ĉu vi certas, ke vi volas ĉifri la monujon?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>GRAVE: antaŭaj sekur-kopioj de via monujo-dosiero estas forigindaj kiam vi havas nove kreitan ĉifritan monujo-dosieron. Pro sekureco, antaŭaj kopioj de la neĉifrita dosiero ne plu funkcios tuj kiam vi ekuzos la novan ĉifritan dosieron.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Atentu: la majuskla baskulo estas ŝaltita!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>La monujo estas ĉifrita</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitmono nun fermiĝos por fini la ĉifradon. Memoru, ke eĉ ĉifrado ne protektas kontraŭ ĉiu atako, ekz. se viruso infektus vian komputilon.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Ĉifrado de la monujo fiaskis</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Ĉifrado de monujo fiaskis pro interna eraro. Via monujo ne estas ĉifrita.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>La pasfrazoj entajpitaj ne samas.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Malŝloso de la monujo fiaskis</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La pasfrazo enigita por ĉifrado de monujo ne ĝustas.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Malĉifrado de la monujo fiaskis</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Vi sukcese ŝanĝis la pasfrazon de la monujo.</translation>
     </message>
@@ -328,362 +260,286 @@ Tiu ĉi produkto enhavas erojn kreitajn de la &quot;OpenSSL Project&quot; por uz
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Subskribi &amp;mesaĝon...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sinkronigante kun reto...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Superrigardo</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation>Nodo</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Vidigi ĝeneralan superrigardon de la monujo</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transakcioj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Esplori historion de transakcioj</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Eliri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Eliri la aplikaĵon</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Vidigi informojjn pri Bitmono</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Pri &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Vidigi informojn pri Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Agordoj...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>Ĉifri &amp;Monujon...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Krei sekurkopion de la monujo...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>Ŝanĝi &amp;Pasfrazon...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;Sendaj adresoj...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;Ricevaj adresoj...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Malfermi &amp;URI-on...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importado de blokoj el disko...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Reindeksado de blokoj sur disko...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Sendi monon al Bitmon-adreso</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modifi agordaĵojn por Bitmono</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Krei alilokan sekurkopion de monujo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Ŝanĝi la pasfrazon por ĉifri la monujon</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Sen&amp;cimiga fenestro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Malfermi konzolon de sencimigo kaj diagnozo</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Kontroli mesaĝon...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitmono</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Monujo</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Sendi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Ricevi</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Montri / Kaŝi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Montri aŭ kaŝi la ĉefan fenestron</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Ĉifri la privatajn ŝlosilojn de via monujo</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Subskribi mesaĝojn per via Bitmon-adresoj por pravigi, ke vi estas la posedanto</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Kontroli mesaĝojn por kontroli ĉu ili estas subskribitaj per specifaj Bitmon-adresoj</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Dosiero</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Agordoj</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Helpo</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Langeto-breto</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Kerno de Bitmono</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Peti pagon (kreas QR-kodojn kaj URI-ojn kun prefikso bitcoin:)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;Pri la Bitmona Kerno</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Vidigi la liston de uzitaj sendaj adresoj kaj etikedoj</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Vidigi la liston de uzitaj ricevaj adresoj kaj etikedoj</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Malfermi bitcoin:-URI-on aŭ pagpeton</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Komandliniaj agordaĵoj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitmon-kliento</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktiva konekto al la bitmona reto</numerusform><numerusform>%n aktivaj konektoj al la bitmona reto</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Neniu fonto de blokoj trovebla...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Traktis %1 el (ĉirkaŭ) %2 blokoj de la transakcia historio.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Traktis %1 blokoj de la transakcia historio.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n horo</numerusform><numerusform>%n horoj</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n tago</numerusform><numerusform>%n tagoj</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n semajno</numerusform><numerusform>%n semajnoj</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 kaj %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>mankas %1</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Lasta ricevita bloko kreiĝis antaŭ %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transakcioj por tio ankoraŭ ne videblas.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Averto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informoj</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Ĝisdata</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Ĝisdatigante...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Sendita transakcio</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Envenanta transakcio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +552,14 @@ Adreso: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Monujo estas &lt;b&gt;ĉifrita&lt;/b&gt; kaj aktuale &lt;b&gt;malŝlosita&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Monujo estas &lt;b&gt;ĉifrita&lt;/b&gt; kaj aktuale &lt;b&gt;ŝlosita&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Okazis neriparebla eraro. Bitmono ne plu povas sekure daŭri, do ĝi sekure ĉesos.</translation>
     </message>
@@ -714,7 +567,6 @@ Adreso: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Reta Averto</translation>
     </message>
@@ -722,291 +574,230 @@ Adreso: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Kvanto:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bajtoj:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Sumo:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioritato:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Krompago:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Malalta Eligo:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Post krompago:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Restmono:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(mal)elekti ĉion</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Arboreĝimo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Listreĝimo</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Sumo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Konfirmoj</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Konfirmita</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioritato</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopii adreson</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopii etikedon</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopii sumon</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopii transakcian ID-on</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Ŝlosi la neelspezitajn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Malŝlosi la neelspezitajn</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Kopii kvanton</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Kopii krompagon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Kopii post krompago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopii bajtojn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopii prioritaton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Kopii malaltan eligon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopii restmonon</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation>plej alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>pli alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>mezalta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>meza</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>mezmalalta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>malalta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>pli malalta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>plej malalta</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 ŝlosita)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>neniu</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Polvo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>jes</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>ne</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Tiu ĉi etikedo ruĝiĝas se la grando de la transakcio estas pli ol 1000 bajtoj.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Tio signifas, ke krompago de almenaŭ po %1 por ĉiu kB estas deviga.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Povas varii po +/- 1 bajton por ĉiu enigo.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Transakcioj kun pli alta prioritato havas pli altan ŝancon inkluziviĝi en bloko.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Tiu ĉi etikedo ruĝiĝas se iu ajn ricevonto ricevos sumon malpli ol %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Tio signifas, ke krompago de almenaŭ %1 estas deviga.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Sumoj, kiuj valoras malpli ol 0.545 oble la minimuman plusendan kromkoston vidiĝas kiel polvo.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Tiu ĉi etikedo ruĝiĝas se la restmono estas malpli ol %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(neniu etikedo)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>restmono de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(restmono)</translation>
     </message>
@@ -1014,67 +805,54 @@ Adreso: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Redakti Adreson</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etikedo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>La etikedo ligita al tiu ĉi adreslistero</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>La adreso ligita al tiu ĉi adreslistero. Eblas modifi tion nur por sendaj adresoj.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adreso</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nova adreso por ricevi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nova adreso por sendi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Redakti adreson por ricevi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Redakti adreson por sendi</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>La adreso enigita &quot;%1&quot; jam ekzistas en la adresaro.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>La adreso enigita &quot;%1&quot; ne estas valida Bitmon-adreso.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Ne eblis malŝlosi monujon.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Fiaskis kreo de nova ŝlosilo.</translation>
     </message>
@@ -1082,27 +860,22 @@ Adreso: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Kreiĝos nova dosierujo por la datumoj.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nomo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Tiu dosierujo jam ekzistas. Aldonu %1 si vi volas krei novan dosierujon ĉi tie.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Vojo jam ekzistas, kaj ne estas dosierujo.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Ne eblas krei dosierujon por datumoj ĉi tie.</translation>
     </message>
@@ -1110,52 +883,46 @@ Adreso: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitmona Kerno - Komandliniaj agordaĵoj</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Kerno de Bitmono</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versio</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Uzado:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>komandliniaj agordaĵoj</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI-agordaĵoj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Agordi lingvon, ekzemple &quot;de_DE&quot; (defaŭlte: tiu de la sistemo)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Lanĉiĝi plejete</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Montri salutŝildon dum lanĉo (defaŭlte: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Elekti dosierujon por datumoj dum lanĉo (defaŭlte: 0)</translation>
     </message>
@@ -1163,57 +930,46 @@ Adreso: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Bonvenon</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Bonvenon al la bitmona kerno, Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Dum tiu ĉi unua uzo de la programo, vi povas elekti lokon, kie Bitcoin Core stokos siajn datumojn.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core elŝutos kaj konservos kopion de la bitmona blokĉeno. Almenaŭ %1GB da datumoj konserviĝos en tiu loko, kaj tio poiome kreskos. Ankaŭ via monujo konserviĝos en tiu dosierujo.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Uzi la defaŭltan dosierujon por datumoj</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Uzi alian dosierujon por datumoj:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitmono</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Eraro: ne eblas krei la elektitan dosierujon por datumoj &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB de libera loko disponebla</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(el %1GB bezonataj)</translation>
     </message>
@@ -1221,27 +977,22 @@ Adreso: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Malfermi URI-on</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Malfermi pagpeton el URI aŭ dosiero</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Elektu la dosieron de la pagpeto</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Elektu la malfermotan dosieron de la pagpeto</translation>
     </message>
@@ -1249,253 +1000,206 @@ Adreso: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Agordaĵoj</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>Ĉ&amp;efa</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Nedeviga krompago por ĉiu kB, kiu helpas plirapidigi la traktadon de via transakcio. Plej multaj transakcioj grandas je 1kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Krompago</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Aŭtomate lanĉi Bitmonon post ensaluto al la sistemo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Lanĉi Bitmonon tuj post ensaluto al la sistemo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>Dosiergrando de &amp;datumbasa kaŝmemoro</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Agordi la nombron de fadenoj por skriptkontrolado (ĝis 16, 0 = aŭtomate, &lt;0 = lasi tiom da kernoj liberaj, defaŭlte: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Reagordi ĉion al defaŭlataj valoroj.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Rekomenci agordadon</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Reto</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Aŭtomate malfermi la kursilan pordon por Bitmono. Tio funkcias nur se via kursilo havas la UPnP-funkcion, kaj se tiu ĉi estas ŝaltita.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapigi pordon per &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Prokurila &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Pordo:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>la pordo de la prokurilo (ekz. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>Versio de SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>la versio de SOCKS ĉe la prokurilo (ekz. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Fenestro</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Montri nur sistempletan piktogramon post minimumigo de la fenestro.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimumigi al la sistempleto anstataŭ al la taskopleto</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimumigi la aplikaĵon anstataŭ eliri kaj ĉesi kiam la fenestro estas fermita. Se tiu ĉi estas agordita, la aplikaĵo ĉesas nur kiam oni elektas &quot;Eliri&quot; el la menuo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimumigi je fermo</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Aspekto</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Lingvo de la fasado:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Vi povas elekti la lingvon uzata en la aplikaĵo ĉi tie. Tiu ekefikos nur post relanĉo de Bitmono.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unuo por vidigi sumojn:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Elekti la defaŭltan manieron por montri bitmonajn sumojn en la interfaco, kaj kiam vi sendos bitmonon.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Elekti ĉu videblu Bitmon-adresoj en la listo de transakcioj.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Montri adresojn en la listo de transakcioj</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Ĉu montri detalan adres-regilon, aŭ ne.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation>Montri &amp;detalan adres-regilon (nur por spertuloj)</translation>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;Bone</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Nuligi</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>defaŭlta</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>neniu</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Konfirmi reŝargo de agordoj</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>La prokurila adreso estas malvalida.</translation>
     </message>
@@ -1503,69 +1207,54 @@ Adreso: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formularo</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Eblas, ke la informoj videblaj ĉi tie estas eksdataj. Via monujo aŭtomate sinkoniĝas kun la bitmona reto kiam ili konektiĝas, sed tiu procezo ankoraŭ ne finfariĝis.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Monujo</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>via aktuala elspezebla saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>la sumo de transakcioj ankoraŭ ne konfirmitaj, kiuj ankoraŭ ne elspezeblas</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Nematura:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Minita saldo, kiu ankoraŭ ne maturiĝis</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Totalo:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>via aktuala totala saldo</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Lastaj transakcioj&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>nesinkronigita</translation>
     </message>
@@ -1573,93 +1262,70 @@ Adreso: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Traktado de URI-oj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>Fiaskis la analizon de la URI! Eble la Bitmon-adreso estas nevalida, aŭ povus esti problemo kun la parametroj de la URI.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>La petita pagosumo de %1 estas tro malgranda (konsiderata kiel polvo).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Eraro dum pagopeto</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Ne eblas lanĉi la ilon &apos;klaki-por-pagi&apos;</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Repago de %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Eraro dum komunikado kun %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Malbona respondo de la servilo %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Pago agnoskita</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Eraro dum ret-peto</translation>
     </message>
@@ -1667,23 +1333,22 @@ Adreso: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitmono</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Eraro: la elektita dosierujo por datumoj &quot;%1&quot; ne ekzistas.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Eraro: nevalida kunigo de -regtest kaj -testnet</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Enigi Bitmon-adreson (ekz. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1691,22 +1356,18 @@ Adreso: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Konservi Bildon...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Kopii Bildon</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Konservi QR-kodon</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG-bildo (*.png)</translation>
     </message>
@@ -1714,192 +1375,146 @@ Adreso: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nomo de kliento</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>neaplikebla</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versio de kliento</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informoj</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Sencimiga fenestro</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Ĝenerala</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>uzas OpenSSL-version</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Horo de lanĉo</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Reto</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nomo</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Nombro de konektoj</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Blokĉeno</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Aktuala nombro de blokoj</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Supozita totalo da blokoj</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Horo de la lasta bloko</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Malfermi</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konzolo</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Reta Trafiko</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Forigi ĉion</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totaloj</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>En:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>El:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Dato de kompilado</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Sencimiga protokoldosiero</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Malfermi la sencimiga protokoldosiero de Bitmono el la aktuala dosierujo por datumoj. Tio eble daŭros plurajn sekundojn por granda protokoldosiero.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Malplenigi konzolon</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bonvenon al la RPC-konzolo de Bitmono.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Uzu la sagojn supran kaj malsupran por esplori la historion, kaj &lt;b&gt;stir-L&lt;/b&gt; por malplenigi la ekranon.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Tajpu &lt;b&gt;help&lt;/b&gt; por superrigardo de la disponeblaj komandoj.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1907,105 +1522,82 @@ Adreso: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Kvanto:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etikedo:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Mesaĝo:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Reuzi unu el la jam uzitaj ricevaj adresoj. Reuzo de adresoj povas krei problemojn pri sekureco kaj privateco. Ne uzu tiun ĉi funkcion krom por rekrei antaŭe faritan pagopeton.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>R&amp;euzi ekzistantan ricevan adreson (malrekomendinda)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Malplenigi ĉiujn kampojn de la formularo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Forigi</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Peti pagon</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Vidigi</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Forigi</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopii etikedon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Kopiu mesaĝon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopii sumon</translation>
     </message>
@@ -2013,67 +1605,54 @@ Adreso: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR-kodo</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Kopii &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Kopii &amp;Adreson</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Konservi Bildon...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Peti pagon al %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Paginformoj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Sumo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etikedo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mesaĝo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>La rezultanta URI estas tro longa. Provu malplilongigi la tekston de la etikedo / mesaĝo.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Eraro de kodigo de URI en la QR-kodon.</translation>
     </message>
@@ -2081,37 +1660,30 @@ Adreso: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etikedo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mesaĝo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Sumo</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(neniu etikedo)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(neniu mesaĝo)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2119,247 +1691,194 @@ Adreso: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Sendi Monon</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Monregaj Opcioj</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Enigoj...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Nesufiĉa mono!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Kvanto:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bajtoj:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Sumo:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioritato:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Krompago:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Malalta Eligo:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Post krompago:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Restmono:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Sendi samtempe al pluraj ricevantoj</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Aldoni &amp;Ricevonton</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Malplenigi ĉiujn kampojn de la formularo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Forigi ĉion</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Konfirmi la sendon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>Ŝendi</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Konfirmi sendon de bitmono</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 al %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Kopii kvanton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopii sumon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Kopii krompagon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Kopii post krompago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopii bajtojn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopii prioritaton</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Kopii malaltan eligon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopii restmonon</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Totala Sumo %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>aŭ</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>La adreso de la ricevonto ne validas. Bonvolu kontroli.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>La pagenda sumo devas esti pli ol 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>La sumo estas pli granda ol via saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>La sumo kun la %1 krompago estas pli granda ol via saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Iu adreso estas ripetita. Vi povas sendi al ĉiu adreso po unufoje en iu send-operacio.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Kreo de transakcio fiaskis!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Averto: Nevalida Bitmon-adreso</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(neniu etikedo)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Ĉu vi certas, ke vi volas sendi?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>aldonita kiel krompago</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Pagopeto nun estas eksdata</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Nevalida pagadreso %1</translation>
     </message>
@@ -2367,98 +1886,74 @@ Adreso: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Sumo:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Ricevonto:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La adreso kie vi sendos la pagon (ekz. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Tajpu etikedon por tiu ĉi adreso kaj aldonu ĝin al via adresaro</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etikedo:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Elektu la jam uzitan adreson</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Tio estas normala pago.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Alglui adreson el tondejo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Forigu ĉi tiun enskribon</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Mesaĝo:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Tajpu etikedon por tiu ĉi adreso por aldoni ĝin al la listo de uzitaj adresoj</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Pagi Al:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memorando:</translation>
     </message>
@@ -2466,12 +1961,10 @@ Adreso: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Ne sistemfermu ĝis ĉi tiu fenestro malaperas.</translation>
     </message>
@@ -2479,186 +1972,142 @@ Adreso: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Subskriboj - Subskribi / Kontroli mesaĝon</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Subskribi Mesaĝon</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Vi povas subskribi mesaĝon per viaj adresoj, por pravigi ke vi estas la posedanto de tiuj adresoj. Atentu, ke vi ne subskriu ion neprecizan, ĉar trompisto povus ruzi kontraŭ vi kaj ŝteli vian identecon. Subskribu nur plene detaligitaj deklaroj pri kiuj vi konsentas.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La adreso por subskribi la mesaĝon (ekz. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Elektu la jam uzitan adreson</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Alglui adreson de tondejo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Tajpu la mesaĝon, kiun vi volas sendi, cîi tie</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Subskribo</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Kopii la aktualan subskribon al la tondejo</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Subskribi la mesaĝon por pravigi, ke vi estas la posedanto de tiu Bitmon-adreso</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Subskribi &amp;Mesaĝon</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Reagordigi ĉiujn prisubskribajn kampojn</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Forigi Ĉion</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Kontroli Mesaĝon</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Enmeti la subskriban adreson, la mesaĝon (kune kun ĉiu linisalto, spaceto, taboj, ktp. precize) kaj la subskribon ĉi sube por kontroli la mesaĝon. Atentu, ke vi ne komprenu per la subskribo pli ol la enhavo de la mesaĝo mem, por eviti homo-en-la-mezo-atakon.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La adreso per kio oni subskribis la mesaĝon (ekz. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Kontroli la mesaĝon por pravigi, ke ĝi ja estas subskribita per la specifa Bitmon-adreso</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Kontroli &amp;Mesaĝon</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Reagordigi ĉiujn prikontrolajn kampojn</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Enigi Bitmon-adreson (ekz. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Klaku &quot;Subskribi Mesaĝon&quot; por krei subskribon</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>La adreso, kiun vi enmetis, estas nevalida.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Bonvolu kontroli la adreson kaj reprovi.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>La adreso, kiun vi enmetis, referencas neniun ŝlosilon.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Malŝloso de monujo estas nuligita.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La privata ŝlosilo por la enigita adreso ne disponeblas.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Subskribo de mesaĝo fiaskis.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Mesaĝo estas subskribita.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Ne eblis malĉifri la subskribon.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Bonvolu kontroli la subskribon kaj reprovu.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>La subskribo ne kongruis kun la mesaĝ-kompilaĵo.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Kontrolo de mesaĝo malsukcesis.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Mesaĝo sukcese kontrolita.</translation>
     </message>
@@ -2666,17 +2115,14 @@ Adreso: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Kerno de Bitmono</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>La programistoj de Bitmona Kerno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2684,7 +2130,6 @@ Adreso: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2692,184 +2137,138 @@ Adreso: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Malferma ĝis %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/senkonekte</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nekonfirmite</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 konfirmoj</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, elsendita(j) tra %n nodo</numerusform><numerusform>, elsendita(j) tra %n nodoj</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Fonto</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Kreita</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Al</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>propra adreso</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etikedo</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Kredito</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>maturiĝos post %n bloko</numerusform><numerusform>maturiĝos post %n blokoj</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>ne akceptita</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debeto</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Krompago</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Neta sumo</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mesaĝo</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Komento</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Transakcia ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Vendisto</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Kreitaj moneroj devas esti maturaj je %1 blokoj antaŭ ol eblas elspezi ilin. Kiam vi generis tiun ĉi blokon, ĝi estis elsendita al la reto por aldono al la blokĉeno. Se tiu aldono malsukcesas, ĝia stato ŝanĝiĝos al &quot;neakceptita&quot; kaj ne eblos elspezi ĝin. Tio estas malofta, sed povas okazi se alia bloko estas kreita je preskaŭ la sama momento kiel la via.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Sencimigaj informoj</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transakcio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Enigoj</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Sumo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>vera</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>malvera</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, ankoraŭ ne elsendita sukcese</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Malferma dum ankoraŭ %n bloko</numerusform><numerusform>Malferma dum ankoraŭ %n blokoj</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>nekonata</translation>
     </message>
@@ -2877,12 +2276,10 @@ Adreso: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Transakciaj detaloj</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Tiu ĉi panelo montras detalan priskribon de la transakcio</translation>
     </message>
@@ -2890,127 +2287,102 @@ Adreso: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Sumo</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Malferma dum ankoraŭ %n bloko</numerusform><numerusform>Malferma dum ankoraŭ %n blokoj</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Malferma ĝis %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Konfirmita (%1 konfirmoj)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Tiun ĉi blokon ne ricevis ajna alia nodo, kaj ĝi verŝajne ne akceptiĝos!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Kreita sed ne akceptita</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Senkonekte</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Nekonfirmita</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Ricevita kun</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Ricevita de</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Sendita al</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pago al vi mem</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minita</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>neaplikebla</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transakcia stato. Ŝvebi super tiu ĉi kampo por montri la nombron de konfirmoj.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Dato kaj horo kiam la transakcio alvenis.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipo de transakcio.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Celadreso de la transakcio.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Sumo elprenita de aŭ aldonita al la saldo.</translation>
     </message>
@@ -3018,178 +2390,142 @@ Adreso: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Ĉiuj</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hodiaŭ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Ĉi-semajne</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Ĉi-monate</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Pasintmonate</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Ĉi-jare</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Intervalo...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Ricevita kun</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Sendita al</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Al vi mem</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Aliaj</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Tajpu adreson aŭ etikedon por serĉi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimuma sumo</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopii adreson</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopii etikedon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopii sumon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopii transakcian ID-on</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Redakti etikedon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Montri detalojn de transakcio</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Perkome disigita dosiero (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Konfirmita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etikedo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adreso</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Sumo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Intervalo:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>al</translation>
     </message>
@@ -3197,7 +2533,6 @@ Adreso: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3205,7 +2540,6 @@ Adreso: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Sendi Bitmonon</translation>
     </message>
@@ -3213,42 +2547,34 @@ Adreso: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Eksporti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Eksporti la datumojn el la aktuala langeto al dosiero</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Krei sekurkopion de monujo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Monuj-datumoj (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Malsukcesis sekurkopio</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Sukcesis krei sekurkopion</translation>
     </message>
@@ -3256,107 +2582,86 @@ Adreso: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Uzado:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Listigi komandojn</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Vidigi helpon pri iu komando</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Agordoj:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Specifi konfiguran dosieron (defaŭlte: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Specifi pid-dosieron (defaŭlte: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Specifi dosieron por datumoj</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Specifi grandon de datumbazo je megabajtoj (defaŭlte: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Aŭskulti al &lt;port&gt; por konektoj (defaŭlte: 8333 aŭ testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Subteni maksimume &lt;n&gt; konektojn al samtavolanoj (defaŭlte: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Konekti al nodo por ricevi adresojn de samtavolanoj, kaj malkonekti</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Specifi vian propran publikan adreson</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Sojlo por malkonekti misagantajn samtavolanojn (defaŭlte: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Nombro da sekundoj por rifuzi rekonekton de misagantaj samtavolanoj (defaŭlte: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Eraro okazis dum estigo de RPC-pordo %u por aŭskulti per IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Aŭskulti al &lt;port&gt; por JSON-RPC-konektoj (defaŭlte: 8332 aŭ testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Akcepti komandojn JSON-RPC kaj el komandlinio</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Ruli fone kiel demono kaj akcepti komandojn</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Uzi la test-reton</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Akcepti konektojn el ekstere (defaŭlte: 1 se ne estas -proxy nek -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,722 +2686,682 @@ ekzemple: alertnotify=echo %%s | mail -s &quot;Averto de Bitmono&quot; admin@foo
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Akcepteblaj ĉifroj (defaŭlte: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Eraro okazis dum estigo de RPC-pordo %u por aŭskulti per IPv6; retrodefaŭltas al IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Bindi al donita adreso kaj ĉiam aŭskulti per ĝi. Uzu la formaton [gastigo]:pordo por IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Ne eblas akiri eksklusivan rajton al dosierujo de datumoj %s. Verŝajne Bitmono jam rulas.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Ŝalti reĝimo de regresotestado, kiu uzas specialan ĉenon en kiu oni povas tuj solvi blokojn. La celo de tio estas regresotestilo kaj la kreado de aplikaĵoj.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Eraro: la transakcio estas rifuzita. Tio povas okazi se iom da Bitmono en via monujo jam elspeziĝis (ekz. se vi uzis kopion de wallet.dat kies Bitmono jam elspeziĝis, sed ne estis markita kiel elspezita ĉi tie).</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Eraro: tiu ĉi transakcio bezonas krompagon de almenaŭ %s pro la sumo, la komplekseco, aŭ la uzo de ĵus ricevita mono!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Plenumi komandon kiam monuja transakcio ŝanĝiĝas (%s en cmd anstataŭiĝas per TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Tiu ĉi estas antaŭeldona testa versio - uzu laŭ via propra risko - ne uzu por minado aŭ por aplikaĵoj por vendistoj</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Averto: -paytxfee estas agordita per tre alta valoro! Tio estas la krompago, kion vi pagos se vi sendas la transakcion.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Averto: Bonvolu kontroli, ke la horo kaj dato de via komputilo estas ĝuste agorditaj! Se via horloĝo malĝustas, Bitmono ne bone funkcios.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Averto: La reto ne tute konsentas! Kelkaj minantoj ŝajne spertas problemojn aktuale.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Averto: ŝajne ni ne tute konsentas kun niaj samtavolanoj! Eble vi devas ĝisdatigi vian klienton, aŭ eble aliaj nodoj faru same.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Averto: okazis eraro dum lego de wallet.dat! Ĉiuj ŝlosiloj sukcese legiĝis, sed la transakciaj datumoj aŭ la adresaro eble mankas aŭ malĝustas.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Averto: via wallet.dat estas difektita, sed la datumoj sukcese saviĝis! La originala wallet.dat estas nun konservita kiel wallet.{timestamp}.bak en %s; se via saldo aŭ transakcioj estas malĝustaj vi devus restaŭri per alia sekurkopio.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; povas esti:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Provo ripari privatajn ŝlosilojn el difektita wallet.dat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Bitmonakerna Demono</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Versio de la Bitmono-RPC-kliento</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Blok-kreaj agordaĵoj:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Konekti nur al specifita(j) nodo(j)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Konekti al la JSON-RPC per &lt;port&gt; (defaŭlte: 8332 aŭ testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Difektita blokdatumbazo trovita</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Malkovri la propran IP-adreson (defaŭlte: 1 dum aŭskultado sen -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Ĉu vi volas rekonstrui la blokdatumbazon nun?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Eraro dum pravalorizado de blokdatumbazo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Eraro dum pravalorizado de monuj-datumbaza ĉirkaŭaĵo %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Eraro dum ŝargado de blokdatumbazo</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Eraro dum malfermado de blokdatumbazo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Eraro: restas malmulte da diskospaco!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Eraro: monujo ŝlosita, ne eblas krei transakcion!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Eraro: sistema eraro: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ne sukcesis aŭskulti ajnan pordon. Uzu -listen=0 se tion vi volas.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Malsukcesis legi blokinformojn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Malsukcesis legi blokon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Malsukcesis sinkronigi blokindekson</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Malsukcesis skribi blokindekson</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Malsukcesis skribi blokinformojn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Malsukcesis skribi blokon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Malsukcesis skribi dosierinformojn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Malsukcesis skribi Bitmon-datumbazon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Malsukcesis skribi transakcian indekson</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Malsukcesis skribi malfarajn datumojn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Trovi samtavolanojn per DNS-elserĉo (defaŭlte: 1 krom kaze de -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generi Bitmonon (defaŭlte: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Kiom da blokoj kontrolendas dum lanĉo (defaŭlte: 288, 0=ĉiuj)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Kiom prizorgema estu la blokkontrolado (0-4, defaŭlte: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Geneza bloko aŭ netrovita aŭ neĝusta. Ĉu eble la datadir de la reto malĝustas?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Nevalida -onion-adreso: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Nesufiĉa nombro de dosierpriskribiloj disponeblas.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Rekontrui blokĉenan indekson el la aktualaj blk000??.dat dosieroj</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Sendi komandon al bitmona servilo</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Specifi la nombron de fadenoj por priatenti RPC-alvokojn (defaŭlte: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Specifi monujan dosieron (ene de dosierujo por datumoj)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Starti bitmonan servilon</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Uzado (malaktuala, uzu anstataŭe bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Kontrolado de blokoj...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Kontrolado de monujo...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Atendu por RPC-an servilo komenci</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Monujo %s troviĝas ekster la dosierujo por datumoj %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Monujaj opcioj:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Vi devas rekontrui la datumbazon kun -reindex por ŝanĝi -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importas blokojn el ekstera dosiero blk000??.dat</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Plenumi komandon kiam rilata alerto riceviĝas, aŭ kiam ni vidas tre longan forkon (%s en cms anstataŭiĝas per mesaĝo)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Agordi la nombron de fadenoj por skriptkontrolado (ĝis 16, 0 = aŭtomate, &lt;0 = lasi tiom da kernoj liberaj, defaŭlte: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informoj</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nevalida sumo por -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nevalida sumo por -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Varti kompletan transakcian indekton (defaŭlte: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maksimuma po riceva bufro por konektoj, &lt;n&gt;*1000 bajtoj (defaŭlte: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maksimuma po senda bufro por konektoj, &lt;n&gt;*1000 bajtoj (defaŭlte: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Akcepti nur blokĉenon, kiu kongruas kun integritaj kontrolpunktoj (defaŭlte: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Konekti nur la nodoj en la reto &lt;net&gt; (IPv4, IPv6 aŭ Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL-agordaĵoj: (vidu la vikio de Bitmono por instrukcioj pri agordado de SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Sendi spurajn/sencimigajn informojn al la konzolo anstataŭ al dosiero debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Agordi minimuman grandon de blokoj je bajtoj (defaŭlte: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Malpligrandigi la sencimigan protokol-dosieron kiam kliento lanĉiĝas (defaŭlte: 1 kiam mankas -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Subskriba transakcio fiaskis</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Specifi konektan tempolimon je milisekundoj (defaŭlte: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Sistema eraro: </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Transakcia sumo tro malgranda</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Transakcia sumo devas esti pozitiva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transakcio estas tro granda</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Uzi UPnP por mapi la aŭskultan pordon (defaŭlte: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Uzi UPnP por mapi la aŭskultan pordon (defaŭlte: 1 dum aŭskultado)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Salutnomo por konektoj JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Averto</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Averto: tiu ĉi versio estas eksdata. Vi bezonas ĝisdatigon!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>versio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat estas difektita, riparo malsukcesis</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Pasvorto por konektoj JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permesi konektojn JSON-RPC de specifa IP-adreso</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Sendi komandon al nodo ĉe &lt;ip&gt; (defaŭlte: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Plenumi komandon kiam plej bona bloko ŝanĝiĝas (%s en cmd anstataŭiĝas per bloka haketaĵo)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Ĝisdatigi monujon al plej lasta formato</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Agordi la grandon de la ŝlosilo-vico al &lt;n&gt; (defaŭlte: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Reskani la blokĉenon por mankantaj monujaj transakcioj</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Uzi OpenSSL (https) por konektoj JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Dosiero de servila atestilo (defaŭlte: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Dosiero de servila privata ŝlosilo (defaŭlte: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Tiu ĉi helpmesaĝo</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Ne eblis bindi al %s en tiu ĉi komputilo (bind resendis eraron %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permesi DNS-elserĉojn por -addnote, -seednote kaj -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Ŝarĝante adresojn...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Eraro dum ŝargado de wallet.dat: monujo difektita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Eraro dum ŝargo de wallet.dat: monujo bezonas pli novan version de Bitmono</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Monujo bezonas esti reskribita: relanĉu Bitmonon por finfari tion</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Eraro dum ŝargado de wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Nevalid adreso -proxy: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Nekonata reto specifita en -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Nekonata versio de -socks petita: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Ne eblas trovi la adreson -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Ne eblas trovi la adreson -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nevalida sumo por -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Nevalida sumo</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Nesufiĉa mono</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Ŝarĝante blok-indekson...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Aldoni nodon por alkonekti kaj provi daŭrigi la malferman konekton</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Ne eblas bindi al %s ĉe tiu ĉi komputilo. Bitmono verŝajne jam rulas.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Ŝargado de monujo...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Ne eblas malpromocii monujon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Ne eblas skribi defaŭltan adreson</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Reskanado...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Ŝargado finiĝis</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Por uzi la agordon %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Eraro</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_es.ts
+++ b/src/qt/locale/bitcoin_es.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Acerca de Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>Versión de &lt;b&gt;Bitcoin Core&lt;b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -30,18 +27,14 @@ el OpenSSL Toolkit (http://www.openssl.org/) y software criptográfico escrito p
 Eric Young (eay@cryptsoft.com) y el software UPnP escrito por Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Los desarrolladores de Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation>(%1-bit)</translation>
     </message>
@@ -49,122 +42,98 @@ Eric Young (eay@cryptsoft.com) y el software UPnP escrito por Thomas Bernard.</t
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Haga doble clic para editar la etiqueta o dirección </translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crear una nueva dirección</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copiar la dirección seleccionada al portapapeles del sistema</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiar</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>&amp;Cerrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copiar dirección</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Borrar de la lista la dirección seleccionada</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar a un archivo los datos de esta pestaña</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Eliminar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Escoja la dirección a la que enviar bitcoins</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Escoja la dirección de la que recibir bitcoins</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Escoger</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Direcciones de envío</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Direcciones de recepción</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Estas son sus direcciones Bitcoin para enviar pagos. Compruebe siempre la cantidad y la dirección receptora antes de enviar bitcoins.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Estas son sus direcciones de Bitcoin para recibir pagos. Se recomienda utilizar una nueva dirección de recepción para cada transacción.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar &amp;etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exportar la lista de direcciones </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Archivos de columnas separadas por coma (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Error exportando</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Ha habido un error al intentar guardar los datos del monedero en %1.</translation>
     </message>
@@ -172,17 +141,14 @@ Eric Young (eay@cryptsoft.com) y el software UPnP escrito por Thomas Bernard.</t
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
@@ -190,140 +156,106 @@ Eric Young (eay@cryptsoft.com) y el software UPnP escrito por Thomas Bernard.</t
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Diálogo de contraseña</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Introducir contraseña</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nueva contraseña</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repita la nueva contraseña</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introduzca la nueva contraseña del monedero.&lt;br/&gt;Por favor elija una con &lt;b&gt;10 o más caracteres aleatorios&lt;/b&gt;, u &lt;b&gt;ocho o más palabras&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Cifrar el monedero</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Esta operación requiere su contraseña para desbloquear el monedero.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desbloquear monedero</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Esta operación requiere su contraseña para descifrar el monedero.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Descifrar el monedero</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Cambiar contraseña</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Introduzca la contraseña anterior del monedero y la nueva. </translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar cifrado del monedero</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Atencion: ¡Si cifra su monedero y pierde la contraseña perderá &lt;b&gt;TODOS SUS BITCOINS&lt;/b&gt;!&quot;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>¿Seguro que desea cifrar su monedero?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>IMPORTANTE: Cualquier copia de seguridad que haya realizado previamente de su archivo de monedero debe reemplazarse con el nuevo archivo de monedero cifrado. Por razones de seguridad, las copias de seguridad previas del archivo de monedero no cifradas serán inservibles en cuanto comience a usar el nuevo monedero cifrado.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Aviso: ¡La tecla de bloqueo de mayúsculas está activada!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Monedero cifrado</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin se cerrará para finalizar el proceso de cifrado. Recuerde que el cifrado de su monedero no puede proteger totalmente sus bitcoins de robo por malware que infecte su sistema.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Ha fallado el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Ha fallado el cifrado del monedero debido a un error interno. El monedero no ha sido cifrado.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Las contraseñas no coinciden.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Ha fallado el desbloqueo del monedero</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña introducida para descifrar el monedero es incorrecta.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Ha fallado el descifrado del monedero</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Se ha cambiado correctamente la contraseña del monedero.</translation>
     </message>
@@ -331,363 +263,286 @@ Eric Young (eay@cryptsoft.com) y el software UPnP escrito por Thomas Bernard.</t
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>Firmar &amp;mensaje...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sincronizando con la red…</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista general</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>Nodo</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Mostrar vista general del monedero</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transacciones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Examinar el historial de transacciones</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Salir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Salir de la aplicación</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Mostrar información acerca de Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Acerca de &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Mostrar información acerca de Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opciones...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Cifrar monedero…</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>%Guardar copia del monedero...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Cambiar la contraseña…</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>Direcciones de &amp;envío...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>Direcciones de &amp;recepción...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Abrir &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importando bloques de disco...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Reindexando bloques en disco...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Enviar bitcoins a una dirección Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modificar las opciones de configuración de Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Copia de seguridad del monedero en otra ubicación</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cambiar la contraseña utilizada para el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Ventana de &amp;depuración</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Abrir la consola de depuración y diagnóstico</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verificar mensaje...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Monedero</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Recibir</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>Mo&amp;strar/ocultar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Mostrar u ocultar la ventana principal</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Cifrar las claves privadas de su monedero</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Firmar mensajes con sus direcciones Bitcoin para demostrar la propiedad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verificar mensajes comprobando que están firmados con direcciones Bitcoin concretas</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuración</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>A&amp;yuda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra de pestañas</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Solicitar pagos (genera codigo QR y URL&apos;s de Bitcoin)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;Acerca de Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Mostrar la lista de direcciones de envío y etiquetas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Muestra la lista de direcciones de recepción y etiquetas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Abrir un bitcoin: URI o petición de pago</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Opciones de consola de comandos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Muestra el mensaje de ayuda Bitcoin Core para obtener una lista con las posibles opciones de la consola de comandos de Bitcoin</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Cliente Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n conexión activa hacia la red Bitcoin</numerusform><numerusform>%n conexiones activas hacia la red Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Ninguna fuente de bloques disponible ...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Se han procesado %1 de %2 bloques (estimados) del historial de transacciones.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Procesados %1 bloques del historial de transacciones.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hora</numerusform><numerusform>%n horas</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n día</numerusform><numerusform>%n días</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n semana</numerusform><numerusform>%n semanas</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 y %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n año</numerusform><numerusform>%n años</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 por detrás</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>El último bloque recibido fue generado hace %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Las transacciones posteriores aún no están visibles.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Actualizado</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Actualizando...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transacción enviada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transacción entrante</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -700,17 +555,14 @@ Dirección: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;desbloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Ha ocurrido un error crítico. Bitcoin ya no puede continuar con seguridad y se cerrará.</translation>
     </message>
@@ -718,7 +570,6 @@ Dirección: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Alerta de red</translation>
     </message>
@@ -726,291 +577,230 @@ Dirección: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Selección de direcciones bajo Coin Control</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Cantidad:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Cuantía:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioridad:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Tasa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Envío pequeño:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Después de tasas:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Cambio:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(des)marcar todos</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Modo árbol</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Modo lista</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Confirmaciones</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioridad</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copiar cuantía</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Copiar identificador de transacción</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Bloquear lo no gastado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Desbloquear lo no gastado</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Copiar donación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copiar después de aplicar donación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copiar prioridad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copiar envío pequeño</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiar cambio</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>lo más alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>más alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>medio-alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>medio</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>bajo-medio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>bajo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>más bajo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>lo más bajo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 bloqueado)</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation>ninguna</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Basura</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>si</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>no</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Esta etiqueta se torna roja si el tamaño de la transación es mayor a 1000 bytes.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Esto implica que se requiere una tarifa de al menos %1 por kB</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Puede variar +/- 1 byte por entrada.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Las transacciones con alta prioridad son más propensas a ser incluidas dentro de un bloque.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Esta etiqueta se muestra en rojo si la prioridad es menor que &quot;media&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Esta etiqueta se torna roja si cualquier destinatario recibe una cantidad menor a %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Esto significa que se necesita una tarifa de al menos %1.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Cantidades por debajo de 0.546 veces la tasa serán mostradas como basura</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Esta etiqueta se vuelve roja si el cambio es menor que %1</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation>Enviar desde %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(cambio)</translation>
     </message>
@@ -1018,67 +808,54 @@ Dirección: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editar Dirección</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>La etiqueta asociada con esta entrada de la lista de direcciones</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>La dirección asociada con esta entrada de la lista de direcciones. Solo puede ser modificada para direcciones de envío.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Dirección</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nueva dirección de recepción</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nueva dirección de envío</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editar dirección de recepción</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editar dirección de envío</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>La dirección introducida &quot;%1&quot; ya está presente en la libreta de direcciones.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>La dirección introducida &quot;%1&quot; no es una dirección Bitcoin válida.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>No se pudo desbloquear el monedero.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Ha fallado la generación de la nueva clave.</translation>
     </message>
@@ -1086,27 +863,22 @@ Dirección: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation>Se creará un nuevo directorio de datos.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nombre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>El directorio ya existe. Añada %1 si pretende crear aquí un directorio nuevo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>La ruta ya existe y no es un directorio.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>No se puede crear un directorio de datos aquí.</translation>
     </message>
@@ -1114,57 +886,46 @@ Dirección: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - Opciones de consola de comandos</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versión</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>opciones de la consola de comandos</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Opciones GUI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Establecer el idioma, por ejemplo, &quot;es_ES&quot; (predeterminado: configuración regional del sistema)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Arrancar minimizado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation>Establecer los certificados raíz SSL para solicitudes de pago (predeterminado: -system-)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Mostrar pantalla de bienvenida en el inicio (predeterminado: 1)</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Elegir directorio de datos al iniciar (predeterminado: 0)</translation>
     </message>
@@ -1172,57 +933,46 @@ Dirección: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Bienvenido</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Bienvenido a Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Al ser la primera vez que se ejecuta el programa, puede elegir dónde almacenará sus datos Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core va a descargar y guardar una copia de la cadena de bloques de Bitcoin. Se almacenará al menos %1GB de datos en este directorio, que irá creciendo con el tiempo. El monedero se guardará también en este directorio.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Utilizar el directorio de datos predeterminado</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Utilice un directorio de datos personalizado:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Error: No puede crearse el directorio de datos especificado &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB de espacio libre disponible</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(de los %1GB necesarios)</translation>
     </message>
@@ -1230,27 +980,22 @@ Dirección: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Abrir URI...</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>El pago requiere una URI o archivo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Seleccione archivo de sulicitud de pago</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Abrir archivo de solicitud de pago</translation>
     </message>
@@ -1258,258 +1003,206 @@ Dirección: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Principal</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Tarifa de transacción opcional por kB que ayuda a asegurar que sus transacciones sean procesadas rápidamente. La mayoría de transacciones son de 1kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Comisión de &amp;transacciones</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Iniciar Bitcoin automáticamente al encender el sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Iniciar Bitcoin al iniciar el sistema</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>Tamaño de cache de la &amp;base de datos</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>Número de procesos de &amp;verificación de scripts</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Conectarse a la red Bitcoin a través de un proxy SOCKS.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>&amp;Conectarse a través de proxy SOCKS (proxy predeterminado):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>Dirección IP del proxy (p. ej. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation>Opciones activas de consola de comandos que tienen preferencia sobre las opciones antes mencionadas:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Restablecer todas las opciones del cliente a las predeterminadas.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Restablecer opciones</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Red</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation>(0 = automático, &lt;0 = dejar libres ese número de núcleos)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation>&amp;Monedero</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>Experto</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation>Habilitar funcionalidad de &amp;coin control</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>Si desactiva el gasto del cambio no confirmado, no se podrá usar el cambio de una transacción hasta que se alcance al menos una confirmación. Esto afecta también a cómo se calcula su saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation>&amp;Gastar cambio no confirmado</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Abrir automáticamente el puerto del cliente Bitcoin en el router. Esta opción solo funciona si el router admite UPnP y está activado.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapear el puerto usando &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Dirección &amp;IP del proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Puerto:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Puerto del servidor proxy (ej. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Versión SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Versión SOCKS del proxy (ej. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Ventana</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Minimizar la ventana a la bandeja de iconos del sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimizar a la bandeja en vez de a la barra de tareas</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimizar en lugar de salir de la aplicación al cerrar la ventana. Cuando esta opción está activa, la aplicación solo se puede cerrar seleccionando Salir desde el menú.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimizar al cerrar</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Interfaz</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>I&amp;dioma de la interfaz de usuario</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>El idioma de la interfaz de usuario puede establecerse aquí. Este ajuste se aplicará cuando se reinicie Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Mostrar las cantidades en la &amp;unidad:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Elegir la subdivisión predeterminada para mostrar cantidades en la interfaz y cuando se envían bitcoins.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Mostrar o no las direcciones Bitcoin en la lista de transacciones.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Mostrar las direcciones en la lista de transacciones</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Mostrar o no funcionalidad de Coin Control</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;Aceptar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>predeterminado</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>ninguna</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation>Confirme el restablecimiento de las opciones</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Se necesita reiniciar el cliente para activar los cambios.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>El cliente se cerrará. ¿Desea continuar?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Este cambio exige el reinicio del cliente.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>La dirección proxy indicada es inválida.</translation>
     </message>
@@ -1517,69 +1210,54 @@ Dirección: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Desde</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>La información mostrada puede estar desactualizada. Su monedero se sincroniza automáticamente con la red Bitcoin después de que se haya establecido una conexión, pero este proceso aún no se ha completado.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Monedero</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Disponible:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Su balance actual gastable</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>Pendiente:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Total de transacciones que deben ser confirmadas, y que no cuentan con el balance gastable necesario</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>No disponible:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Saldo recién minado que aún no está disponible.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Su balance actual total</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Movimientos recientes&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>desincronizado</translation>
     </message>
@@ -1587,93 +1265,70 @@ Dirección: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Gestión de URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>¡No se puede interpretar la URI! Esto puede deberse a una dirección Bitcoin inválida o a parámetros de URI mal formados.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>La cantidad del pago solicitado (%1) es demasiado pequeña (considerada polvo).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Error en petición de pago</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>No se pudo iniciar bitcoin: manejador de pago-al-clic</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Advertencia del gestor de red</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>El proxy configurado no soporta el protocolo SOCKS5, el cual es requerido para pagos vía proxy.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>La URL de obtención de la solicitud de pago es inválida: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Procesado del archivo de solicitud de pago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>¡No se ha podido leer o procesar el archivo de solicitud de pago! Esto puede deberse a un archivo inválido de solicitud de pago.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>No están soportadas las peticiones inseguras a scripts de pago personalizados</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Devolución de %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Error en la comunicación con %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>¡La solicitud de pago no puede leerse ni procesarse!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Respuesta errónea del servidor %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Pago aceptado</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Error en petición de red</translation>
     </message>
@@ -1681,29 +1336,22 @@ Dirección: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Error: El directorio de datos especificado &quot;%1&quot; no existe.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation>Error: No se ha podido leer el archivo de configuración: %1. Debe utilizarse solamente la sintaxis clave=valor.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Error: Combinación no válida de -regtest y -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduzca una dirección Bitcoin (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1711,22 +1359,18 @@ Dirección: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>Guardar Imagen...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>Copiar imagen</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Guardar código QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>Imágenes PNG (*.png)</translation>
     </message>
@@ -1734,194 +1378,146 @@ Dirección: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nombre del cliente</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>N/D</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versión del cliente</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Información</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Ventana de depuración</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Utilizando la versión OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Hora de inicio</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Red</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Número de conexiones</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Cadena de bloques</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Número actual de bloques</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Bloques totales estimados</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Hora del último bloque</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Consola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Tráfico de Red</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Vaciar</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>Entrante:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>Saliente:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Fecha de compilación</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Archivo de registro de depuración</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Abrir el archivo de registro de depuración en el directorio actual de datos. Esto puede llevar varios segundos para archivos de registro grandes.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Borrar consola</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bienvenido a la consola RPC de Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Use las flechas arriba y abajo para navegar por el historial y &lt;b&gt;Control+L&lt;/b&gt; para vaciar la pantalla.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Escriba &lt;b&gt;help&lt;/b&gt; para ver un resumen de los comandos disponibles.</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1929,105 +1525,82 @@ Dirección: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>Mensaje:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Reutilizar una de las direcciones previamente usadas para recibir. Reutilizar direcciones tiene problemas de seguridad y privacidad. No lo uses a menos que antes regeneres una solicitud de pago.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>R&amp;eutilizar una dirección existente para recibir (no recomendado)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>Un mensaje opcional para adjuntar a la solicitud de pago, que se muestra cuando se abre la solicitud. Nota: El mensaje no se enviará con el pago por la red Bitcoin.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Etiqueta opcional para asociar con la nueva dirección de recepción.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Utilice este formulario para solicitar pagos. Todos los campos son &lt;b&gt;opcionales&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Para solicitar una cantidad opcional. Deje este vacío o cero para no solicitar una cantidad específica.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Vaciar todos los campos del formulario.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Vaciar</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Historial de pagos solicitados</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Solicitar pago</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>Muestra la petición seleccionada (También doble clic)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation>Borrar de la lista las direcciónes actualmente seleccionadas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar cuantía</translation>
     </message>
@@ -2035,67 +1608,54 @@ Dirección: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Copiar &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Copiar &amp;Dirección</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>Guardar Imagen...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Solicitar pago a %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Información de pago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI resultante demasiado larga. Intente reducir el texto de la etiqueta / mensaje.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Error al codificar la URI en el código QR.</translation>
     </message>
@@ -2103,37 +1663,30 @@ Dirección: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(Ningun mensaje)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(sin cantidad)</translation>
     </message>
@@ -2141,247 +1694,194 @@ Dirección: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Enviar bitcoins</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Características de Coin Control</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Entradas...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>Seleccionado automáticamente</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Fondos insuficientes!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Cantidad:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Cuantía:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioridad:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Tasa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Envío pequeño:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Después de tasas:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Cambio:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Si se marca esta opción pero la dirección de cambio está vacía o es inválida, el cambio se enviará a una nueva dirección recién generada.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Dirección propia</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Enviar a múltiples destinatarios de una vez</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Añadir &amp;destinatario</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Vaciar todos los campos del formulario</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Vaciar &amp;todo</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Confirmar el envío</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirmar el envío de bitcoins</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 a %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar cuantía</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Copiar donación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copiar después de aplicar donación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copiar prioridad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copiar envío pequeño</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiar Cambio</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Cuantía Total %1 (=%2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>o</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>La dirección de recepción no es válida, compruébela de nuevo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>La cantidad por pagar tiene que ser mayor de 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>La cantidad sobrepasa su saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>El total sobrepasa su saldo cuando se incluye la tasa de envío de %1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Se ha encontrado una dirección duplicada. Solo se puede enviar a cada dirección una vez por operación de envío.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>¡Ha fallado la creación de la transacción!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>¡La transacción fue rechazada! Esto puede haber ocurrido si alguno de los bitcoins de su monedero ya estaba gastado o si ha usado una copia de wallet.dat y los bitcoins estaban gastados en la copia pero no se habían marcado como gastados aqui.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Alerta: Dirección de Bitcoin inválida</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Alerta: Dirección de Bitcoin inválida</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>¿Está seguro que desea enviar?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>añadido como comisión de transacción</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Petición de pago expirada</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Dirección de pago no válida %1</translation>
     </message>
@@ -2389,98 +1889,74 @@ Dirección: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Ca&amp;ntidad:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Pagar a:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La dirección a la que enviar el pago (p. ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Etiquete esta dirección para añadirla a la libreta</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Escoger direcciones previamente usadas</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Esto es un pago ordinario.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar dirección desde portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Eliminar esta transacción</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Mensaje:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Esto es una petición de pago verificado.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Introduce una etiqueta para esta dirección para añadirla a la lista de direcciones utilizadas</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>Un mensaje que se adjuntó a la bitcoin: URL que será almacenada con la transacción para su referencia. Nota: Este mensaje no se envía a través de la red Bitcoin.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Esto es una petición de pago no verificado.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Paga a:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memo:</translation>
     </message>
@@ -2488,13 +1964,11 @@ Dirección: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Core se está cerrando...
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>No apague el equipo hasta que desaparezca esta ventana.</translation>
     </message>
@@ -2502,186 +1976,142 @@ Dirección: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Firmas - Firmar / verificar un mensaje</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Firmar mensaje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Puede firmar mensajes con sus direcciones para demostrar que las posee. Tenga cuidado de no firmar cualquier cosa vaga, ya que los ataques de phishing pueden tratar de engañarle para suplantar su identidad. Firme solo declaraciones totalmente detalladas con las que usted esté de acuerdo.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La dirección con la que firmar el mensaje (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Escoger dirección previamente usada</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar dirección desde portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Introduzca el mensaje que desea firmar aquí</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Firma</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copiar la firma actual al portapapeles del sistema</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Firmar el mensaje para demostrar que se posee esta dirección Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Firmar &amp;mensaje</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Vaciar todos los campos de la firma de mensaje</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Vaciar &amp;todo</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verificar mensaje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Introduzca la dirección para la firma, el mensaje (asegurándose de copiar tal cual los saltos de línea, espacios, tabulaciones, etc.) y la firma a continuación para verificar el mensaje. Tenga cuidado de no asumir más información de lo que dice el propio mensaje firmado para evitar fraudes basados en ataques de tipo man-in-the-middle.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La dirección con la que se firmó el mensaje (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verificar el mensaje para comprobar que fue firmado con la dirección Bitcoin indicada</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verificar &amp;mensaje</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Vaciar todos los campos de la verificación de mensaje</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduzca una dirección Bitcoin (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Haga clic en &quot;Firmar mensaje&quot; para generar la firma</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>La dirección introducida es inválida.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Verifique la dirección e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>La dirección introducida no corresponde a una clave.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Se ha cancelado el desbloqueo del monedero. </translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>No se dispone de la clave privada para la dirección introducida.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Ha fallado la firma del mensaje.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Mensaje firmado.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>No se puede decodificar la firma.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Compruebe la firma e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>La firma no coincide con el resumen del mensaje.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>La verificación del mensaje ha fallado.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Mensaje verificado.</translation>
     </message>
@@ -2689,17 +2119,14 @@ Dirección: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Los desarrolladores de Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2707,7 +2134,6 @@ Dirección: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2715,184 +2141,138 @@ Dirección: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Abierto hasta %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>en conflicto</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/fuera de línea</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/no confirmado</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmaciones</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, transmitir a través de %n nodo</numerusform><numerusform>, transmitir a través de %n nodos</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generado</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>dirección propia</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Crédito</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>disponible en %n bloque más</numerusform><numerusform>disponible en %n bloques más</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>no aceptada</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Débito</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Comisión de transacción</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Cantidad neta</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Identificador de transacción</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Los bitcoins generados deben madurar %1 bloques antes de que puedan gastarse. Cuando generó este bloque, se transmitió a la red para que se añadiera a la cadena de bloques. Si no consigue entrar en la cadena, su estado cambiará a &quot;no aceptado&quot; y ya no se podrá gastar. Esto puede ocurrir ocasionalmente si otro nodo genera un bloque a pocos segundos del suyo.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Información de depuración</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transacción</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>entradas</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>verdadero</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, todavía no se ha sido difundido satisfactoriamente</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abrir para %n bloque más</numerusform><numerusform>Abrir para %n bloques más</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
@@ -2900,12 +2280,10 @@ Dirección: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detalles de transacción</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Esta ventana muestra información detallada sobre la transacción</translation>
     </message>
@@ -2913,127 +2291,102 @@ Dirección: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>No vencidos (%1 confirmaciones. Estarán disponibles al cabo de %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abrir para %n bloque más</numerusform><numerusform>Abrir para %n bloques más</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Abierto hasta %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmaciones)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Este bloque no ha sido recibido por otros nodos y probablemente no sea aceptado!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generado pero no aceptado</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Sin conexión</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Sin confirmar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Confirmando (%1 de %2 confirmaciones recomendadas)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>En conflicto</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Recibido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Recibidos de</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Enviado a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pago propio</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(nd)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estado de transacción. Pasa el ratón sobre este campo para ver el número de confirmaciones.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Fecha y hora en que se recibió la transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipo de transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Dirección de destino de la transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Cantidad retirada o añadida al saldo.</translation>
     </message>
@@ -3041,178 +2394,142 @@ Dirección: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Todo</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hoy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Esta semana</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Este mes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Mes pasado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Este año</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Rango...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Recibido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Enviado a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>A usted mismo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Otra</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Introduzca una dirección o etiqueta que buscar</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Cantidad mínima</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar cuantía</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copiar identificador de transacción</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Editar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Mostrar detalles de la transacción</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Exportar historial de transacciones</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Error exportando</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Ha habido un error al intentar guardar la transacción con %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Exportación finalizada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>La transacción ha sido guardada en %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Archivos de columnas separadas por coma (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Rango:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>para</translation>
     </message>
@@ -3220,7 +2537,6 @@ Dirección: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>No se ha cargado ningún monedero</translation>
     </message>
@@ -3228,7 +2544,6 @@ Dirección: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Enviar bitcoins</translation>
     </message>
@@ -3236,42 +2551,34 @@ Dirección: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar a un archivo los datos de esta pestaña</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation>Copia de seguridad del monedero</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Datos de monedero (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Ha fallado el respaldo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Ha habido un error al intentar guardar los datos del monedero en %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Los datos del monedero se han guardado con éxito en %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Se ha completado la copia de seguridad del monedero</translation>
     </message>
@@ -3279,115 +2586,94 @@ Dirección: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>Muestra comandos
 </translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Recibir ayuda para un comando
 </translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>Opciones:
 </translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Especificar archivo de configuración (predeterminado: bitcoin.conf)
 </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Especificar archivo pid (predeterminado: bitcoin.pid)
 </translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Especificar directorio para los datos</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Escuchar conexiones en &lt;puerto&gt; (predeterminado: 8333 o testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Mantener como máximo &lt;n&gt; conexiones a pares (predeterminado: 125)</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Conectar a un nodo para obtener direcciones de pares y desconectar</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation>Especifique su propia dirección pública</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Umbral para la desconexión de pares con mal comportamiento (predeterminado: 100)</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Número de segundos en que se evita la reconexión de pares con mal comportamiento (predeterminado: 86400)</translation>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Ha ocurrido un error al configurar el puerto RPC %u para escucha en IPv4: %s</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Escuchar conexiones JSON-RPC en &lt;puerto&gt; (predeterminado: 8332 o testnet:18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Aceptar comandos consola y JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation>Versión del cliente RPC de Bitcoin Core RPC</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Ejecutar en segundo plano como daemon y aceptar comandos
 </translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>Usar la red de pruebas
 </translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Aceptar conexiones desde el exterior (predeterminado: 1 si no -proxy o -connect)</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3412,861 +2698,691 @@ Por ejemplo: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Cifrados aceptables (predeterminados: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ha ocurrido un error al configurar el puerto RPC %u para escuchar mediante IPv6. Recurriendo a IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Vincular a la dirección dada y escuchar siempre en ella. Utilice la notación [host]:port para IPv6</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation>Limitar continuamente las transacciones gratuitas a &lt;n&gt;*1000 bytes por minuto (predeterminado:15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Iniciar modo de prueba de regresión, el cuál utiliza una cadena especial en la cual los bloques pueden ser resueltos instantáneamente. Se utiliza para herramientas de prueba de regresión y desarrollo de aplicaciones.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>Ingresar en el modo de prueba de regresión, que utiliza una cadena especial en la que los bloques se pueden resolver instantáneamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation>Error: Ha fallado la escucha de conexiones entrantes (listen ha devuelto el error %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>¡Error: se ha rechazado la transacción! Esto puede ocurrir si ya se han gastado algunos de los bitcoins del monedero, como ocurriría si hubiera hecho una copia de wallet.dat y se hubieran gastado bitcoins a partir de la copia, con lo que no se habrían marcado aquí como gastados.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>¡Error: Esta transacción requiere una comisión de al menos %s debido a su cantidad, complejidad, o al uso de fondos recién recibidos!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Ejecutar comando cuando una transacción del monedero cambia (%s en cmd se remplazará por TxID)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation>Las comisiones inferiores se consideran comisión cero (a efectos de creación de transacciones) (predeterminado:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation>Volcar la actividad de la base de datos de memoria al registro en disco cada &lt;n&gt; megabytes (predeterminado: 100)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation>Nivel de rigor en la verificación de bloques de -checkblocks (0-4; predeterminado: 3)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation>En este modo -genproclimit controla cuántos bloques se generan de inmediato.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation>Establecer el número de hilos (threads) de verificación de scripts (entre %u y %d, 0 = automático, &lt;0 = dejar libres ese número de núcleos; predeterminado: %d)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation>Establecer el límite de procesadores cuando está activada la generación (-1 = sin límite; predeterminado: -1)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Esta es una versión de pre-prueba - utilícela bajo su propio riesgo. No la utilice para usos comerciales o de minería.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation>No se ha podido acceder a %s en esta máquina. Probablemente ya se está ejecutando Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Usar proxy SOCKS5 distinto para comunicarse vía Tor de forma anónima (Predeterminado: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Aviso: ¡-paytxfee tiene un valor muy alto! Esta es la comisión que pagará si envía una transacción.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Precaución: Por favor, ¡revise que la fecha y hora de su ordenador son correctas! Si su reloj está mal, Bitcoin no funcionará correctamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Atención: ¡Parece que la red no está totalmente de acuerdo! Algunos mineros están presentando inconvenientes.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Atención: ¡Parece que no estamos completamente de acuerdo con nuestros pares! Podría necesitar una actualización, u otros nodos podrían necesitarla.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Aviso: ¡Error al leer wallet.dat! Todas las claves se han leído correctamente, pero podrían faltar o ser incorrectos los datos de transacciones o las entradas de la libreta de direcciones.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Aviso: ¡Recuperados datos de wallet.dat corrupto! El wallet.dat original se ha guardado como wallet.{timestamp}.bak en %s; si hubiera errores en su saldo o transacciones, deberá restaurar una copia de seguridad.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation>(predeterminado: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation>(predeterminado: wallet.dat)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; puede ser:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Intento de recuperar claves privadas de un wallet.dat corrupto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Bitcoin Core Daemon (proceso independiente)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation>Opciones de creación de bloques:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Vaciar lista de transacciones del monedero (herramienta de diagnóstico; implica -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Conectar sólo a los nodos (o nodo) especificados</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Conectar a través de un proxy SOCKS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Conectar a JSON-RPC en &lt;puerto&gt; (predeterminado: 8332 o testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation>Opciones de conexión:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation>Corrupción de base de datos de bloques detectada.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation>Opciones de depuración/pruebas:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation>Inhabilitar el modo seguro, no considerar un suceso real de modo seguro (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Descubrir dirección IP propia (predeterminado: 1 al escuchar sin -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>No cargar el monedero y desactivar las llamadas RPC del monedero</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>¿Quieres reconstruir la base de datos de bloques ahora?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Error al inicializar la base de datos de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Error al inicializar el entorno de la base de datos del monedero  %s</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Error cargando base de datos de bloques</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Error al abrir base de datos de bloques.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Error: ¡Espacio en disco bajo!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Error: ¡El monedero está bloqueado; no se puede crear la transacción!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Error: error de sistema: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ha fallado la escucha en todos los puertos. Use -listen=0 si desea esto.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>No se ha podido leer la información de bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>No se ha podido leer el bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>No se ha podido sincronizar el índice de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>No se ha podido escribir en el índice de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>No se ha podido escribir la información de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>No se ha podido escribir el bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>No se ha podido escribir la información de archivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>No se ha podido escribir en la base de datos de bitcoins</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>No se ha podido escribir en el índice de transacciones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>No se han podido escribir los datos de deshacer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Donación por KB añadida a las transacciones que envíe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation>Las comisiones inferiores se consideran comisión cero (a efectos de propagación) (predeterminado:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Encontrar pares mediante búsqueda de DNS (predeterminado: 1 salvo con -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation>Forzar modo seguro (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation>Generar bitcoins (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Cuántos bloques comprobar al iniciar (predeterminado: 288, 0 = todos)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>Si no se proporciona &lt;category&gt;, mostrar toda la depuración</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Incorrecto o bloque de génesis no encontrado. Datadir equivocada para la red?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Dirección -onion inválida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation>No hay suficientes descriptores de archivo disponibles. </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>Anteponer marca temporal a la información de depuración (predeterminado: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation>Opciones para cliente RPC:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Reconstruir el índice de la cadena de bloques a partir de los archivos blk000??.dat actuales</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Seleccionar versión de SOCKS para -proxy (4 o 5, predeterminado: 5)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation>Asignar tamaño de cache en megabytes (entre %d y %d; predeterminado: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Establecer tamaño máximo de bloque en bytes (predeterminado: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Establecer el número de procesos para atender las llamadas RPC (predeterminado: 4)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Especificar archivo de monedero (dentro del directorio de datos)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Gastar cambio no confirmado al enviar transacciones (predeterminado: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>Esto afecta a las herramientas de prueba de regresión y al desarrollo informático de la aplicación.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Uso (desaconsejado, usar bitcoin-cli)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verificando bloques...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Verificando monedero...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Espere a que se inicie el servidor RPC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>El monedero %s se encuentra fuera del directorio de datos %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Opciones de monedero:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Aviso: Argumento -debugnet anticuado, utilice -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Usted necesita reconstruir la base de datos utilizando -reindex para cambiar -txindex</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importa los bloques desde un archivo blk000??.dat externo</translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation>No se ha podido bloquear el directorio de datos %s. Probablemente ya se está ejecutando Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Ejecutar un comando cuando se reciba una alerta importante o cuando veamos un fork demasiado largo (%s en cmd se reemplazará por el mensaje)</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Mostrar información de depuración (predeterminado: 0, proporcionar &lt;category&gt; es opcional)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Establecer tamaño máximo de las transacciones de alta prioridad/baja comisión en bytes (predeterminado: %d)</translation>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidad inválida para -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidad inválida para -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation>Limitar tamaño de la cache de firmas a &lt;n&gt; entradas (predeterminado: 50000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation>Registrar en el log la prioridad de transacciones y la comisión por kB al minar bloques (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Mantener índice de transacciones completo (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Búfer de recepción máximo por conexión, &lt;n&gt;*1000 bytes (predeterminado: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Búfer de recepción máximo por conexión, , &lt;n&gt;*1000 bytes (predeterminado: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Aceptar solamente cadena de bloques que concuerde con los puntos de control internos (predeterminado: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Conectarse solo a nodos de la red &lt;net&gt; (IPv4, IPv6 o Tor)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation>Imprimir bloque al iniciar, si se encuentra en el índice de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation>Imprimir árbol de bloques al iniciar (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Opciones SSL de RPC: (véase la wiki de Bitcoin para las instrucciones de instalación de SSL)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation>Opciones de servidor RPC:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation>Ignorar 1 de cada &lt;n&gt; mensajes de red al azar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation>Introducir datos fuzz en 1 de cada &lt;n&gt; mensajes de red al azar</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation>Ejecutar un hilo (thread) para limpiar de la memoria el monedero periódicamente (predeterminado: 1)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Opciones SSL: (ver la Bitcoin Wiki para instrucciones de configuración SSL)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation>Enviar orden a Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Enviar información de trazas/depuración a la consola en lugar de al archivo debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Establecer tamaño mínimo de bloque en bytes (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation>Establece la opción DB_PRIVATE en el entorno de base de datos del monedero (predeterminado: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation>Muestra todas las opciones de depuración (uso: --help -help-debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation>Mostrar información de benchmarking (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Reducir el archivo debug.log al iniciar el cliente (predeterminado: 1 sin -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Transacción falló</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Especificar el tiempo máximo de conexión en milisegundos (predeterminado: 5000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation>Iniciar Bitcoin Core Daemon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>Error de sistema: </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Cantidad de la transacción demasiado pequeña</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Las cantidades en las transacciones deben ser positivas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transacción demasiado grande</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Usar UPnP para asignar el puerto de escucha (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Usar UPnP para asignar el puerto de escucha (predeterminado: 1 al escuchar)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nombre de usuario para las conexiones JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Aviso: Esta versión es obsoleta, actualización necesaria!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Eliminando todas las transacciones del monedero...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation>al iniciar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>versión</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corrupto. Ha fallado la recuperación.</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Contraseña para las conexiones JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permitir conexiones JSON-RPC desde la dirección IP especificada
 </translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Enviar comando al nodo situado en &lt;ip&gt; (predeterminado: 127.0.0.1)
 </translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Ejecutar un comando cuando cambia el mejor bloque (%s en cmd se sustituye por el hash de bloque)</translation>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Actualizar el monedero al último formato</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Ajustar el número de claves en reserva &lt;n&gt; (predeterminado: 100)
 </translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Volver a examinar la cadena de bloques en busca de transacciones del monedero perdidas</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Usar OpenSSL (https) para las conexiones JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Certificado del servidor (predeterminado: server.cert)
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Clave privada del servidor (predeterminado: server.pem)
 </translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>Este mensaje de ayuda
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>No es posible conectar con %s en este sistema (bind ha dado el error %d, %s)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permitir búsquedas DNS para -addnode, -seednode y -connect</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>Cargando direcciones...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Error al cargar wallet.dat: el monedero está dañado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Error al cargar wallet.dat: El monedero requiere una versión más reciente de Bitcoin</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>El monedero ha necesitado ser reescrito. Reinicie Bitcoin para completar el proceso</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>Error al cargar wallet.dat</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Dirección -proxy inválida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>La red especificada en -onlynet &apos;%s&apos; es desconocida</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Solicitada versión de proxy -socks desconocida: %i</translation>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>No se puede resolver la dirección de -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>No se puede resolver la dirección de -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidad inválida para -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Cuantía no válida</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Fondos insuficientes</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>Cargando el índice de bloques...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Añadir un nodo al que conectarse y tratar de mantener la conexión abierta</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>Cargando monedero...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation>No se puede rebajar el monedero</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>No se puede escribir la dirección predeterminada</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>Reexplorando...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>Generado pero no aceptado</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>Para utilizar la opción %s</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_es_CL.ts
+++ b/src/qt/locale/bitcoin_es_CL.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -30,18 +27,14 @@ el OpenSSL Toolkit (http://www.openssl.org/), software criptográfico escrito po
 Eric Young (eay@cryptsoft.com) y UPnP software escrito por Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -49,122 +42,98 @@ Eric Young (eay@cryptsoft.com) y UPnP software escrito por Thomas Bernard.</tran
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Haz doble clic para editar una dirección o etiqueta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crea una nueva dirección</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copia la dirección seleccionada al portapapeles</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copia dirección</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar los datos de la pestaña actual a un archivo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copia &amp;etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Archivos separados por coma (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -172,17 +141,14 @@ Eric Young (eay@cryptsoft.com) y UPnP software escrito por Thomas Bernard.</tran
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
@@ -190,140 +156,106 @@ Eric Young (eay@cryptsoft.com) y UPnP software escrito por Thomas Bernard.</tran
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Introduce contraseña actual      </translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nueva contraseña</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repite nueva contraseña</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introduce la nueva contraseña para la billetera.&lt;br/&gt;Por favor utiliza un contraseña de&lt;b&gt;10 o más caracteres aleatorios&lt;/b&gt;, u &lt;b&gt;ocho o más palabras&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Codificar billetera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Esta operación necesita la contraseña para desbloquear la billetera.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desbloquea billetera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Esta operación necesita la contraseña para decodificar la billetara.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Decodificar cartera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Cambia contraseña</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Introduce la contraseña anterior y la nueva de cartera</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirma la codificación de cartera</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Atención: ¡Si codificas tu billetera y pierdes la contraseña perderás &lt;b&gt;TODOS TUS BITCOINS&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>¿Seguro que quieres seguir codificando la billetera?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>IMPORTANTE: Cualquier versión anterior que hayas realizado de tu archivo de billetera será reemplazada por el nuevo archivo de billetera encriptado. Por razones de seguridad, los respaldos anteriores de los archivos de billetera se volverán inútiles en tanto comiences a usar la nueva billetera encriptada.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Precaucion: Mayúsculas Activadas</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Billetera codificada</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin se cerrará para finalizar el proceso de encriptación. Recuerde que encriptar su billetera no protegera completatamente sus bitcoins de ser robados por malware que infecte su computador</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Falló la codificación de la billetera</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>La codificación de la billetera falló debido a un error interno. Tu billetera no ha sido codificada.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Las contraseñas no coinciden.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Ha fallado el desbloqueo de la billetera</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña introducida para decodificar la billetera es incorrecta.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Ha fallado la decodificación de la billetera</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>La contraseña de billetera ha sido cambiada con éxito.</translation>
     </message>
@@ -331,363 +263,286 @@ Eric Young (eay@cryptsoft.com) y UPnP software escrito por Thomas Bernard.</tran
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>Firmar &amp;Mensaje...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sincronizando con la red...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista general</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Muestra una vista general de la billetera</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transacciones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Explora el historial de transacciónes</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Salir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Salir del programa</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Muestra información acerca de Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Acerca de</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Mostrar Información sobre QT</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opciones</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Codificar la billetera...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Respaldar billetera...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Cambiar la contraseña...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Cargando el index de bloques...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Enviar monedas a una dirección bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modifica las opciones de configuración de bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Respaldar billetera en otra ubicación</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cambiar la contraseña utilizada para la codificación de la billetera</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Ventana &amp;Debug</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Abre consola de depuración y diagnóstico</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Cartera</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Mostrar/Ocultar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Firmar un mensaje para provar que usted es dueño de esta dirección</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuración</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra de pestañas</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[red-de-pruebas]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Cliente Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n conexión activa hacia la red Bitcoin</numerusform><numerusform>%n conexiones activas hacia la red Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hora</numerusform><numerusform>%n horas</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n día</numerusform><numerusform>%n días</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n semana</numerusform><numerusform>%n semanas</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Atención</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Actualizado</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Recuperando...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transacción enviada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transacción entrante</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -699,17 +554,14 @@ Tipo: %3
 Dirección: %4</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>La billetera esta &lt;b&gt;codificada&lt;/b&gt; y actualmente &lt;b&gt;desbloqueda&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>La billetera esta &lt;b&gt;codificada&lt;/b&gt; y actualmente &lt;b&gt;bloqueda&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -717,7 +569,6 @@ Dirección: %4</translation>
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Alerta de Red</translation>
     </message>
@@ -725,291 +576,230 @@ Dirección: %4</translation>
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Cantidad:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Copia dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copia etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copiar Cantidad</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1017,67 +807,54 @@ Dirección: %4</translation>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editar dirección</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Dirección</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nueva dirección para recibir</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nueva dirección para enviar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editar dirección de recepción</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editar dirección de envio</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>La dirección introducida &quot;%1&quot; ya esta guardada en la libreta de direcciones.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>La dirección introducida &quot;%1&quot; no es una dirección Bitcoin valida.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>No se pudo desbloquear la billetera.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>La generación de nueva clave falló.</translation>
     </message>
@@ -1085,27 +862,22 @@ Dirección: %4</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1113,58 +885,47 @@ Dirección: %4</translation>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versión</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI opciones</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Arranca minimizado
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1172,57 +933,46 @@ Dirección: %4</translation>
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1230,27 +980,22 @@ Dirección: %4</translation>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1258,258 +1003,206 @@ Dirección: %4</translation>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Principal</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Comisión de &amp;transacciónes</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Inicia Bitcoin automáticamente despues de encender el computador</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Inicia Bitcoin al iniciar el sistema</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Reestablece todas las opciones.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Red</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Abre automáticamente el puerto del cliente Bitcoin en el router. Esto funciona solo cuando tu router es compatible con UPnP y está habilitado.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Direcciona el puerto usando &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP Proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Puerto:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Puerto del servidor proxy (ej. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Muestra solo un ícono en la bandeja después de minimizar la ventana</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimiza a la bandeja en vez de la barra de tareas</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimiza la ventana en lugar de salir del programa cuando la ventana se cierra. Cuando esta opción esta activa el programa solo se puede cerrar seleccionando Salir desde el menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimiza a la bandeja al cerrar</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Mostrado</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unidad en la que mostrar cantitades:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Elige la subdivisión por defecto para mostrar cantidaded en la interfaz cuando se envien monedas</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Muestra direcciones en el listado de transaccioines</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancela</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>predeterminado</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation>Confirmar reestablecimiento de las opciones</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1517,69 +1210,54 @@ Dirección: %4</translation>
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulario</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Cartera</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transacciones recientes&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>desincronizado</translation>
     </message>
@@ -1587,93 +1265,70 @@ Dirección: %4</translation>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Pago completado</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1681,29 +1336,22 @@ Dirección: %4</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduce una dirección Bitcoin (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1711,22 +1359,18 @@ Dirección: %4</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>Guardar imagen...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>Copiar Imagen</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1734,194 +1378,146 @@ Dirección: %4</translation>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nombre del cliente</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versión del Cliente</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Información</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Tiempo de inicio</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Red</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Número de conexiones</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Bloquea cadena</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Consola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Limpiar Consola</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1929,105 +1525,82 @@ Dirección: %4</translation>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;mensaje</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Copia etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar Cantidad</translation>
     </message>
@@ -2035,67 +1608,54 @@ Dirección: %4</translation>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Código QR </translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>&amp;Copia dirección</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>Guardar imagen...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2103,37 +1663,30 @@ Dirección: %4</translation>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2141,247 +1694,194 @@ Dirección: %4</translation>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Cantidad:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Enviar a múltiples destinatarios</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;Agrega destinatario</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Borra todos</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Balance:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Confirma el envio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Envía</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirmar el envio de monedas</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar Cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>La dirección de destinatarion no es valida, comprueba otra vez.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>La cantidad por pagar tiene que ser mayor 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>La cantidad sobrepasa tu saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>El total sobrepasa tu saldo cuando se incluyen %1 como tasa de envio.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Tienes una dirección duplicada, solo puedes enviar a direcciónes individuales de una sola vez.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2389,98 +1889,74 @@ Dirección: %4</translation>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Cantidad:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Pagar a:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La dirección donde enviar el pago (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Introduce una etiqueta a esta dirección para añadirla a tu guia</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Pega dirección desde portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Mensaje:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2488,12 +1964,10 @@ Dirección: %4</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2501,186 +1975,142 @@ Dirección: %4</translation>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Firmar Mensaje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduce una dirección Bitcoin (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Pega dirección desde portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Escriba el mensaje que desea firmar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Firma</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Firmar un mensjage para probar que usted es dueño de esta dirección</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Firmar Mensaje</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Borra todos</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Firmar Mensaje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduce una dirección Bitcoin (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>&amp;Firmar Mensaje</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduce una dirección Bitcoin (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Click en &quot;Firmar Mensage&quot; para conseguir firma</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>La dirección introducida &quot;%1&quot; no es una dirección Bitcoin valida.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Por favor, revise la dirección Bitcoin e inténtelo denuevo</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Ha fallado el desbloqueo de la billetera</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Firma fallida</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Mensaje firmado</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Mensaje comprobado</translation>
     </message>
@@ -2688,17 +2118,14 @@ Dirección: %4</translation>
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[red-de-pruebas]</translation>
     </message>
@@ -2706,7 +2133,6 @@ Dirección: %4</translation>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2714,184 +2140,138 @@ Dirección: %4</translation>
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Abierto hasta %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/fuera de linea</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/no confirmado</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmaciónes</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generado</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>propia dirección</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Credito</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>no aceptada</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debito</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Comisión transacción</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Cantidad total</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID de Transacción</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transacción</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, no ha sido emitido satisfactoriamente todavía</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abierto para %n bloque más</numerusform><numerusform>Abierto para %n bloques más</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
@@ -2899,12 +2279,10 @@ Dirección: %4</translation>
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detalles de transacción</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Esta ventana muestra información detallada sobre la transacción</translation>
     </message>
@@ -2912,127 +2290,102 @@ Dirección: %4</translation>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abierto para &amp;n bloque más</numerusform><numerusform>Abierto para &amp;n bloques más</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Abierto hasta %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmaciones)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Este bloque no ha sido recibido por otros nodos y probablemente no sea aceptado !</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generado pero no acceptado</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Recibido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Recibido de</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Enviado a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pagar a usted mismo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estado de transacción. Pasa el raton sobre este campo para ver el numero de confirmaciónes.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Fecha y hora cuando se recibió la transaccion</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipo de transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Dirección de destino para la transacción</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Cantidad restada o añadida al balance</translation>
     </message>
@@ -3040,178 +2393,142 @@ Dirección: %4</translation>
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Todo</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hoy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Esta semana</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Esta mes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Mes pasado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Este año</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Rango...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Recibido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Enviado a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>A ti mismo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Otra</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Introduce una dirección o etiqueta para  buscar</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Cantidad minima</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copia dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copia etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar Cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Edita etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Mostrar detalles de la transacción</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Archivos separados por coma (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Rango:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>para</translation>
     </message>
@@ -3219,7 +2536,6 @@ Dirección: %4</translation>
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3227,7 +2543,6 @@ Dirección: %4</translation>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>
     </message>
@@ -3235,42 +2550,34 @@ Dirección: %4</translation>
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar los datos de la pestaña actual a un archivo</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3278,116 +2585,95 @@ Dirección: %4</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>Muestra comandos
 </translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Recibir ayuda para un comando
 </translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>Opciones:
 </translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Especifica archivo de configuración (predeterminado: bitcoin.conf)
 </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Especifica archivo pid (predeterminado: bitcoin.pid)
 </translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Especifica directorio para los datos
 </translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Escuchar por conecciones en &lt;puerto&gt; (Por defecto: 8333 o red de prueba: 18333)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Mantener al menos &lt;n&gt; conecciones por cliente (por defecto: 125) </translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Umbral de desconección de clientes con mal comportamiento (por defecto: 100)</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Escucha conexiones JSON-RPC en el puerto &lt;port&gt; (predeterminado: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Aceptar comandos consola y JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Correr como demonio y acepta comandos
 </translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>Usa la red de pruebas
 </translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3402,864 +2688,694 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Precaución: -paytxfee es muy alta. Esta es la comisión que pagarás si envias una transacción.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Precaución: Por favor revise que la fecha y hora de tu ordenador son correctas. Si tu reloj está mal configurado Bitcoin no funcionará correctamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Conecta solo al nodo especificado
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Error cargando blkindex.dat</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Atención: Poco espacio en el disco duro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Error: error de sistema:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Falló la lectura de la información del bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Falló la lectura del bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Falló sincronización del índice del bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Falló la escritura del bloque del índice</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Falló la escritura de la información del bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Falló la escritura del bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Comisión por kB para adicionarla a las transacciones enviadas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importar bloques desde el archivo externo blk000??.dat </translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Opciones SSL: (ver la Bitcoin Wiki para instrucciones de configuración SSL)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Enviar informacion de seguimiento a la consola en vez del archivo debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Establezca el tamaño mínimo del bloque en bytes (por defecto: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Especifica tiempo de espera para conexion en milisegundos (predeterminado: 5000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>Error de sistema:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Intenta usar UPnP para mapear el puerto de escucha (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Intenta usar UPnP para mapear el puerto de escucha (default: 1 when listening)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Usuario para las conexiones JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Atención</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Advertencia: Esta versión está obsoleta, se necesita actualizar!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>versión</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corrompió, guardado fallido</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Contraseña para las conexiones JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permite conexiones JSON-RPC desde la dirección IP especificada
 </translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Envia comando al nodo situado en &lt;ip&gt; (predeterminado: 127.0.0.1)
 </translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Actualizar billetera al formato actual</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Ajusta el numero de claves en reserva &lt;n&gt; (predeterminado: 100)
 </translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Rescanea la cadena de bloques para transacciones perdidas de la cartera
 </translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Usa OpenSSL (https) para las conexiones JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Certificado del servidor (Predeterminado: server.cert)
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Clave privada del servidor (Predeterminado: server.pem)
 </translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>Este mensaje de ayuda
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>No es posible escuchar en el %s en este ordenador (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permite búsqueda DNS para addnode y connect
 </translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>Cargando direcciónes...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Error cargando wallet.dat: Billetera corrupta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Error cargando wallet.dat: Billetera necesita una vercion reciente de Bitcoin</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>La billetera necesita ser reescrita: reinicie Bitcoin para completar</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>Error cargando wallet.dat</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Dirección -proxy invalida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidad inválida para -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Cantidad inválida</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Fondos insuficientes</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>Cargando el index de bloques...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Agrega un nodo para conectarse and attempt to keep the connection open</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>Cargando cartera...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>Rescaneando...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>Carga completa</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>Para utilizar la opción %s</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_es_DO.ts
+++ b/src/qt/locale/bitcoin_es_DO.ts
@@ -1,18 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="es_DO" version="2.1">
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="es_DO" version="2.0">
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Acerca del Núcleo de Bitcoin</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>Versión del &lt;b&gt;Núcleo de Bitcoin&lt;b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -30,141 +27,113 @@ el OpenSSL Toolkit (http://www.openssl.org/) y software criptográfico escrito p
 Eric Young (eay@cryptsoft.com) y el software UPnP escrito por Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Los desarrolladores del Núcleo de Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Haga doble clic para editar una dirección o etiqueta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crear una nueva dirección</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>Nuevo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copiar la dirección seleccionada al portapapeles del sistema</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiar</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>&amp;Cerrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copiar dirección</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Borrar de la lista la dirección seleccionada</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar a un archivo los datos de esta pestaña</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Eliminar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Escoja la dirección para enviar monedas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Escoja la dirección para recibir monedas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Escoger</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Enviando dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Recibiendo dirección</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Estas son sus direcciones Bitcoin para enviar pagos. Compruebe siempre la cantidad y la dirección receptora antes de transferir monedas.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Estas son sus direcciones de Bitcoin para recibir pagos. Se recomienda utilizar una nueva dirección de recepción para cada transacción.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar &amp;etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exportar la lista de direcciones </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Archivos de columnas separadas por coma (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Error exportando</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -172,17 +141,14 @@ Eric Young (eay@cryptsoft.com) y el software UPnP escrito por Thomas Bernard.</t
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
@@ -190,140 +156,106 @@ Eric Young (eay@cryptsoft.com) y el software UPnP escrito por Thomas Bernard.</t
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Diálogo de contraseña</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Introducir contraseña</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nueva contraseña</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repita la nueva contraseña</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introduzca la nueva contraseña de la cartera.&lt;br/&gt;Por favor elija una con &lt;b&gt;10 o más caracteres aleatorios&lt;/b&gt;, u &lt;b&gt;ocho o más palabras&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Cifrar la cartera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Esta operación requiere su contraseña para desbloquear la cartera</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desbloquear cartera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Esta operación requiere su contraseña para descifrar la cartera.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Descifrar la certare</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Cambiar contraseña</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Introduzca la contraseña anterior de la cartera y la nueva. </translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar cifrado de la cartera</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Atencion: ¡Si cifra su monedero y pierde la contraseña perderá &lt;b&gt;TODOS SUS BITCOINS&lt;/b&gt;!&quot;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>¿Seguro que desea cifrar su monedero?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>IMPORTANTE: Cualquier copia de seguridad que haya realizado previamente de su archivo de monedero debe reemplazarse con el nuevo archivo de monedero cifrado. Por razones de seguridad, las copias de seguridad previas del archivo de monedero no cifradas serán inservibles en cuanto comience a usar el nuevo monedero cifrado.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Aviso: ¡La tecla de bloqueo de mayúsculas está activada!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Monedero cifrado</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin se cerrará para finalizar el proceso de cifrado. Recuerde que el cifrado de su monedero no puede proteger totalmente sus bitcoins de robo por malware que infecte su sistema.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Ha fallado el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Ha fallado el cifrado del monedero debido a un error interno. El monedero no ha sido cifrado.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Las contraseñas no coinciden.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Ha fallado el desbloqueo del monedero</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña introducida para descifrar el monedero es incorrecta.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Ha fallado el descifrado del monedero</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Se ha cambiado correctamente la contraseña del monedero.</translation>
     </message>
@@ -331,363 +263,286 @@ Eric Young (eay@cryptsoft.com) y el software UPnP escrito por Thomas Bernard.</t
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>Firmar &amp;mensaje...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sincronizando con la red…</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista general</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>Nodo</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Mostrar vista general del monedero</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transacciones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Examinar el historial de transacciones</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Salir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Salir de la aplicación</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Mostrar información acerca de Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Acerca de &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Mostrar información acerca de Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opciones...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Cifrar monedero…</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>Copia de &amp;respaldo del monedero...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Cambiar la contraseña…</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>$Enviando dirección...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;Recibiendo dirección</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Abrir URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importando bloques de disco...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Reindexando bloques en disco...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Enviar monedas a una dirección Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modificar las opciones de configuración de Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Copia de seguridad del monedero en otra ubicación</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cambiar la contraseña utilizada para el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Ventana de &amp;depuración</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Abrir la consola de depuración y diagnóstico</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verificar mensaje...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Monedero</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Recibir</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>Mo&amp;strar/ocultar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Mostrar u ocultar la ventana principal</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Cifrar las claves privadas de su monedero</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Firmar mensajes con sus direcciones Bitcoin para demostrar la propiedad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verificar mensajes comprobando que están firmados con direcciones Bitcoin concretas</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuración</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>A&amp;yuda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra de pestañas</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Núcleo de Bitcoin</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Solicitar pagos (genera codigo QR y URL&apos;s de Bitcoin)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;Acerca del Núcleo de Bitcoin</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Mostrar la lista de direcciones de envío y etiquetas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Muestra la lista de direcciones de recepción y etiquetas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Abrir un bitcoin: URI o petición de pago</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Opciones de linea de comando</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Cliente Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n conexión activa hacia la red Bitcoin</numerusform><numerusform>%n conexiones activas hacia la red Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Ninguna fuente de bloques disponible ...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Se han procesado %1 de %2 bloques (estimados) del historial de transacciones.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Procesados %1 bloques del historial de transacciones.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hora</numerusform><numerusform>%n horas</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n día</numerusform><numerusform>%n días</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n semana</numerusform><numerusform>%n semanas</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 atrás</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>El último bloque recibido fue generado hace %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Las transacciones posteriores aún no están visibles.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Actualizado</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Actualizando...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transacción enviada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transacción entrante</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -700,17 +555,14 @@ Dirección: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;desbloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>El monedero está &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+441"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Ha ocurrido un error crítico. Bitcoin ya no puede continuar con seguridad y se cerrará.</translation>
     </message>
@@ -718,7 +570,6 @@ Dirección: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Alerta de red</translation>
     </message>
@@ -726,291 +577,230 @@ Dirección: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Selección de la dirección de control de la moneda</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Cantidad:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Cuantía:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioridad:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Tasa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Envío pequeño:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Después de tasas:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Cambio:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(des)selecciona todos</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Modo arbol</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Modo lista</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Confirmaciones</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioridad</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copiar cantidad</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Copiar identificador de transacción</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Bloquear lo no gastado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Desbloquear lo no gastado</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Copiar donación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copiar después de aplicar donación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copiar prioridad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copiar envío pequeño</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiar cambio</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>lo más alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>más alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>medio-alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>medio</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>bajo-medio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>bajo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>más bajo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>lo más bajo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 bloqueado)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>ninguno</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Basura</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>si</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>no</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Esta etiqueta se torna roja si el tamaño de la transación es mayor a 1000 bytes.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Esto implica que se requiere una tarifa de al menos %1 por kB</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Puede variar +/- 1 byte por entrada.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Las transacciones con alta prioridad son más propensas a ser incluidas dentro de un bloque.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Esta etiqueta se convierte en rojo, si la prioridad es menor que &quot;medio&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Esta etiqueta se torna roja si cualquier destinatario recibe una cantidad menor a %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Esto significa que se necesita una tarifa de al menos %1.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Cantidades por debajo de 0.546 veces la tasa serán mostradas como basura</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Esta etiqueta se vuelve roja si la cantidad de monedas es menor a %1</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+63"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>Enviar desde %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(cambio)</translation>
     </message>
@@ -1018,67 +808,54 @@ Dirección: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editar Dirección</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>La etiqueta asociada con esta entrada de la lista de direcciones</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>La dirección asociada con esta entrada de la lista de direcciones. Solo puede ser modificada para direcciones de envío.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Dirección</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nueva dirección de recepción</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nueva dirección de envío</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editar dirección de recepción</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editar dirección de envío</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>La dirección introducida &quot;%1&quot; ya está presente en la libreta de direcciones.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>La dirección introducida &quot;%1&quot; no es una dirección Bitcoin válida.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>No se pudo desbloquear el monedero.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Ha fallado la generación de la nueva clave.</translation>
     </message>
@@ -1086,27 +863,22 @@ Dirección: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Se creará un nuevo directorio de datos.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nombre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>El directorio ya existe. Añada %1 si pretende crear aquí un directorio nuevo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>La ruta ya existe y no es un directorio.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>No se puede crear un directorio de datos aquí.</translation>
     </message>
@@ -1114,52 +886,46 @@ Dirección: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Núcleo de Bitcoin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versión</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>opciones de la línea de órdenes</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Opciones GUI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Establecer el idioma, por ejemplo, &quot;es_ES&quot; (predeterminado: configuración regional del sistema)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Arrancar minimizado</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Mostrar pantalla de bienvenida en el inicio (predeterminado: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Elegir directorio de datos al iniciar (predeterminado: 0)</translation>
     </message>
@@ -1167,57 +933,46 @@ Dirección: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Bienvenido</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Bienvenido al Núcleo de Bitcoin</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Al ser la primera vez que se ejecuta el programa, puede elegir dónde almacenará sus datos Bitcoin-Qt.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin-Qt va a descargar y guardar una copia de la cadena de bloques de Bitcoin. Se almacenará al menos %1GB de datos en este directorio, que irá creciendo con el tiempo. El monedero se guardará también en este directorio.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Utilizar el directorio de datos predeterminado</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Utilice un directorio de datos personalizado:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Error: No puede crearse el directorio de datos especificado &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB de espacio libre disponible</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(de los %1GB necesarios)</translation>
     </message>
@@ -1225,27 +980,22 @@ Dirección: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Abrir URI...</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>El pago requiere una URI o archivo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Seleccione archivo de sulicitud de pago</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Abrir archivo de solicitud de pago</translation>
     </message>
@@ -1253,258 +1003,206 @@ Dirección: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Principal</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Tarifa de transacción opcional por kB que ayuda a asegurar que sus transacciones sean procesadas rápidamente. La mayoría de transacciones son de 1kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Comisión de &amp;transacciones</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Iniciar Bitcoin automáticamente al encender el sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Iniciar Bitcoin al iniciar el sistema</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Configura el número de hilos para el script de verificación (hasta 16, 0 = auto, &lt;0 = leave that many cores free, por fecto: 0)</translation>
-    </message>
-    <message>
-        <location line="+153"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Conéctese a la red Bitcoin través de un proxy SOCKS.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>Dirección IP del proxy (ej. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Restablecer todas las opciones del cliente a las predeterminadas.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Restablecer opciones</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Red</translation>
     </message>
     <message>
-        <location line="-95"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>Experto</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Abrir automáticamente el puerto del cliente Bitcoin en el router. Esta opción solo funciona si el router admite UPnP y está activado.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapear el puerto usando &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Dirección &amp;IP del proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Puerto:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Puerto del servidor proxy (ej. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Versión SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Versión del proxy SOCKS (ej. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Ventana</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Minimizar la ventana a la bandeja de iconos del sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimizar a la bandeja en vez de a la barra de tareas</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimizar en lugar de salir de la aplicación al cerrar la ventana. Cuando esta opción está activa, la aplicación solo se puede cerrar seleccionando Salir desde el menú.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimizar al cerrar</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Interfaz</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>I&amp;dioma de la interfaz de usuario</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>El idioma de la interfaz de usuario puede establecerse aquí. Este ajuste se aplicará cuando se reinicie Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Mostrar las cantidades en la &amp;unidad:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Elegir la subdivisión predeterminada para mostrar cantidades en la interfaz y cuando se envían monedas.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Mostrar o no las direcciones Bitcoin en la lista de transacciones.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Mostrar las direcciones en la lista de transacciones</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Mostrar o no características de control de moneda</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;Aceptar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>predeterminado</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>Ninguna</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Confirme el restablecimiento de las opciones</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Reinicio del cliente para activar cambios.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Este cambio requiere reinicio por parte del cliente.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>La dirección proxy indicada es inválida.</translation>
     </message>
@@ -1512,69 +1210,54 @@ Dirección: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Desde</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>La información mostrada puede estar desactualizada. Su monedero se sincroniza automáticamente con la red Bitcoin después de que se haya establecido una conexión, pero este proceso aún no se ha completado.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Monedero</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Su balance actual gastable</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Total de transacciones que deben ser confirmadas, y que no cuentan con el balance gastable necesario</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>No disponible:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Saldo recién minado que aún no está disponible.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Su balance actual total</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Movimientos recientes&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>desincronizado</translation>
     </message>
@@ -1582,93 +1265,70 @@ Dirección: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Gestión de URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>¡No se puede interpretar la URI! Esto puede deberse a una dirección Bitcoin inválida o a parámetros de URI mal formados.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>La cantidad del pago solicitado (%1) es demasiado pequeña (considerada polvo).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Error en petición de pago</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>No se pudo iniciar bitcoin: manejador de pago-al-clic</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>No están soportadas las peticiones inseguras a scripts de pago personalizados</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Devolución de %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Error en la comunicación con %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Respuesta errónea del servidor %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Pago aceptado</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Error en petición de red</translation>
     </message>
@@ -1676,23 +1336,22 @@ Dirección: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+14"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Error: El directorio de datos especificado &quot;%1&quot; no existe.</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Error: Combinación no válida de -regtest y -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduzca una dirección Bitcoin (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1700,22 +1359,18 @@ Dirección: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>Guardar Imagen...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>Copiar imagen</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Guardar código QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>Imágenes PNG (*.png)</translation>
     </message>
@@ -1723,194 +1378,146 @@ Dirección: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nombre del cliente</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>N/D</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versión del cliente</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Información</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Ventana de depuración</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Utilizando la versión OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Hora de inicio</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Red</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Número de conexiones</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Cadena de bloques</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Número actual de bloques</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Bloques totales estimados</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Hora del último bloque</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Consola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Tráfico de Red</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Limpiar</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>Dentro:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>Fuera:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Fecha de compilación</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Archivo de registro de depuración</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Abrir el archivo de registro de depuración en el directorio actual de datos. Esto puede llevar varios segundos para archivos de registro grandes.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Borrar consola</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bienvenido a la consola RPC de Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Use las flechas arriba y abajo para navegar por el historial y &lt;b&gt;Control+L&lt;/b&gt; para limpiar la pantalla.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Escriba &lt;b&gt;help&lt;/b&gt; para ver un resumen de los comandos disponibles.</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1918,105 +1525,82 @@ Dirección: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>Mensaje:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Reutilizar una de las direcciones previamente usadas para recibir. Reutilizar direcciones tiene problemas de seguridad y privacidad. No lo uses a menos que antes regeneres una solicitud de pago.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>R&amp;eutilizar una dirección existente para recibir (no recomendado)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Limpiar todos los campos del formulario.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Limpiar</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Solicitar pago</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>Muestra la petición seleccionada (También doble clic)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation>Borrar de la lista las direcciónes actualmente seleccionadas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar cantidad</translation>
     </message>
@@ -2024,67 +1608,54 @@ Dirección: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Copiar &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Copiar &amp;Dirección</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>Guardar Imagen...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Solicitar pago a %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Información de pago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI resultante demasiado larga. Intente reducir el texto de la etiqueta / mensaje.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Error al codificar la URI en el código QR.</translation>
     </message>
@@ -2092,37 +1663,30 @@ Dirección: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(Ningun mensaje)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2130,247 +1694,194 @@ Dirección: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Características de control de la moneda</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Entradas...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>Seleccionado automaticamente</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Fondos insuficientes!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Cantidad:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Cuantía:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioridad:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Tasa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Envío pequeño:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Después de tasas:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Cambio:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Al activarse, si la dirección esta vacía o es inválida, las monedas serán enviadas a una nueva dirección generada.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Dirección propia</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Enviar a múltiples destinatarios de una vez</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Añadir &amp;destinatario</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Limpiar todos los campos del formulario</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Limpiar &amp;todo</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Confirmar el envío</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirmar el envío de monedas</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 a %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar cuantía</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Copiar donación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copiar después de aplicar donación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copiar prioridad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copiar envío pequeño</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiar Cambio</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Cuantía Total %1 (=%2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>o</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>La dirección de recepción no es válida, compruébela de nuevo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>La cantidad por pagar tiene que ser mayor de 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>La cantidad sobrepasa su saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>El total sobrepasa su saldo cuando se incluye la tasa de envío de %1</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Se ha encontrado una dirección duplicada. Solo se puede enviar a cada dirección una vez por operación de envío.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>¡Ha fallado la creación de la transacción!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>La transacción fue rechazada. Esto puede haber ocurrido si alguna de las monedas ya estaba gastada o si ha usado una copia de wallet.dat y las monedas se gastaron en la copia pero no se han marcado como gastadas aqui.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Alerta: Dirección de Bitcoin inválida</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Alerta: Dirección de Bitcoin inválida</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>¿Está seguro que desea enviar?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>añadido como comisión de transacción</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Petición de pago expirada</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Dirección de pago no válida %1</translation>
     </message>
@@ -2378,98 +1889,74 @@ Dirección: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Ca&amp;ntidad:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Pagar a:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La dirección a la que enviar el pago (p. ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Etiquete esta dirección para añadirla a la libreta</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Escoger direcciones previamente usadas</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Esto es un pago ordinario.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar dirección desde portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Eliminar esta transacción</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Esto es una petición de pago verificado.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Introduce una etiqueta para esta dirección para añadirla a la lista de direcciones utilizadas</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Esto es una petición de pago no verificado.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Paga a:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memo:</translation>
     </message>
@@ -2477,12 +1964,10 @@ Dirección: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2490,186 +1975,142 @@ Dirección: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Firmas - Firmar / verificar un mensaje</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Firmar mensaje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Puede firmar mensajes con sus direcciones para demostrar que las posee. Tenga cuidado de no firmar cualquier cosa vaga, ya que los ataques de phishing pueden tratar de engañarle para suplantar su identidad. Firme solo declaraciones totalmente detalladas con las que usted esté de acuerdo.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La dirección con la que firmar el mensaje (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Escoger dirección previamente usada</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar dirección desde portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Introduzca el mensaje que desea firmar aquí</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Firma</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copiar la firma actual al portapapeles del sistema</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Firmar el mensaje para demostrar que se posee esta dirección Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Firmar &amp;mensaje</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Limpiar todos los campos de la firma de mensaje</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Limpiar &amp;todo</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verificar mensaje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Introduzca la dirección para la firma, el mensaje (asegurándose de copiar tal cual los saltos de línea, espacios, tabulaciones, etc.) y la firma a continuación para verificar el mensaje. Tenga cuidado de no asumir más información de lo que dice el propio mensaje firmado para evitar fraudes basados en ataques de tipo man-in-the-middle.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>La dirección con la que se firmó el mensaje (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verificar el mensaje para comprobar que fue firmado con la dirección Bitcoin indicada</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verificar &amp;mensaje</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Limpiar todos los campos de la verificación de mensaje</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduzca una dirección Bitcoin (ej. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Haga clic en &quot;Firmar mensaje&quot; para generar la firma</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>La dirección introducida es inválida.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Verifique la dirección e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>La dirección introducida no corresponde a una clave.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Se ha cancelado el desbloqueo del monedero. </translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>No se dispone de la clave privada para la dirección introducida.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Ha fallado la firma del mensaje.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Mensaje firmado.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>No se puede decodificar la firma.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Compruebe la firma e inténtelo de nuevo.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>La firma no coincide con el resumen del mensaje.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>La verificación del mensaje ha fallado.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Mensaje verificado.</translation>
     </message>
@@ -2677,17 +2118,14 @@ Dirección: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Núcleo de Bitcoin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Los desarrolladores del Núcleo de Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2695,7 +2133,6 @@ Dirección: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2703,184 +2140,138 @@ Dirección: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Abierto hasta %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/fuera de línea</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/no confirmado</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmaciones</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, transmitir a través de %n nodo</numerusform><numerusform>, transmitir a través de %n nodos</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generado</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>dirección propia</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Crédito</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>disponible en %n bloque más</numerusform><numerusform>disponible en %n bloques más</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>no aceptada</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Débito</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Comisión de transacción</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Cantidad neta</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mensaje</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Identificador de transacción</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Vendedor</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Las monedas generadas deben madurar %1 bloques antes de que puedan ser gastadas. Una vez que generas este bloque, es propagado por la red para ser añadido a la cadena de bloques. Si falla el intento de meterse en la cadena, su estado cambiará a &quot;no aceptado&quot; y ya no se puede gastar. Esto puede ocurrir ocasionalmente si otro nodo genera un bloque a pocos segundos del tuyo.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Información de depuración</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transacción</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>entradas</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>verdadero</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, todavía no se ha sido difundido satisfactoriamente</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abrir para %n bloque más</numerusform><numerusform>Abrir para %n bloques más</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
@@ -2888,12 +2279,10 @@ Dirección: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detalles de transacción</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Esta ventana muestra información detallada sobre la transacción</translation>
     </message>
@@ -2901,127 +2290,102 @@ Dirección: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abrir para %n bloque más</numerusform><numerusform>Abrir para %n bloques más</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Abierto hasta %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmaciones)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Este bloque no ha sido recibido por otros nodos y probablemente no sea aceptado!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generado pero no aceptado</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Recibido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Recibidos de</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Enviado a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pago propio</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(nd)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estado de transacción. Pasa el ratón sobre este campo para ver el número de confirmaciones.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Fecha y hora en que se recibió la transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipo de transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Dirección de destino de la transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Cantidad retirada o añadida al saldo.</translation>
     </message>
@@ -3029,178 +2393,142 @@ Dirección: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Todo</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hoy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Esta semana</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Este mes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Mes pasado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Este año</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Rango...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Recibido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Enviado a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>A usted mismo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Otra</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Introduzca una dirección o etiqueta que buscar</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Cantidad mínima</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar cuantía</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copiar identificador de transacción</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Editar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Mostrar detalles de la transacción</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Exportar historial de transacciones</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Error exportando</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Ha habido un error al intentar guardar la transacción con %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Exportación finalizada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>La transacción ha sido guardada en %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Archivos de columnas separadas por coma (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Rango:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>para</translation>
     </message>
@@ -3208,7 +2536,6 @@ Dirección: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>No se ha cargado ningún monedero</translation>
     </message>
@@ -3216,7 +2543,6 @@ Dirección: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>
     </message>
@@ -3224,42 +2550,34 @@ Dirección: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar a un archivo los datos de esta pestaña</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Respaldo de monedero</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Datos de monedero (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Ha fallado el respaldo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Ha habido un error al intentar guardar los datos del monedero en %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Los datos del monedero se han guardado con éxito en %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Se ha completado con éxito la copia de respaldo</translation>
     </message>
@@ -3267,110 +2585,94 @@ Dirección: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+226"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Muestra comandos
 </translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Recibir ayuda para un comando
 </translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Opciones:
 </translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Especificar archivo de configuración (predeterminado: bitcoin.conf)
 </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Especificar archivo pid (predeterminado: bitcoin.pid)
 </translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Especificar directorio para los datos</translation>
     </message>
     <message>
-        <location line="-35"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Escuchar conexiones en &lt;puerto&gt; (predeterminado: 8333 o testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Mantener como máximo &lt;n&gt; conexiones a pares (predeterminado: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Conectar a un nodo para obtener direcciones de pares y desconectar</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Especifique su propia dirección pública</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Umbral para la desconexión de pares con mal comportamiento (predeterminado: 100)</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Número de segundos en que se evita la reconexión de pares con mal comportamiento (predeterminado: 86400)</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Ha ocurrido un error al configurar el puerto RPC %u para escucha en IPv4: %s</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Escuchar conexiones JSON-RPC en &lt;puerto&gt; (predeterminado: 8332 o testnet:18332)</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Aceptar comandos consola y JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Ejecutar en segundo plano como daemon y aceptar comandos
 </translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Usar la red de pruebas
 </translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Aceptar conexiones desde el exterior (predeterminado: 1 si no -proxy o -connect)</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3395,741 +2697,691 @@ Por ejemplo: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Cifradores aceptables (por defecto: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ha ocurrido un error al configurar el puerto RPC %u para escuchar mediante IPv6. Recurriendo a IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Vincular a la dirección dada y escuchar siempre en ella. Utilice la notación [host]:port para IPv6</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Iniciar modo de prueba de regresión, el cuál utiliza una cadena especial en la cual los bloques pueden ser resueltos instantáneamente. Se utiliza para herramientas de prueba de regresión y desarrollo de aplicaciones.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>¡Error: se ha rechazado la transacción! Esto puede ocurrir si ya se han gastado algunas de las monedas del monedero, como ocurriría si hubiera hecho una copia de wallet.dat y se hubieran gastado monedas a partir de la copia, con lo que no se habrían marcado aquí como gastadas.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>¡Error: Esta transacción requiere una comisión de al menos %s debido a su monto, complejidad, o al uso de fondos recién recibidos!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Ejecutar comando cuando una transacción del monedero cambia (%s en cmd se remplazará por TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Esta es una versión de pre-prueba - utilícela bajo su propio riesgo. No la utilice para usos comerciales o de minería.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Usar distintos proxys SOCKS5 para comunicarse vía Tor de forma anónima (Por defecto: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Aviso: ¡-paytxfee tiene un valor muy alto! Esta es la comisión que pagará si envía una transacción.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Precaución: Por favor, ¡revise que la fecha y hora de su ordenador son correctas! Si su reloj está mal, Bitcoin no funcionará correctamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Atención: ¡Parece que la red no está totalmente de acuerdo! Algunos mineros están presentando inconvenientes.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Atención: ¡Parece que no estamos completamente de acuerdo con nuestros pares! Podría necesitar una actualización, u otros nodos podrían necesitarla.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Aviso: ¡Error al leer wallet.dat! Todas las claves se han leído correctamente, pero podrían faltar o ser incorrectos los datos de transacciones o las entradas de la libreta de direcciones.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Aviso: ¡Recuperados datos de wallet.dat corrupto! El wallet.dat original se ha guardado como wallet.{timestamp}.bak en %s; si hubiera errores en su saldo o transacciones, deberá restaurar una copia de seguridad.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; puede ser:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Intento de recuperar claves privadas de un wallet.dat corrupto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Proceso Bitcoin-QT</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Versión de cliente BitcoinROC</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Opciones de creación de bloques:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Conectar sólo a los nodos (o nodo) especificados</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Conectar a través de un proxy SOCKS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Conectar a JSON-RPC en &lt;puerto&gt; (predeterminado: 8332 o testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Corrupción de base de datos de bloques detectada.</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Descubrir dirección IP propia (predeterminado: 1 al escuchar sin -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>¿Quieres reconstruir la base de datos de bloques ahora?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Error al inicializar la base de datos de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Error al inicializar el entorno de la base de datos del monedero  %s</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Error cargando base de datos de bloques</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Error al abrir base de datos de bloques.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Error: ¡Espacio en disco bajo!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Error: ¡El monedero está bloqueado; no se puede crear la transacción!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Error: error de sistema: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ha fallado la escucha en todos los puertos. Use -listen=0 si desea esto.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>No se ha podido leer la información de bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>No se ha podido leer el bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>No se ha podido sincronizar el índice de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>No se ha podido escribir en el índice de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>No se ha podido escribir la información de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>No se ha podido escribir el bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>No se ha podido escribir la información de archivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>No se ha podido escribir en la base de datos de monedas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>No se ha podido escribir en el índice de transacciones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>No se han podido escribir los datos de deshacer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Donación por KB añadida a las transacciones que envíe</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Encontrar pares mediante búsqueda de DNS (predeterminado: 1 salvo con -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generar monedas (por defecto: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Cuántos bloques comprobar al iniciar (predeterminado: 288, 0 = todos)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Como es de exhaustiva la verificación de bloques (0-4, por defecto 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>Si no se proporciona &lt;category&gt;, mostrar toda la depuración</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Incorrecto o bloque de génesis no encontrado. Datadir equivocada para la red?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Dirección -onion inválida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>No hay suficientes descriptores de archivo disponibles. </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>Anteponer marca temporal a la información de depuración (por defecto: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>Opciones para cliente RPC:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Reconstruir el índice de la cadena de bloques a partir de los archivos blk000??.dat actuales</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Seleccionar version de SOCKS para -proxy (4 o 5, por defecto: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Enviar comando a servidor Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Establecer tamaño máximo de bloque en bytes (por defecto: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Establecer el número de hilos para atender las llamadas RPC (predeterminado: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Especificar archivo de monedero (dentro del directorio de datos)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Iniciar servidor Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Uso (desaconsejado, usar bitcoin-cli)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verificando bloques...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Verificando monedero...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Espere a que se inicie el servidor RPC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>El monedero %s se encuentra fuera del directorio de datos %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Aviso: Argumento -debugnet anticuado, utilice -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Usted necesita reconstruir la base de datos utilizando -reindex para cambiar -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importa los bloques desde un archivo blk000??.dat externo</translation>
     </message>
     <message>
-        <location line="-126"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Ejecutar un comando cuando se reciba una alerta importante o cuando veamos un fork demasiado largo (%s en cmd se reemplazará por el mensaje)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Mostrar depuración (por defecto: 0, proporcionar &lt;category&gt; es opcional)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Establecer tamaño máximo de las transacciones de alta prioridad/comisión baja en bytes (por defecto: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Configura el número de hilos para el script de verificación (hasta 16, 0 = auto, &lt;0 = leave that many cores free, por fecto: 0)</translation>
-    </message>
-    <message>
-        <location line="+91"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Inválido por el monto -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Inválido por el monto -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Mantener índice de transacciones completo (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Búfer de recepción máximo por conexión, &lt;n&gt;*1000 bytes (predeterminado: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Búfer de recepción máximo por conexión, , &lt;n&gt;*1000 bytes (predeterminado: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Aceptar solamente cadena de bloques que concuerde con los puntos de control internos (predeterminado: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Conectarse solo a nodos de la red &lt;net&gt; (IPv4, IPv6 o Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Opciones SSL: (ver la Bitcoin Wiki para instrucciones de configuración SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Enviar información de trazas/depuración a la consola en lugar de al archivo debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Establecer tamaño mínimo de bloque en bytes (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Reducir el archivo debug.log al iniciar el cliente (predeterminado: 1 sin -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Transacción falló</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Especificar el tiempo máximo de conexión en milisegundos (predeterminado: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Error de sistema: </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Monto de la transacción muy pequeño</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Montos de transacciones deben ser positivos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transacción demasiado grande</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Usar UPnP para asignar el puerto de escucha (predeterminado: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Usar UPnP para asignar el puerto de escucha (predeterminado: 1 al escuchar)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nombre de usuario para las conexiones JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Aviso: Esta versión es obsoleta, actualización necesaria!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>versión</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corrupto. Ha fallado la recuperación.</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Contraseña para las conexiones JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permitir conexiones JSON-RPC desde la dirección IP especificada
 </translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Enviar comando al nodo situado en &lt;ip&gt; (predeterminado: 127.0.0.1)
 </translation>
     </message>
     <message>
-        <location line="-134"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Ejecutar un comando cuando cambia el mejor bloque (%s en cmd se sustituye por el hash de bloque)</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Actualizar el monedero al último formato</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Ajustar el número de claves en reserva &lt;n&gt; (predeterminado: 100)
 </translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Volver a examinar la cadena de bloques en busca de transacciones del monedero perdidas</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Usar OpenSSL (https) para las conexiones JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Certificado del servidor (predeterminado: server.cert)
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Clave privada del servidor (predeterminado: server.pem)
 </translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Este mensaje de ayuda
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>No es posible conectar con %s en este sistema (bind ha dado el error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permitir búsquedas DNS para -addnode, -seednode y -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Cargando direcciones...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Error al cargar wallet.dat: el monedero está dañado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Error al cargar wallet.dat: El monedero requiere una versión más reciente de Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>El monedero ha necesitado ser reescrito. Reinicie Bitcoin para completar el proceso</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Error al cargar wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Dirección -proxy inválida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>La red especificada en -onlynet &apos;%s&apos; es desconocida</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Solicitada versión de proxy -socks desconocida: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>No se puede resolver la dirección de -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>No se puede resolver la dirección de -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidad inválida para -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Cuantía no válida</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Fondos insuficientes</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Cargando el índice de bloques...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Añadir un nodo al que conectarse y tratar de mantener la conexión abierta</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Loading wallet...</source>
         <translation>Cargando monedero...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>No se puede rebajar el monedero</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>No se puede escribir la dirección predeterminada</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Reexplorando...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Generado pero no aceptado</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Para utilizar la opción %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_es_MX.ts
+++ b/src/qt/locale/bitcoin_es_MX.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>El nucleo de Bitcoin de desarrolladores</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Haga doble clic para editar el domicilio o la etiqueta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crear una dirección nueva</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copiar el domicilio seleccionado al portapapeles del sistema</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Archivo separado por comas (*.CSV)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Fallo en la exportación</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Ocurrio un error al intentar guardar la lista de direccione en %1</translation>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Domicilio</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Ingrese la contraseña</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nueva contraseña</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repita la nueva contraseña</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Ingrese la nueva contraseña a la cartera&lt;br/&gt;Por favor use una contraseña de&lt;b&gt;10 o más caracteres aleatorios&lt;/b&gt; o &lt;b&gt;ocho o más palabras&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Cartera encriptada.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Esta operación necesita la contraseña de su cartera para desbloquear su cartera.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desbloquear cartera.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Esta operación necesita la contraseña de su cartera para desencriptar su cartera.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Desencriptar la cartera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Cambiar contraseña</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Ingrese la antugüa y nueva contraseña de la cartera</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar la encriptación de cartera</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Cartera encriptada</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>La encriptación de la cartera falló</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>La encriptación de la cartera falló debido a un error interno. Su cartera no fue encriptada.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Las contraseñas dadas no coinciden</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>El desbloqueo de la cartera Fallo</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña ingresada para la des encriptación de la cartera es incorrecto</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>La desencriptación de la cartera fallo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sincronizando con la red...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista previa</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Mostrar la vista previa general de la cartera</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transacciones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Explorar el historial de transacciones</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>S&amp;alir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Salir de la aplicación</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Mostrar información acerca de Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opciones</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cambiar la contraseña usada para la encriptación de la cartera</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuraciones</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Pestañas</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>nucleo Bitcoin</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>opciones de la &amp;Linea de comandos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Mostrar mensaje de ayuda del nucleo de Bitcoin para optener una lista con los posibles comandos  de Bitcoin</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n Activar conexión a la red de Bitcoin</numerusform><numerusform>%n Activar conexiones a la red de Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Actualizado al dia </translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Resiviendo...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Enviar Transacción</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transacción entrante</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>La cartera esta &lt;b&gt;encriptada&lt;/b&gt; y &lt;b&gt;desbloqueada&lt;/b&gt; actualmente </translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>La cartera esta &lt;b&gt;encriptada&lt;/b&gt; y &lt;b&gt;bloqueada&lt;/b&gt; actualmente </translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Monto:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioridad:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Cuota:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Monto</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Domicilio</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmado </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Copiar dirección </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar capa </translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>copiar monto</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>copiar cantidad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>copiar cuota</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>copiar despues de cuota</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>copiar prioridad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>copiar cambio</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editar dirección</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Dirección</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nueva dirección de entregas</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nueva dirección de entregas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editar dirección de entregas</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editar dirección de envios</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>El domicilio ingresado &quot;%1&quot; ya existe en la libreta de direcciones</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>No se puede desbloquear la cartera</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>La generación de la nueva clave fallo</translation>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Opciones de lineas de comando del nucleo de Bitcoin</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>nucleo Bitcoin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>Opciones de comando de lineas</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Opciones de interfaz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Definir idioma, por ejemplo &quot;de_DE&quot; (por defecto: Sistema local)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Iniciar minimizado</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Mostrar pantalla de arraque al iniciar (por defecto: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Escojer el directorio de información al iniciar (por defecto : 0)</translation>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation>Activar las opciones de linea de comando que sobre escriben las siguientes opciones:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulario</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transacciones recientes&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>advertencia del administrador de red.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>Tu active proxy no soporta SOCKS5, el cual es requerido para solicitud de pago via proxy. </translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ingrese una direccion Bitcoin (ejem. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>Mensaje opcional para agregar a la solicitud de pago, el cual será mostrado cuando la solicitud este abierta. Nota: El mensaje no se manda con el pago a travéz de la red de Bitcoin.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Use este formulario para la solicitud de pagos. Todos los campos son &lt;b&gt;opcionales&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Monto opcional a solicitar. Dejarlo vacion o en cero no solicita un monto especifico.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Copiar capa </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>copiar monto</translation>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Domicilio</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Monto</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Monto</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Mandar monedas</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Monto:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioridad:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Cuota:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Enviar a múltiples receptores a la vez</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Confirme la acción de enviar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirme para mandar monedas</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>copiar cantidad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>copiar monto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>copiar cuota</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>copiar despues de cuota</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>copiar prioridad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>copiar cambio</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Monto total %1(=%2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>o</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>El monto a pagar debe ser mayor a 0</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>¡La creación de transacion falló!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>¡La transación fue rechazada! Esto puede ocurrir si algunas de tus monedas en tu cartera han sido gastadas, al igual que si usas una cartera copiada y la monedas fueron gastadas en la copia pero no se marcaron como gastadas.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Advertencia: Dirección de Bitcoin invalida</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Advertencia: Cambio de dirección desconocido</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>M&amp;onto</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Pagar &amp;a:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Ingrese una etiqueta para esta dirección para agregarlo en su libreta de direcciones.</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Este es un pago normal</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar dirección  del portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Quitar esta entrada</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Mensaje:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Esta es una verificación de solicituda de pago.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Esta es una solicitud de pago no verificada.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Pago para:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Apagando el nucleo de Bitcoin...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>No apague su computadora hasta que esta ventana desaparesca.</translation>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar dirección  del portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ingrese una direccion Bitcoin (ejem. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>nucleo Bitcoin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>El nucleo de Bitcoin de desarrolladores</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Abrir hasta %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/No confirmado</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmaciones</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Monto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, no ha sido transmitido aun</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detalles de la transacción</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Este panel muestras una descripción detallada de la transacción</translation>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Domicilio</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Monto</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Abrir hasta %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confimado (%1 confirmaciones)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Este bloque no fue recibido por ningun nodo y probablemente no fue aceptado !</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generado pero no aprovado</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Recivido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Enviar a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pagar a si mismo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Fecha y hora en que la transacción fue recibida </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Escriba una transacción</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Direccion del destinatario de la transacción</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Cantidad removida del saldo o agregada </translation>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Todo</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hoy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Esta semana </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Este mes </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>El mes pasado </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Este año</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Recivido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Enviar a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Para ti mismo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minado </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Otro</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Ingrese dirección o capa a buscar </translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Monto minimo </translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copiar dirección </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar capa </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>copiar monto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Editar capa </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation>Exportar el historial de transacción</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Fallo en la exportación</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Ocurrio un error intentando guardar el historial de transaciones a %1</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Exportacion satisfactoria</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>el historial de transaciones ha sido guardado exitosamente en 1%</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Arhchivo separado por comas (*.CSV)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmado </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Domicilio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Monto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>Para</translation>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>No se há cargado la cartera.</translation>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Mandar monedas</translation>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Ocurrio un error tratando de guardar la información de la cartera %1</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>La información de la cartera fué guardada exitosamente a 1%</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Lista de comandos</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;categoria&gt; puede ser:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Enviar instrucción al servidor de Bitcoin</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Iniciar servidor Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Opciones de cartera:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>Versión</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Cargando direcciones...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Cargando indice de bloques... </translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Cargando billetera...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Carga completa</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_es_UY.ts
+++ b/src/qt/locale/bitcoin_es_UY.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Doble clic para editar etiqueta o dirección </translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crear una nueva dirección </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copia la dirección seleccionada al portapapeles del sistema</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Archivos separados por coma (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Direccion </translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(Sin etiqueta)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Escriba la contraseña</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nueva contraseña</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repetir nueva contraseña</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introduzca la nueva contraseña para el monedero. &lt;br/&gt; Utilice una contraseña de &lt;b&gt; 10 o más caracteres al azar &lt;/ b&gt;, o &lt;b&gt; ocho o más palabras &lt;/ b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Monedero cifrado</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Esta operacion necesita la contraseña del monedero para desbloquear el mismo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Monedero destrabado</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Esta operacion necesita la contraseña del monedero para descifrar el mismo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Monedero descifrado</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Cambiar contraseña</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Ingrese la contraseña anterior y la nueva de acceso a el monedero</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirme el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Monedero cifrado</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Fallo en el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Fallo en el cifrado del monedero a causa de un error interno. Su monedero no esta cifrado</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Las contraseñas suministradas no coinciden.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Fallo en el desbloqueo del mondero</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La contraseña introducida para el descifrado del monedero es incorrecta.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Fallo en el descifrado del monedero</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sincronizando con la red...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista previa</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Mostrar descripción general del monedero</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;transaciones </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Buscar en el historial de transacciones</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Salir de la aplicacion </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Mostrar informacion sobre Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opciones...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cambie la clave utilizada para el cifrado del monedero</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuracion </translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra de herramientas</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[prueba_de_red]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n conexión activa a la red Bitcoin </numerusform><numerusform>%n conexiones activas a la red Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>A la fecha</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Ponerse al dia...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transaccion enviada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transacción entrante</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>El Monedero esta &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;desbloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>El Monedero esta &lt;b&gt;cifrado&lt;/b&gt; y actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Direccion </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(Sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editar dirección</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Direccion </translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nueva dirección de recepción </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nueva dirección de envío </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editar dirección de recepcion </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editar dirección de envío </translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>La dirección introducida &quot;% 1&quot; ya está en la libreta de direcciones.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>No se puede abrir el monedero.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Fallo en la nueva clave generada.</translation>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulario</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transacciones recientes&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Direccion </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(Sin etiqueta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Enviar a varios destinatarios a la vez</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Balance:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Confirmar el envío</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirmar el envio de monedas</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>La cantidad a pagar debe ser mayor que 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(Sin etiqueta)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>A&amp;Monto:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Pagar &amp;A:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Introduzca una etiqueta para esta dirección para añadirla a su libreta de direcciones</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar la dirección desde el portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar la dirección desde el portapapeles</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[prueba_de_red]</translation>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Abrir hasta %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>desconocido</translation>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Direccion </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Abrir hasta %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Archivos separados por coma (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Fecha</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Direccion </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Enviar monedas</translation>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_et.ts
+++ b/src/qt/locale/bitcoin_et.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Levitatud MIT/X11 tarkvara litsentsi all, vaata kaasasolevat faili COPYING või 
 Toode sisaldab OpenSSL Projekti all toodetud tarkvara, mis on kasutamiseks OpenSSL Toolkitis (http://www.openssl.org/) ja Eric Young&apos;i poolt loodud krüptograafilist tarkvara (eay@cryptsoft.com) ning Thomas Bernard&apos;i loodud UPnP tarkvara.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Autoriõigus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Topeltklõps aadressi või märgise muutmiseks</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Loo uus aadress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopeeri märgistatud aadress vahemällu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Aadressi kopeerimine</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Kustuta märgistatud aadress loetelust</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Kustuta</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Need on sinu Bitcoini aadressid maksete saatmiseks. Müntide saatmisel kontrolli alati summat ning saaja aadressi.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>&amp;Märgise kopeerimine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Muuda</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Komaeraldatud fail (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ Toode sisaldab OpenSSL Projekti all toodetud tarkvara, mis on kasutamiseks OpenS
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Silt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Aadress</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(silti pole)</translation>
     </message>
@@ -187,140 +153,106 @@ Toode sisaldab OpenSSL Projekti all toodetud tarkvara, mis on kasutamiseks OpenS
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Salafraasi dialoog</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Sisesta salafraas</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Uus salafraas</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Korda salafraasi</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Sisesta rahakotile uus salafraas.&lt;br/&gt;Palun kasuta salafraasina &lt;b&gt;vähemalt 10 tähte/numbrit/sümbolit&lt;/b&gt;, või &lt;b&gt;vähemalt 8 sõna&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Krüpteeri rahakott</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>See toiming nõuab sinu rahakoti salafraasi.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Tee rahakott lukust lahti.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>See toiming nõuab sinu rahakoti salafraasi.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dekrüpteeri rahakott.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Muuda salafraasi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Sisesta rahakoti vana ning uus salafraas.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Kinnita rahakoti krüpteering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Hoiatus: Kui sa kaotad oma, rahakoti krüpteerimisel kasutatud, salafraasi, siis &lt;b&gt;KAOTAD KA KÕIK OMA BITCOINID&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Kas soovid oma rahakoti krüpteerida?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>TÄHTIS: Kõik varasemad rahakoti varundfailid tuleks üle kirjutada äsja loodud krüpteeritud rahakoti failiga. Turvakaalutlustel tühistatakse krüpteerimata rahakoti failid alates uue, krüpteeritud rahakoti, kasutusele võtust.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Hoiatus: Caps Lock on sisse lülitatud!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Rahakott krüpteeritud</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin sulgub krüpteeringu lõpetamiseks. Pea meeles, et rahakoti krüpteerimine ei välista bitcoinide vargust, kui sinu arvuti on nakatunud pahavaraga.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Tõrge rahakoti krüpteerimisel</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Rahakoti krüpteering ebaõnnestus tõrke tõttu. Sinu rahakotti ei krüpteeritud.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Salafraasid ei kattu.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Rahakoti avamine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Rahakoti salafraas ei ole õige.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Rahakoti dekrüpteerimine ei õnnestunud</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Rahakoti salafraasi muutmine õnnestus.</translation>
     </message>
@@ -328,362 +260,286 @@ Toode sisaldab OpenSSL Projekti all toodetud tarkvara, mis on kasutamiseks OpenS
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Signeeri &amp;sõnum</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Võrgusünkimine...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Ülevaade</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Kuva rahakoti üld-ülevaade</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Tehingud</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Sirvi tehingute ajalugu</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>V&amp;älju</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Väljumine</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Kuva info Bitcoini kohta</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Teave &amp;Qt kohta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Kuva Qt kohta käiv info</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Valikud...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Krüpteeri Rahakott</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Varunda Rahakott</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Salafraasi muutmine</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Impordi blokid kettalt...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Kettal olevate blokkide re-indekseerimine...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Saada münte Bitcoini aadressile</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Muuda Bitcoini seadeid</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Varunda rahakott teise asukohta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Rahakoti krüpteerimise salafraasi muutmine</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Debugimise aken</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Ava debugimise ja diagnostika konsool</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Kontrolli sõnumit...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Rahakott</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Saada</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Saama</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Näita / Peida</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Näita või peida peaaken</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Krüpteeri oma rahakoti privaatvõtmed</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Omandi tõestamiseks allkirjasta sõnumid oma Bitcoini aadressiga</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Kinnita sõnumid kindlustamaks et need allkirjastati määratud Bitcoini aadressiga</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Fail</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Seaded</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Abi</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Vahelehe tööriistariba</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoini tuumik</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoini klient</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktiivne ühendus Bitcoini võrku</numerusform><numerusform>%n aktiivset ühendust Bitcoini võrku</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Protsessitud %1 (arvutuslikult) tehingu ajaloo blokki %2-st.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Protsessitud %1 tehingute ajaloo blokki.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n tund</numerusform><numerusform>%n tundi</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n päev</numerusform><numerusform>%n päeva</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n nädal</numerusform><numerusform>%n nädalat</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 maas</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Viimane saabunud blokk loodi %1 tagasi.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Peale seda ei ole tehingud veel nähtavad.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Tõrge</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Hoiatus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informatsioon</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Ajakohane</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Jõuan...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Saadetud tehing</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Sisenev tehing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -695,17 +551,14 @@ Tüüp: %3⏎
 Aadress: %4⏎</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Rahakott on &lt;b&gt;krüpteeritud&lt;/b&gt; ning hetkel &lt;b&gt;avatud&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Rahakott on &lt;b&gt;krüpteeritud&lt;/b&gt; ning hetkel &lt;b&gt;suletud&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Ilmnes kriitiline tõrge. Bitcoin suletakse turvakaalutluste tõttu.</translation>
     </message>
@@ -713,7 +566,6 @@ Aadress: %4⏎</translation>
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Võrgu Häire</translation>
     </message>
@@ -721,291 +573,230 @@ Aadress: %4⏎</translation>
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Summa:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Kogus</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Aadress</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Kuupäev</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Kinnitatud</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Aadressi kopeerimine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Märgise kopeerimine</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopeeri summa</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopeeri tehingu ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(silti pole)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1013,67 +804,54 @@ Aadress: %4⏎</translation>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Muuda aadressi</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Märgis</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Aadress</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Uus sissetulev aadress</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Uus väljaminev aadress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Sissetulevate aadresside muutmine</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Väljaminevate aadresside muutmine</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Selline aadress on juba olemas: &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Sisestatud aadress &quot;%1&quot; ei ole Bitcoinis kehtiv.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Rahakotti ei avatud</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Tõrge uue võtme loomisel.</translation>
     </message>
@@ -1081,27 +859,22 @@ Aadress: %4⏎</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1109,52 +882,46 @@ Aadress: %4⏎</translation>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoini tuumik</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versioon</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Kasutus:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>käsurea valikud</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI valikud</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Keele valik, nt &quot;ee_ET&quot; (vaikeväärtus: system locale)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Käivitu tegumiribale</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Käivitamisel teabeakna kuvamine (vaikeväärtus: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1162,57 +929,46 @@ Aadress: %4⏎</translation>
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1220,27 +976,22 @@ Aadress: %4⏎</translation>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1248,253 +999,206 @@ Aadress: %4⏎</translation>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Valikud</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>%Peamine</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Tasu tehingu &amp;fee</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Käivita Bitcoin süsteemi logimisel.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Start Bitcoin sisselogimisel</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Taasta kõik klientprogrammi seadete vaikeväärtused.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Lähtesta valikud</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Võrk</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Bitcoini kliendi pordi automaatne avamine ruuteris. Toimib, kui sinu ruuter aktsepteerib UPnP ühendust.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Suuna port &amp;UPnP kaudu</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxi &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Proxi port (nt 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>Turva proxi SOCKS &amp;Version:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Turva proxi SOCKS versioon (nt 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Aken</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Minimeeri systray alale.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimeeri systray alale</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Sulgemise asemel minimeeri aken. Selle valiku tegemisel suletakse programm Menüüst &quot;Välju&quot; käsuga.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimeeri sulgemisel</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Kuva</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Kasutajaliidese &amp;keel:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Kasutajaliidese keele valimise koht. Valik rakendub Bitcoini käivitamisel.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Summade kuvamise &amp;Unit:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Vali liideses ning müntide saatmisel kuvatav vaikimisi alajaotus.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Kuvada Bitcoini aadress tehingute loetelus või mitte.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>Tehingute loetelu &amp;Display aadress</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Katkesta</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>vaikeväärtus</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Kinnita valikute algseadistamine</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Sisestatud kehtetu proxy aadress.</translation>
     </message>
@@ -1502,69 +1206,54 @@ Aadress: %4⏎</translation>
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Vorm</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Kuvatav info ei pruugi olla ajakohane. Ühenduse loomisel süngitakse sinu rahakott automaatselt Bitconi võrgustikuga, kuid see toiming on hetkel lõpetamata.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Rahakott</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Ebaküps:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Mitte aegunud mine&apos;itud jääk</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Uuesti saadetud tehingud&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>sünkimata</translation>
     </message>
@@ -1572,93 +1261,70 @@ Aadress: %4⏎</translation>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI käsitsemine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI ei suudeta parsida. Põhjuseks võib olla kehtetu Bitcoini aadress või vigased URI parameetrid.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Bitcoin ei käivitu: vajuta-maksa toiming</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1666,23 +1332,22 @@ Aadress: %4⏎</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Sisesta Bitcoini aadress (nt: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1690,22 +1355,18 @@ Aadress: %4⏎</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Salvesta QR kood</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1713,192 +1374,146 @@ Aadress: %4⏎</translation>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Kliendi nimi</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Kliendi versioon</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informatsioon</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Kasutan OpenSSL versiooni</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Käivitamise hetk</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Võrgustik</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Ühenduste arv</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Ploki jada</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Plokkide hetkearv</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Ligikaudne plokkide kogus</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Viimane ploki aeg</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Ava</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsool</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Valmistusaeg</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Debugimise logifail</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Ava Bitcoini logifail praegusest andmekaustast. Toiminguks võib kuluda kuni mõni sekund.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Puhasta konsool</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Teretulemast Bitcoini RPC konsooli.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Ajaloo sirvimiseks kasuta üles ja alla nooli, ekraani puhastamiseks &lt;b&gt;Ctrl-L&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Ülevaateks võimalikest käsklustest trüki &lt;b&gt;help&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1906,105 +1521,82 @@ Aadress: %4⏎</translation>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Märgis</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Märgise kopeerimine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopeeri summa</translation>
     </message>
@@ -2012,67 +1604,54 @@ Aadress: %4⏎</translation>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Aadress</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Kogus</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Silt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Sõnum</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Tulemuseks on liiga pikk URL, püüa lühendada märgise/teate teksti.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Tõrge URI&apos;st QR koodi loomisel</translation>
     </message>
@@ -2080,37 +1659,30 @@ Aadress: %4⏎</translation>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Kuupäev</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Silt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Sõnum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Kogus</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(silti pole)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2118,247 +1690,194 @@ Aadress: %4⏎</translation>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Müntide saatmine</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Summa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Saatmine mitmele korraga</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Lisa &amp;Saaja</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Puhasta &amp;Kõik</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Jääk:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Saatmise kinnitamine</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>S&amp;aada</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Müntide saatmise kinnitamine</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopeeri summa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Saaja aadress ei ole kehtiv, palun kontrolli.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Makstav summa peab olema suurem kui 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Summa ületab jäägi.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Summa koos tehingu tasuga %1 ületab sinu jääki.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Ühe saatmisega topelt-adressaati olla ei tohi.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(silti pole)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2366,98 +1885,74 @@ Aadress: %4⏎</translation>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>S&amp;umma:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Maksa &amp;:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Tehingu saaja aadress (nt: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Aadressiraamatusse sisestamiseks märgista aadress</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Märgis</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Kleebi aadress vahemälust</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Sõnum:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2465,12 +1960,10 @@ Aadress: %4⏎</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2478,186 +1971,142 @@ Aadress: %4⏎</translation>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Signatuurid - Allkirjasta / Kinnita Sõnum</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Allkirjastamise teade</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Omandiõigsuse tõestamiseks saad sõnumeid allkirjastada oma aadressiga. Ettevaatust petturitega, kes üritavad saada sinu allkirja endale saada. Allkirjasta ainult korralikult täidetud avaldusi, millega nõustud.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Sõnumi signeerimise aadress (nt: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Kleebi aadress vahemälust</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Sisesta siia allkirjastamise sõnum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Signatuur</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Kopeeri praegune signatuur vahemällu</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Allkirjasta sõnum Bitcoini aadressi sulle kuulumise tõestamiseks</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Allkirjasta &amp;Sõnum</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Tühjenda kõik sõnumi allkirjastamise väljad</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Puhasta &amp;Kõik</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Kinnita Sõnum</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Kinnitamiseks sisesta allkirjastamise aadress, sõnum (kindlasti kopeeri täpselt ka reavahetused, tühikud, tabulaatorid jms) ning allolev signatuur.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Aadress, millega sõnum allkirjastati (nt: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Kinnita sõnum tõestamaks selle allkirjastatust määratud Bitcoini aadressiga.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Kinnita &amp;Sõnum</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Tühjenda kõik sõnumi kinnitamise väljad</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Sisesta Bitcoini aadress (nt: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Signatuuri genereerimiseks vajuta &quot;Allkirjasta Sõnum&quot;</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Sisestatud aadress ei kehti.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Palun kontrolli aadressi ning proovi uuesti.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Sisestatud aadress ei viita võtmele.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Rahakoti avamine katkestati.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Sisestatud aadressi privaatvõti ei ole saadaval.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Sõnumi signeerimine ebaõnnestus.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Sõnum signeeritud.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Signatuuri ei õnnestunud dekodeerida.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Palun kontrolli signatuuri ning proovi uuesti.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Signatuur ei kattunud sõnumi kokkuvõttega.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Sõnumi kontroll ebaõnnestus.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Sõnum kontrollitud.</translation>
     </message>
@@ -2665,17 +2114,14 @@ Aadress: %4⏎</translation>
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoini tuumik</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,7 +2129,6 @@ Aadress: %4⏎</translation>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2691,184 +2136,138 @@ Aadress: %4⏎</translation>
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Avatud kuni %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%/1offline&apos;is</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/kinnitamata</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 kinnitust</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Staatus</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, levita läbi %n node&apos;i</numerusform><numerusform>, levita läbi %n node&apos;i</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Kuupäev</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Allikas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Genereeritud</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Saatja</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Saaja</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>oma aadress</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>märgis</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Krediit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>aegub %n bloki pärast</numerusform><numerusform>aegub %n bloki pärast</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>mitte aktsepteeritud</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Deebet</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Tehingu tasu</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Neto summa</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Sõnum</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Kommentaar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Tehingu ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Debug&apos;imise info</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Tehing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Sisendid</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Kogus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>õige</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>vale</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, veel esitlemata</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Avaneb %n bloki pärast</numerusform><numerusform>Avaneb %n bloki pärast</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>tundmatu</translation>
     </message>
@@ -2876,12 +2275,10 @@ Aadress: %4⏎</translation>
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Tehingu üksikasjad</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Paan kuvab tehingu detailid</translation>
     </message>
@@ -2889,127 +2286,102 @@ Aadress: %4⏎</translation>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Kuupäev</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tüüp</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Aadress</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Kogus</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Avaneb %n bloki pärast</numerusform><numerusform>Avaneb %n bloki pärast</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Avatud kuni %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Kinnitatud (%1 kinnitust)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Antud klotsi pole saanud ükski osapool ning tõenäoliselt seda ei aktsepteerita!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Loodud, kuid aktsepteerimata</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Saadud koos</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Kellelt saadud</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Saadetud</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Makse iseendale</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Mine&apos;itud</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Tehingu staatus. Kinnituste arvu kuvamiseks liigu hiire noolega selle peale.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Tehingu saamise kuupäev ning kellaaeg.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tehingu tüüp.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Tehingu saaja aadress.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Jäägile lisatud või eemaldatud summa.</translation>
     </message>
@@ -3017,178 +2389,142 @@ Aadress: %4⏎</translation>
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Kõik</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Täna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Jooksev nädal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Jooksev kuu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Eelmine kuu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Jooksev aasta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Ulatus...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Saadud koos</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Saadetud</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Iseendale</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Mine&apos;itud</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Muu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Otsimiseks sisesta märgis või aadress</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Vähim summa</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Aadressi kopeerimine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Märgise kopeerimine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopeeri summa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopeeri tehingu ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Märgise muutmine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Kuva tehingu detailid</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Komaeraldatud fail (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Kinnitatud</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Kuupäev</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tüüp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Silt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Aadress</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Kogus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Ulatus:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>saaja</translation>
     </message>
@@ -3196,7 +2532,6 @@ Aadress: %4⏎</translation>
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,7 +2539,6 @@ Aadress: %4⏎</translation>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3212,42 +2546,34 @@ Aadress: %4⏎</translation>
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Varundatud Rahakott</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Rahakoti andmed (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Varundamine nurjus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Varundamine õnnestus</translation>
     </message>
@@ -3255,107 +2581,86 @@ Aadress: %4⏎</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Kasutus:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Käskluste loetelu</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Käskluste abiinfo</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Valikud:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Täpsusta sätete fail (vaikimisi: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Täpsusta PID fail (vaikimisi: bitcoin.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Täpsusta andmekataloog</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Sea andmebaasi vahemälu suurus MB (vaikeväärtus: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Kuula ühendusi pordil &lt;port&gt; (vaikeväärtus: 8333 või testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Säilita vähemalt &lt;n&gt; ühendust peeridega (vaikeväärtus: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Peeri aadressi saamiseks ühendu korraks node&apos;iga</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Täpsusta enda avalik aadress</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Ulakate peeride valulävi (vaikeväärtus: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Mitme sekundi pärast ulakad peerid tagasi võivad tulla (vaikeväärtus: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>RPC pordi %u kuulamiseks seadistamisel ilmnes viga IPv4&apos;l: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Kuula JSON-RPC ühendusel seda porti &lt;port&gt; (vaikeväärtus: 8332 või testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Luba käsurea ning JSON-RPC käsklusi</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Tööta taustal ning aktsepteeri käsklusi</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Testvõrgu kasutamine</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Luba välisühendusi (vaikeväärtus: 1 kui puudub -proxy või -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3380,722 +2685,682 @@ nt: alertnotify=echo %%s | email -s &quot;Bitcoin Alert&quot; admin@foo.com
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>RPC pordi %u kuulamiseks seadistamisel ilmnes viga IPv6&apos;l, lülitumine tagasi IPv4&apos;le : %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Määratud aadressiga sidumine ning sellelt kuulamine. IPv6 jaoks kasuta vormingut [host]:port</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Ei suuda määrata ainuõigust andmekaustale %s. Tõenäolisel on Bitcoin juba avatud.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Tõrge: Tehingust keelduti! Põhjuseks võib olla juba kulutatud mündid, nt kui wallet.dat fail koopias kulutatid mündid, kuid ei märgitud neid siin vastavalt.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Tõrge: Selle tehingu jaoks on nõutav lisatasu vähemalt %s. Põhjuseks võib olla summa suurus, keerukus või hiljuti saadud summade kasutamine!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Käivita käsklus, kui rahakoti tehing muutub (%s cmd&apos;s muudetakse TxID&apos;ks)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>See on test-versioon - kasutamine omal riisikol - ära kasuta mining&apos;uks ega kaupmeeste programmides</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Hoiatus: -paytxfee on seatud väga kõrgeks! See on sinu poolt makstav tehingu lisatasu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Hoiatus: Palun kontrolli oma arvuti kuupäeva/kellaaega! Kui arvuti kell on vale, siis Bitcoin ei tööta korralikult</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Hoiatus: ilmnes tõrge wallet.dat faili lugemisel! Võtmed on terved, kuid tehingu andmed või aadressiraamatu kirjed võivad olla kadunud või vigased.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Hoiatus: toimus wallet.dat faili andmete päästmine! Originaal wallet.dat nimetati kaustas %s ümber wallet.{ajatempel}.bak&apos;iks, jäägi või tehingute ebakõlade puhul tuleks teha backup&apos;ist taastamine.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Püüa vigasest wallet.dat failist taastada turvavõtmed</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Blokeeri loomise valikud:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Ühendu ainult määratud node&apos;i(de)ga</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Tuvastati vigane bloki andmebaas</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Leia oma IP aadress (vaikeväärtus: 1, kui kuulatakse ning puudub -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Kas soovid bloki andmebaasi taastada?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Tõrge bloki andmebaasi käivitamisel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Tõrge rahakoti keskkonna %s käivitamisel!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Tõrge bloki baasi lugemisel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Tõrge bloki andmebaasi avamisel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Tõrge: liiga vähe kettaruumi!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Tõrge: Rahakott on lukus, tehingu loomine ei ole võimalik!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Tõrge: süsteemi tõrge:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Pordi kuulamine nurjus. Soovikorral kasuta -listen=0.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Tõrge bloki sisu lugemisel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Bloki lugemine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Bloki indeksi sünkimine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Bloki indeksi kirjutamine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Bloki sisu kirjutamine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Tõrge bloki sisu kirjutamisel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Tõrge faili info kirjutamisel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Tõrge mündi andmebaasi kirjutamisel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Tehingu indeksi kirjutamine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Tagasivõtmise andmete kirjutamine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Otsi DNS&apos;i lookup&apos;i kastavaid peere (vaikeväärtus: 1, kui mitte -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Käivitamisel kontrollitavate blokkide arv (vaikeväärtus: 288, 0=kõik)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Blokkide kontrollimise põhjalikkus (0-4, vaikeväärtus: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Taasta bloki jada indeks blk000??.dat failist</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Määra RPC kõnede haldurite arv (vaikeväärtus: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Kontrollin blokke...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Kontrollin rahakotti...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Impordi blokid välisest blk000??.dat failist</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informatsioon</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Säilita kogu tehingu indeks (vaikeväärtus: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maksimaalne saamise puhver -connection kohta , &lt;n&gt;*1000 baiti (vaikeväärtus: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maksimaalne saatmise puhver -connection kohta , &lt;n&gt;*1000 baiti (vaikeväärtus: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Tunnusta ainult sisseehitatud turvapunktidele vastavaid bloki jadu (vaikeväärtus: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Ühenda ainult node&apos;idega &lt;net&gt; võrgus (IPv4, IPv6 või Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL valikud: (vaata Bitcoini Wikist või SSL sätete juhendist)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Saada jälitus/debug, debug.log faili asemel, konsooli</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Sea minimaalne bloki suurus baitides (vaikeväärtus: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Kahanda programmi käivitamisel debug.log faili (vaikeväärtus: 1, kui ei ole -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Sea ühenduse timeout millisekundites (vaikeväärtus: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Süsteemi tõrge:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Kasuta kuulatava pordi määramiseks UPnP ühendust (vaikeväärtus: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Kasuta kuulatava pordi määramiseks UPnP ühendust (vaikeväärtus: 1, kui kuulatakse)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>JSON-RPC ühenduste kasutajatunnus</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Hoiatus</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Hoiatus: versioon on aegunud, uuendus on nõutav!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>versioon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat fail on katki, päästmine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>JSON-RPC ühenduste salasõna</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>JSON-RPC ühenduste lubamine kindla IP pealt</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Saada käsklusi node&apos;ile IP&apos;ga &lt;ip&gt; (vaikeväärtus: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Käivita käsklus, kui parim plokk muutub (käskluse %s asendatakse ploki hash&apos;iga)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Uuenda rahakott uusimasse vormingusse</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Sea võtmete hulgaks &lt;n&gt; (vaikeväärtus: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Otsi ploki jadast rahakoti kadunud tehinguid</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Kasuta JSON-RPC ühenduste jaoks OpenSSL&apos;i (https)</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Serveri sertifikaadifail (vaikeväärtus: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Serveri privaatvõti (vaikeväärtus: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Käesolev abitekst</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Selle arvutiga ei ole võimalik siduda %s külge (katse nurjus %d, %s tõttu)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>-addnode, -seednode ja -connect tohivad kasutada DNS lookup&apos;i</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Aadresside laadimine...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Viga wallet.dat käivitamisel. Vigane rahakkott</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Viga wallet.dat käivitamisel: Rahakott nõuab Bitcoini uusimat versiooni</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Rahakott tuli ümberkirjutada: toimingu lõpetamiseks taaskäivita Bitcoin</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Viga wallet.dat käivitamisel</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Vigane -proxi aadress: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Kirjeldatud tundmatu võrgustik -onlynet&apos;is: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Küsitud tundmatu -socks proxi versioon: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Tundmatu -bind aadress: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Tundmatu -externalip aadress: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-paytxfee=&lt;amount&gt; jaoks vigane kogus: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Kehtetu summa</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Liiga suur summa</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Klotside indeksi laadimine...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Lisa node ning hoia ühendus avatud</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>%s&apos;ga ei ole võimalik sellest arvutist siduda. Bitcoin juba töötab.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Rahakoti laadimine...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Rahakoti vanandamine ebaõnnestus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Tõrge vaikimisi aadressi kirjutamisel</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Üleskaneerimine...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Laetud</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>%s valiku kasutamine</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Tõrge</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_eu_ES.ts
+++ b/src/qt/locale/bitcoin_eu_ES.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Klik bikoitza helbidea edo etiketa editatzeko</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Sortu helbide berria</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopiatu hautatutako helbidea sistemaren arbelera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Ezabatu</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Komaz bereizitako artxiboa (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiketa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Helbidea</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(etiketarik ez)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Sartu pasahitza</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Pasahitz berria</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Errepikatu pasahitz berria</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Sartu zorrorako pasahitz berria.&lt;br/&gt; Mesedez erabili &lt;b&gt;gutxienez ausazko 10 karaktere&lt;/b&gt;, edo &lt;b&gt;gutxienez zortzi hitz&lt;/b&gt; pasahitza osatzeko.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Enkriptatu zorroa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Eragiketa honek zorroaren pasahitza behar du zorroa desblokeatzeko.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desblokeatu zorroa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Eragiketa honek zure zorroaren pasahitza behar du, zorroa desenkriptatzeko.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Desenkriptatu zorroa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Aldatu pasahitza</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Sartu zorroaren pasahitz zaharra eta berria.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Berretsi zorroaren enkriptazioa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Zorroa enkriptatuta</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Zorroaren enkriptazioak huts egin du</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Zorroaren enkriptazioak huts egin du barne-errore baten ondorioz. Zure zorroa ez da enkriptatu.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Eman dituzun pasahitzak ez datoz bat.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Zorroaren desblokeoak huts egin du</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Zorroa desenkriptatzeko sartutako pasahitza okerra da.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Zorroaren desenkriptazioak huts egin du</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sarearekin sinkronizatzen...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Gainbegiratu</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Ikusi zorroaren begirada orokorra</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transakzioak</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Ikusi transakzioen historia</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>Irten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Irten aplikaziotik</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Erakutsi Bitcoin-i buruzko informazioa</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>&amp;Qt-ari buruz</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Erakutsi Bitcoin-i buruzko informazioa</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Aukerak...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Aldatu zorroa enkriptatzeko erabilitako pasahitza</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Artxiboa</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ezarpenak</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Laguntza</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Fitxen tresna-barra</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>Konexio aktibo %n Bitcoin-en sarera</numerusform><numerusform>%n konexio aktibo Bitcoin-en sarera</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Egunean</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Eguneratzen...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Bidalitako transakzioa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Sarrerako transakzioa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Zorroa &lt;b&gt;enkriptatuta&lt;/b&gt; eta &lt;b&gt;desblokeatuta&lt;/b&gt; dago une honetan</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Zorroa &lt;b&gt;enkriptatuta&lt;/b&gt; eta &lt;b&gt;blokeatuta&lt;/b&gt; dago une honetan</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Kopurua</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Kopurua</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Helbidea</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopiatu helbidea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopiatu etiketa</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(etiketarik ez)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editatu helbidea</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiketa</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Helbidea</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Jasotzeko helbide berria</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Bidaltzeko helbide berria</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editatu jasotzeko helbidea</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editatu bidaltzeko helbidea</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Sartu berri den helbidea, &quot;%1&quot;, helbide-liburuan dago jadanik.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Ezin desblokeatu zorroa.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Gako berriaren sorrerak huts egin du.</translation>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Aukerak</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Inprimakia</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Azken transakzioak&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Sartu Bitocin helbide bat (adb.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L) </translation>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiketa:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopiatu etiketa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Helbidea</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Kopurua</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiketa</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiketa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Kopurua</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(etiketarik ez)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Bidali txanponak</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Kopurua</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Bidali hainbat jasotzaileri batera</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Saldoa:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Berretsi bidaltzeko ekintza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Berretsi txanponak bidaltzea</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Ordaintzeko kopurua 0 baino handiagoa izan behar du.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(etiketarik ez)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>K&amp;opurua:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Ordaindu &amp;honi:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Sartu etiketa bat helbide honetarako, eta gehitu zure helbide-liburuan</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiketa:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Itsatsi helbidea arbeletik</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Mezua</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Itsatsi helbidea arbeletik</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Sartu Bitocin helbide bat (adb.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L) </translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Zabalik %1 arte</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/konfirmatu gabe</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 konfirmazioak</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Kopurua</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, ez da arrakastaz emititu oraindik</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>ezezaguna</translation>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Transakzioaren xehetasunak</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Panel honek transakzioaren deskribapen xehea erakusten du</translation>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Mota</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Helbidea</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Kopurua</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Zabalik %1 arte</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Konfirmatuta (%1 konfirmazio)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Bloke hau ez du beste inongo nodorik jaso, eta seguruenik ez da onartuko!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Sortua, baina ez onartua</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Jasoa honekin: </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Honi bidalia: </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Ordainketa zeure buruari</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Bildua</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transakzioaren egoera. Pasatu sagua gainetik konfirmazio kopurua ikusteko.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Transakzioa jasotako data eta ordua.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Transakzio mota.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Transakzioaren xede-helbidea.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Saldoan kendu edo gehitutako kopurua.</translation>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Denak</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Gaur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Aste honetan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Hil honetan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Azken hilean</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Aurten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Muga...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Jasota honekin: </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Hona bidalia: </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Zeure buruari</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Bildua</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Beste</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Sartu bilatzeko helbide edo etiketa</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Kopuru minimoa</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopiatu helbidea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopiatu etiketa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Komaz bereizitako artxiboa (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Mota</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiketa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Helbidea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Kopurua</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Komandoen lista</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Laguntza komando batean</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Aukerak</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Ezarpen fitxategia aukeratu (berezkoa: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>pid fitxategia aukeratu (berezkoa: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Laguntza mezu hau</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Birbilatzen...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Zamaketa amaitua</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_fa.ts
+++ b/src/qt/locale/bitcoin_fa.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation>⏎ ⏎ این یک نرم‌افزار آزمایشی است⏎ ⏎ نرم افزار تحت مجوز MIT/X11 منتشر شده است. پروندهٔ COPYING یا نشانی http://www.opensource.org/licenses/mit-license.php. را ببینید⏎ ⏎ این محصول شامل نرم‌افزار  توسعه داده‌شده در پروژهٔ OpenSSL است. در این نرم‌افزار از OpenSSL Toolkit (http://www.openssl.org/) و نرم‌افزار رمزنگاری نوشته شده توسط اریک یانگ (eay@cryptsoft.com) و UPnP توسط توماس برنارد استفاده شده است.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>حق تألیف</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>برای ویرایش نشانی یا برچسب دوبار کلیک کنید</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>ایجاد نشانی جدید</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>نشانی انتخاب شده را در حافظهٔ سیستم کپی کن!</translation>
+        <translation>کپی نشانی انتخاب شده به حافظهٔ سیستم</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;کپی نشانی</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>حذف نشانی انتخاب‌شده از لیست</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>خروجی گرفتن داده‌های برگهٔ فعلی به یک پرونده</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;صدور</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;حذف</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>این‌ها نشانی‌های بیت‌کوین شما برای ارسال وجود هستند. همیشه قبل از ارسال سکه‌ها، نشانی دریافت‌کننده و مقدار ارسالی را بررسی کنید.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>کپی و برچسب‌&amp;گذاری</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;ویرایش</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>پروندهٔ نوع CSV جداشونده با کاما (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
-        <translation>نشانی</translation>
+        <translation>آدرس</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(بدون برچسب)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>پنجرهٔ گذرواژه</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>گذرواژه را وارد کنید</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>گذرواژهٔ جدید</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>تکرار گذرواژهٔ جدید</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>گذرواژهٔ جدید کیف پول خود را وارد کنید.&lt;br/&gt;لطفاً از گذرواژه‌ای با &lt;b&gt;حداقل ۱۰ حرف تصادفی&lt;/b&gt;، یا &lt;b&gt;حداقل هشت کلمه&lt;/b&gt; انتخاب کنید.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>رمزنگاری کیف پول</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>انجام این عملیات نیازمند گذرواژهٔ کیف پول شما برای باز کردن قفل آن است.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>باز کردن قفل کیف پول</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>انجام این عملیات نیازمند گذرواژهٔ کیف پول شما برای رمزگشایی کردن آن است.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>رمزگشایی کیف پول</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>تغییر گذرواژه</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>گذرواژهٔ قدیمی و جدید کیف پول را وارد کنید.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>تأیید رمزنگاری کیف پول</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>هشدار: اگر کیف پول خود را رمزنگاری کنید و گذرواژه را فراموش کنید، &lt;b&gt;تمام دارایی بیت‌کوین خود را از دست خواهید داد&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>آیا مطمئن هستید که می‌خواهید کیف پول خود را رمزنگاری کنید؟</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>مهم: هر نسخهٔ پشتیبانی که تا کنون از کیف پول خود تهیه کرده‌اید، باید با کیف پول رمزنگاری شدهٔ جدید جایگزین شود. به دلایل امنیتی، پروندهٔ قدیمی کیف پول بدون رمزنگاری، تا زمانی که از کیف پول رمزنگاری‌شدهٔ جدید استفاده نکنید، غیرقابل استفاده خواهد بود.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>هشدار: کلید Caps Lock روشن است!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>کیف پول رمزنگاری شد</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>بیت‌کوین هم اکنون بسته می‌شود تا فرایند رمزگذاری را تمام کند. به خاطر داشته باشید که رمزگذاری کردن کیف پول‌تان نمی‌تواند به طور کامل بیت‌کوین‌های شما را در برابر دزدیده شدن توسط بدافزارهایی که احتمالاً رایانهٔ شما را آلوده می‌کنند، محافظت نماید.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
-        <translation>رمزنگاری کیف پول با خطا مواجه شد</translation>
+        <translation>رمزنگاری کیف پول با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>رمزنگاری کیف پول بنا به یک خطای داخلی با شکست مواجه شد. کیف پول شما رمزنگاری نشد.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>گذرواژه‌های داده شده با هم تطابق ندارند.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>بازگشایی قفل کیف‌پول با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>گذرواژهٔ وارد شده برای رمزگشایی کیف پول نادرست بود.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>رمزگشایی ناموفق کیف پول</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>گذرواژهٔ کیف پول با موفقیت عوض شد.</translation>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;امضای پیام...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>همگام‌سازی با شبکه...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;بررسی اجمالی</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>نمایش بررسی اجمالی کیف پول</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;تراکنش‌ها</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>مرور تاریخچهٔ تراکنش‌ها</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;خروج</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>خروج از برنامه</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>نمایش اطلاعات در مورد بیت‌کوین</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>دربارهٔ &amp;کیوت</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>نمایش اطلاعات دربارهٔ کیوت</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;تنظیمات...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;رمزنگاری کیف پول...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;پیشتیبان‌گیری از کیف پول...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;تغییر گذرواژه...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>دریافت بلوک‌ها از دیسک...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>بازنشانی بلوک‌ها روی دیسک...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>ارسال وجه به نشانی بیت‌کوین</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>تغییر و اصلاح تنظیمات پیکربندی بیت‌کوین</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>تهیهٔ پشتیبان از کیف پول در یک مکان دیگر</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>تغییر گذرواژهٔ مورد استفاده در رمزنگاری کیف پول</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>پنجرهٔ ا&amp;شکال‌زدایی</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>باز کردن کنسول خطایابی و اشکال‌زدایی</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>با&amp;زبینی پیام...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>بیت‌کوین</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>کیف پول</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;ارسال</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;دریافت</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;نمایش/ عدم نمایش</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>نمایش یا مخفی‌کردن پنجرهٔ اصلی</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>رمزنگاری کلیدهای خصوصی متعلق به کیف پول شما</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>برای اثبات اینکه پیام‌ها به شما تعلق دارند، آن‌ها را با نشانی بیت‌کوین خود امضا کنید</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>برای حصول اطمینان از اینکه پیام با نشانی بیت‌کوین مشخص شده امضا است یا خیر، پیام را شناسایی کنید</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
-        <translation>&amp;پرونده</translation>
+        <translation>&amp;فایل</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;تنظیمات</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;کمک‌رسانی</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>نوارابزار برگه‌ها</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[شبکهٔ آزمایش]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation> هسته Bitcoin </translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>کلاینت بیت‌کوین</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n ارتباط فعال با شبکهٔ بیت‌کوین</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>منبعی برای دریافت بلاک در دسترس نیست...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>%1 بلاک از مجموع %2 بلاک (تخمینی) تاریخچهٔ تراکنش‌ها پردازش شده است.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>%1 بلاک از تاریخچهٔ تراکنش‌ها پردازش شده است.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n ساعت</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n روز</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n هفته</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 عقب‌تر</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>آخرین بلاک دریافتی %1 پیش ایجاد شده است.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>تراکنش‌های بعد از این هنوز قابل مشاهده نیستند.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>خطا</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>هشدار</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>اطلاعات</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>وضعیت به‌روز</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>به‌روز رسانی...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>تراکنش ارسال شد</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>تراکنش دریافت شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -691,17 +547,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>کیف پول &lt;b&gt;رمزنگاری شده&lt;/b&gt; است و هم‌اکنون &lt;b&gt;باز&lt;/b&gt; است</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>کیف پول &lt;b&gt;رمزنگاری شده&lt;/b&gt; است و هم‌اکنون &lt;b&gt;قفل&lt;/b&gt; است</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>یک خطای مهلک اتفاق افتاده است. بیت‌کوین نمی‌تواند بدون مشکل به کار خود ادامه دهد و بسته خواهد شد.</translation>
     </message>
@@ -709,7 +562,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>پیام شبکه</translation>
     </message>
@@ -717,291 +569,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>مبلغ:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>مبلغ</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>نشانی</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>تأیید شده</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>کپی نشانی</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>کپی برچسب</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>کپی مقدار</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>کپی شناسهٔ تراکنش</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(بدون برچسب)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1009,67 +800,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>ویرایش نشانی</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;برچسب</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;نشانی</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>نشانی دریافتی جدید</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>نشانی ارسالی جدید</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>ویرایش نشانی دریافتی</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>ویرایش نشانی ارسالی</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>نشانی وارد شده «%1» در حال حاضر در دفترچه وجود دارد.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>نشانی وارد شده «%1» یک نشانی معتبر بیت‌کوین نیست.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>نمی‌توان کیف پول را رمزگشایی کرد.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>ایجاد کلید جدید با شکست مواجه شد.</translation>
     </message>
@@ -1077,27 +855,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>یک مسیر دادهٔ جدید ایجاد خواهد شد.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>نام</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>این پوشه در حال حاضر وجود دارد. اگر می‌خواهید یک دایرکتوری جدید در این‌جا ایجاد کنید، %1 را اضافه کنید.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>مسیر داده شده موجود است و به یک پوشه اشاره نمی‌کند.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>نمی‌توان پوشهٔ داده در این‌جا ایجاد کرد.</translation>
     </message>
@@ -1105,52 +878,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation> هسته Bitcoin </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>نسخه</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>استفاده:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>گزینه‌های خط فرمان</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>گزینه‌های رابط کاربری</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>زبان را تنظیم کنید؛ برای مثال «de_DE» (زبان پیش‌فرض محلی)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>اجرای برنامه به صورت کوچک‌شده</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>نمایش پنجرهٔ خوشامدگویی در ابتدای اجرای برنامه (پیش‌فرض: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>انتخاب مسیر داده‌ها در ابتدای اجرای برنامه (پیش‌فرض: 0)</translation>
     </message>
@@ -1158,57 +925,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>خوش‌آمدید</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>استفاده از مسیر پیش‌فرض</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>استفاده از یک مسیر سفارشی:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>بیت‌کوین</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>خطا: نمی‌توان پوشه‌ای برای داده‌ها در «%1» ایجاد کرد.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>خطا</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>گیگابات فضا موجود است</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(از %1 گیگابایت فضای مورد نیاز)</translation>
     </message>
@@ -1216,27 +972,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1244,253 +995,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>گزینه‌ها</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;عمومی</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>کارمزد اختیاریِ هر کیلوبایت برای انتقال سریع‌تر تراکنش. اکثر تراکنش‌ها ۱ کیلوبایتی هستند.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>پرداخت &amp;کارمزد تراکنش</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>اجرای خودکار بیت‌کوین در زمان ورود به سیستم.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;اجرای بیت‌کوین با ورود به سیستم</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>بازنشانی تمام تنظیمات به پیش‌فرض.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;بازنشانی تنظیمات</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;شبکه</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>باز کردن خودکار درگاه شبکهٔ بیت‌کوین روی روترها. تنها زمانی کار می‌کند که روتر از پروتکل UPnP پشتیبانی کند و این پروتکل فعال باشد.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>نگاشت درگاه شبکه با استفاده از پروتکل &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>آ&amp;ی‌پی پراکسی:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;درگاه:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>درگاه پراکسی (مثال 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;نسخهٔ SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>نسخهٔ پراکسی SOCKS (مثلاً 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;پنجره</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>تنها بعد از کوچک کردن پنجره، tray icon را نشان بده.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;کوچک کردن به سینی به‌جای نوار وظیفه</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>مخفی کردن در نوار کناری به‌جای خروج هنگام بستن پنجره. زمانی که این گزینه فعال است، برنامه فقط با استفاده از گزینهٔ خروج در منو قابل بسته شدن است.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>کوچک کردن &amp;در زمان بسته شدن</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;نمایش</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>زبان &amp;رابط کاربری:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>زبان رابط کاربر می‌تواند در این‌جا تنظیم شود. تنظیمات بعد از ظروع مجدد بیت‌کوین اعمال خواهد شد.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;واحد نمایش مبالغ:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>انتخاب واحد پول مورد استفاده برای نمایش در پنجره‌ها و برای ارسال سکه.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>نمایش یا عدم نمایش نشانی‌های بیت‌کوین در لیست تراکنش‌ها.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>نمایش ن&amp;شانی‌ها در فهرست تراکنش‌ها</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;تأیید</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;لغو</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>پیش‌فرض</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>تأییدِ بازنشانی گزینه‌ها</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>آدرس پراکسی داده شده صحیح نیست.</translation>
     </message>
@@ -1498,69 +1202,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>فرم</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>اطلاعات نمایش‌داده شده ممکن است قدیمی باشند. بعد از این که یک اتصال با شبکه برقرار شد، کیف پول شما به‌صورت خودکار با شبکهٔ بیت‌کوین همگام‌سازی می‌شود. اما این روند هنوز کامل نشده است.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>کیف پول</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>تراز علی‌الحساب شما</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>مجموع تراکنش‌هایی که هنوز تأیید نشده‌اند؛ و هنوز روی تراز علی‌الحساب اعمال نشده‌اند</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>نارسیده:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>تراز استخراج شده از معدن که هنوز بالغ نشده است</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>جمع کل:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>تراز کل فعلی شما</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;تراکنش‌های اخیر&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>ناهمگام</translation>
     </message>
@@ -1568,93 +1257,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>مدیریت URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>نشانی اینترنتی قابل تجزیه و تحلیل نیست! دلیل این وضعیت ممکن است یک نشانی نامعتبر بیت‌کوین و یا پارامترهای ناهنجار در URI بوده باشد.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>نمی‌توان بیت‌کوین را اجرا کرد: کنترل‌کنندهٔ کلیک-و-پرداخت</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1662,23 +1328,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>بیت‌کوین</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>خطا: پوشهٔ مشخص شده برای داده‌ها در «%1» وجود ندارد.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>یک آدرس بیت‌کوین وارد کنید (مثلاً 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1686,22 +1351,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>ذخیرهٔ کد QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1709,192 +1370,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>نام کلاینت</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>ناموجود</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>نسخهٔ کلاینت</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;اطلاعات</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>نسخهٔ OpenSSL استفاده شده</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>زمان آغاز به کار</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>شبکه</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>اسم</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>تعداد ارتباطات</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>زنجیرهٔ بلوک‌ها</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>تعداد فعلی بلوک‌ها</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>تعداد تخمینی بلوک‌ها</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>زمان آخرین بلوک</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>با&amp;ز کردن</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;کنسول</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>ساخت تاریخ</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>فایلِ لاگِ اشکال زدایی</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>فایلِ لاگِ اشکال زدایی Bitcoin  را از دایرکتوری جاری داده ها باز کنید. این عملیات ممکن است برای فایلهای لاگِ حجیم طولانی شود.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>پاکسازی کنسول</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>به کنسور RPC بیت‌کوین خوش آمدید.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>دکمه‌های بالا و پایین برای پیمایش تاریخچه و &lt;b&gt;Ctrl-L&lt;/b&gt; برای پاک کردن صفحه.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>برای نمایش یک مرور کلی از دستورات ممکن، عبارت &lt;b&gt;help&lt;/b&gt; را بنویسید.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1902,105 +1517,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;برچسب:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>کپی برچسب</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>کپی مقدار</translation>
     </message>
@@ -2008,67 +1600,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>کد QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>نشانی</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>مبلغ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>پیام</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URL ایجاد شده خیلی طولانی است. سعی کنید طول برچسب و یا پیام را کمتر کنید.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>خطا در تبدیل نشانی اینترنتی به صورت کد QR.</translation>
     </message>
@@ -2076,37 +1655,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>پیام</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>مبلغ</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(بدون برچسب)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2114,247 +1686,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>ارسال سکه</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>مبلغ:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>ارسال به چند دریافت‌کنندهٔ به‌طور همزمان</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;دریافت‌کنندهٔ جدید</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>پاکسازی &amp;همه</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>تزار:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>عملیات ارسال را تأیید کنید</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;ارسال</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>ارسال سکه را تأیید کنید</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>کپی مقدار</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>نشانی گیرنده معتبر نیست؛ لطفا دوباره بررسی کنید.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>مبلغ پرداخت باید بیشتر از ۰ باشد.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>میزان پرداخت از تراز شما بیشتر است.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>با احتساب هزینهٔ %1 برای هر تراکنش، مجموع میزان پرداختی از مبلغ تراز شما بیشتر می‌شود.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>یک نشانی تکراری پیدا شد. در هر عملیات ارسال، به هر نشانی فقط مبلغ می‌توان ارسال کرد.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(بدون برچسب)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2362,98 +1881,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>A&amp;مبلغ :</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>پرداخ&amp;ت به:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>نشانی مقصد برای پرداخت (مثلاً 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>برای این نشانی یک برچسب وارد کنید تا در دفترچهٔ آدرس ذخیره شود</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;برچسب:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>چسباندن نشانی از حافظهٔ سیستم</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>پیام:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2461,12 +1956,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2474,186 +1967,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>امضاها - امضا / تأیید یک پیام</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>ا&amp;مضای پیام</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>برای احراز اینکه پیام‌ها از جانب شما هستند، می‌توانید آن‌ها را با نشانی خودتان امضا کنید. مراقب باشید چیزی که بدان اطمینان ندارید را امضا نکنید زیرا حملات فیشینگ ممکن است بخواهند از.پیامی با امضای شما سوءاستفاده کنند. تنها مواردی را که حاوی اطلاعات دقیق و قابل قبول برای شما هستند امضا کنید.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>نشانی مورد استفاده برای امضا کردن پیام (برای مثال 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>چسباندن نشانی از حافظهٔ سیستم</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>پیامی را که می‌خواهید امضا کنید در اینجا وارد کنید</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>امضا</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>امضای فعلی را به حافظهٔ سیستم کپی کن</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>برای اثبات تعلق این نشانی به شما، پیام را امضا کنید</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>ا&amp;مضای پیام</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>بازنشانی تمام فیلدهای پیام</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>پاک &amp;کردن همه</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;شناسایی پیام</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>برای شناسایی پیام، نشانیِ امضا کننده و متن پیام را وارد کنید. (مطمئن شوید که فاصله‌ها، تب‌ها و خطوط را عیناً کپی می‌کنید.) مراقب باشید در امضا چیزی بیشتر از آنچه در پیام می‌بینید وجود نداشته باشد تا فریب دزدان اینترنتی و حملات از نوع MITM را نخورید.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>نشانی مورد استفاده برای امضا کردن پیام (برای مثال 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>برای حصول اطمینان از اینکه پیام با نشانی بیت‌کوین مشخص شده امضا است یا خیر، پیام را شناسایی کنید</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>&amp;شناسایی پیام</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>بازنشانی تمام فیلدهای پیام</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>یک نشانی بیت‌کوین وارد کنید (مثلاً 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>برای ایجاد یک امضای جدید روی «امضای پیام» کلیک کنید</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>نشانی وارد شده نامعتبر است.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>لطفاً نشانی را بررسی کنید و دوباره تلاش کنید.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>نشانی وارد شده به هیچ کلیدی اشاره نمی‌کند.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>عملیات باز کرن قفل کیف پول لغو شد.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>کلید خصوصی برای نشانی وارد شده در دسترس نیست.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>امضای پیام با شکست مواجه شد.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>پیام امضا شد.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>امضا نمی‌تواند کدگشایی شود.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>لطفاً امضا را بررسی نموده و دوباره تلاش کنید.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>امضا با خلاصهٔ پیام مطابقت ندارد.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>شناسایی پیام با شکست مواجه شد.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>پیام شناسایی شد.</translation>
     </message>
@@ -2661,17 +2110,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation> هسته Bitcoin </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>آزمایش شبکه</translation>
     </message>
@@ -2679,7 +2125,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2687,184 +2132,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>باز تا %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/آفلاین</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/تأیید نشده</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 تأییدیه</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>وضعیت</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>، پخش از طریق %n گره</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>منبع</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>تولید شده</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>فرستنده</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>گیرنده</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>آدرس شما</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>بدهی</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>بلوغ در %n بلوک دیگر</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>پذیرفته نشد</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>اعتبار</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>هزینهٔ تراکنش</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>مبلغ خالص</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>پیام</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>نظر</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>شناسهٔ تراکنش</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>اطلاعات اشکال‌زدایی</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>تراکنش</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>ورودی‌ها</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>مبلغ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>درست</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>نادرست</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>، هنوز با موفقیت ارسال نشده</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>باز برای %n بلوک دیگر</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>ناشناس</translation>
     </message>
@@ -2872,12 +2271,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>جزئیات تراکنش</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>این پانل شامل توصیف کاملی از جزئیات تراکنش است</translation>
     </message>
@@ -2885,127 +2282,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>نوع</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>نشانی</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>مبلغ</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>باز برای %n بلوک دیگر</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>باز شده تا %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>تأیید شده (%1 تأییدیه)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>این بلوک از هیچ همتای دیگری دریافت نشده است و احتمال می‌رود پذیرفته نشود!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>تولید شده ولی قبول نشده</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>دریافت‌شده با</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>دریافت‌شده از</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>ارسال‌شده به</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>پر داخت به خودتان</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>استخراج‌شده</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(ناموجود)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>وضعیت تراکنش. نشانگر را روی این فیلد نگه دارید تا تعداد تأییدیه‌ها نشان داده شود.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>تاریخ و ساعت دریافت تراکنش.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>نوع تراکنش.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>نشانی مقصد تراکنش.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>مبلغ کسر شده و یا اضافه شده به تراز.</translation>
     </message>
@@ -3013,178 +2385,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>همه</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>امروز</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>این هفته</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>این ماه</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>ماه گذشته</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>امسال</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>محدوده...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>دریافت‌شده با </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>ارسال به</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>به خودتان</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>استخراج‌شده</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>دیگر</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>برای جست‌‌وجو نشانی یا برچسب را وارد کنید</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>مبلغ حداقل</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>کپی نشانی</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>کپی برچسب</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>کپی مقدار</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>کپی شناسهٔ تراکنش</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>ویرایش برچسب</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>نمایش جزئیات تراکنش</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>پروندهٔ نوع CSV جداشونده با کاما (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>تأیید شده</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>نوع</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>نشانی</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>مبلغ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>شناسه</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>محدوده:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>به</translation>
     </message>
@@ -3192,7 +2528,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3200,7 +2535,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>ارسال وجه</translation>
     </message>
@@ -3208,42 +2542,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;صدور</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>داده ها  نوارِ جاری را به فایل انتقال دهید</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>نسخهٔ پشتیبان کیف پول</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>دادهٔ کیف پول (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>خطا در پشتیبان‌گیری</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>پشتیبان‌گیری موفق</translation>
     </message>
@@ -3251,107 +2577,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>استفاده:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>نمایش لیست فرمان‌ها</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>راهنمایی در مورد یک دستور</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>گزینه‌ها:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>مشخص کردن فایل پیکربندی (پیش‌فرض: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>مشخص کردن فایل شناسهٔ پردازش - pid - (پیش‌فرض: bitcoin.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>مشخص کردن دایرکتوری داده‌ها</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>تنظیم اندازهٔ کَش پایگاه‌داده برحسب مگابایت (پیش‌فرض: ۲۵)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>پذیرش اتصالات روی پورت &lt;port&gt; (پیش‌فرض: 8833 یا شبکهٔ آزمایشی: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>حداکثر &lt;n&gt; اتصال با همتایان برقرار شود (پیش‌فرض: ۱۲۵)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>اتصال به یک گره برای دریافت آدرس‌های همتا و قطع اتصال پس از اتمام عملیات</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>آدرس عمومی خود را مشخص کنید</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>حد آستانه برای قطع ارتباط با همتایان بدرفتار (پیش‌فرض: ۱۰۰)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>مدت زمان جلوگیری از اتصال مجدد همتایان بدرفتار، به ثانیه (پیش‌فرض: ۸۴۶۰۰)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>هنگام تنظیم پورت RPC %u برای گوش دادن روی IPv4 خطایی رخ داده است: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>پورت مورد شنود برای اتصالات JSON-RPC (پیش‌فرض: 8332 برای شبکهٔ تست 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>پذیرش دستورات خط فرمان و دستورات JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>اجرا در پشت زمینه به‌صورت یک سرویس و پذیرش دستورات</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>استفاده از شبکهٔ آزمایش</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>پذیرش اتصالات از بیرون (پیش فرض:1 بدون پراکسی یا اتصال)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3366,722 +2671,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>مقید به نشانی داده شده باشید و همیشه از آن پیروی کنید. از نشانه گذاری استاندار IPv6 به صورت Host]:Port] استفاده کنید.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>نمی توان یک قفل برای مسیر اطلاعات ایجاد کرد %s. احتمال دارد بیتکوین در حال اجرا باشد.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>تراکنش پذیرفته نیست! این خطا ممکن است در حالتی رخ داده باشد که مقداری از سکه های شما در کیف پولتان از جایی دیگر، همانند یک کپی از کیف پول اصلی اتان، خرج شده باشد اما در کیف پول اصلی اتان به عنوان مبلغ خرج شده، نشانه گذاری نشده باشد.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>خطا: این تراکنش به علت میزان وجه، دشواری، و یا استفاده از وجوه دریافتی اخیر نیازمند کارمزد به مبلغ حداقل %s است.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>هنگامی که یک تراکنش در کیف پولی رخ می دهد، دستور را اجرا کن(%s در دستورات بوسیله ی TxID جایگزین می شود)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>این یک نسخه ی آزمایشی است - با مسئولیت خودتان از آن استفاده کنید -  آن را در معدن و بازرگانی بکار نگیرید.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>هشدار: مبلغ paytxfee بسیار بالایی تنظیم شده است! این مبلغ هزینه‌ای است که شما برای تراکنش‌ها پرداخت می‌کنید.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>هشدار: لطفا زمان و تاریخ رایانه خود را تصحیح نمایید! اگر ساعت رایانه شما اشتباه باشد bitcoin ممکن است صحیح کار نکند</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>بستن گزینه ایجاد</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>تنها در گره (های) مشخص شده متصل شوید</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>یک پایگاه داده ی بلوک خراب یافت شد</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>آدرس آی.پی. خود را شناسایی کنید (پیش فرض:1 در زمان when listening وno -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>آیا مایلید که اکنون پایگاه داده ی بلوک را بازسازی کنید؟</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>خطا در آماده سازی پایگاه داده ی بلوک</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>خطا در بارگذاری پایگاه داده ها</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>خطا در بازگشایی پایگاه داده ی بلوک</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>خطا: خطای سامانه:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>شنیدن هر گونه درگاه انجام پذیر نیست. ازlisten=0  برای اینکار استفاده کیند.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>خواندن اطلاعات بلوک با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>خواندن بلوک با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>همگام سازی فهرست بلوک با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>نوشتن فهرست بلوک با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>نوشتن اطلاعات بلوک با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>نوشتن بلوک با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>نوشتن اطلاعات پرونده با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>نوشتن اطلاعات در پایگاه داده ی سکه ها با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>نوشتن فهرست تراکنش ها با شکست مواجه شد</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>عملیات بازگشت دادن اطلاعات با شکست مواجه شدن</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>نرخ هر کیلوبایت برای اضافه کردن به تراکنش‌هایی که می‌فرستید</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>قرینه ها را برای جستجوی DNS بیاب (پیش فرض: 1 مگر در زمان اتصال)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>چند بلوک نیاز است که در ابتدای راه اندازی بررسی شوند(پیش فرض:288 ،0=همه)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>&quot;بلوک تصدیق&quot; تا چه حد کامل و دقیق است (0-4، پیش فرض: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>در حال بازبینی بلوک ها...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>در حال بازبینی کیف پول...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>اطلاعات</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>حداکثر بافر دریافت شده بر اساس اتصال &lt;n&gt;*  1000 بایت  (پیش فرض:5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>حداکثر بافر دریافت شده بر اساس اتصال &lt;n&gt;*  1000 بایت  (پیش فرض:1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>تنها =به گره ها در شبکه متصا شوید  &lt;net&gt; (IPv4, IPv6 or Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>گزینه ssl (به ویکیbitcoin برای راهنمای راه اندازی ssl مراجعه شود)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>اطلاعات ردگیری/اشکال‌زدایی را به جای فایل لاگ اشکال‌زدایی به کنسول بفرستید</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>حداقل سایز بلاک بر اساس بایت تنظیم شود (پیش فرض: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>فایل debug.log  را در startup مشتری کوچک کن (پیش فرض:1 اگر اشکال زدایی روی نداد)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>(میلی ثانیه )فاصله ارتباط خاص</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>خطای سامانه</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>از UPnP  برای شناسایی درگاه شنیداری استفاده کنید (پیش فرض:0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>از UPnP  برای شناسایی درگاه شنیداری استفاده کنید (پیش فرض:1 در زمان شنیدن)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>JSON-RPC شناسه برای ارتباطات</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>هشدار</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>هشدار: این نسخه قدیمی است، روزآمدسازی مورد نیاز است</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>نسخه</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>JSON-RPC عبارت عبور برای ارتباطات</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>از آدرس آی پی خاص JSON-RPC قبول ارتباطات</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>(127.0.0.1پیش فرض: ) &amp;lt;ip&amp;gt; دادن فرمانها برای استفاده گره ها روی</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>زمانی که بهترین بلاک تغییر کرد، دستور را اجرا کن (%s در cmd با block hash جایگزین شده است)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>wallet  را به جدیدترین فرمت روزآمد کنید</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation> (100پیش فرض:)&amp;lt;n&amp;gt; گذاشتن اندازه کلید روی </translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>اسکان مجدد زنجیر بلوکها برای گم والت معامله</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>JSON-RPCبرای ارتباطات   استفاده کنید OpenSSL (https)</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation> (server.certپیش فرض: )گواهی نامه سرور</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>(server.pemپیش فرض: ) کلید خصوصی سرور</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>پیام کمکی</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>امکان اتصال به %s از این رایانه وجود ندارد ( bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>به DNS اجازه بده تا برای addnode ، seednode و اتصال جستجو کند</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>بار گیری آدرس ها</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>خطا در بارگیری wallet.dat: کیف پول خراب شده است</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>خطا در بارگیری wallet.dat: کیف پول به ویرایش جدیدتری از Biticon نیاز دارد</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>سلام</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>خطا در بارگیری wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>آدرس پراکسی اشتباه %s</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>شبکه مشخص شده غیرقابل شناسایی در onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>نسخه پراکسی ساکس غیرقابل شناسایی  درخواست شده است: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>آدرس قابل اتصال- شناسایی نیست %s</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>آدرس خارجی قابل اتصال- شناسایی نیست %s</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>میزان وجه اشتباه برای paytxfee=&lt;میزان وجه&gt;: %s</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>میزان وجه اشتباه</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>بود جه نا کافی </translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>بار گیری شاخص بلوک</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>به اتصال یک گره اضافه کنید و اتصال را باز نگاه دارید</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>اتصال به %s از این رایانه امکان پذیر نیست. Bitcoin احتمالا در حال اجراست.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>بار گیری والت</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>امکان تنزل نسخه در wallet وجود ندارد</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>آدرس پیش فرض قابل ذخیره نیست</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>اسکان مجدد</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>بار گیری انجام شده است</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>برای استفاده از %s از انتخابات</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>خطا</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_fa_IR.ts
+++ b/src/qt/locale/bitcoin_fa_IR.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>برای ویرایش حساب و یا برچسب دوبار کلیک نمایید</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>گشایش حسابی جدید</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>کپی کردن حساب انتخاب شده به حافظه سیستم - کلیپ بورد</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>و کپی آدرس</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>صدور داده نوار جاری به یک فایل</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>و حذف</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>کپی و برچسب</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>و ویرایش</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>سی.اس.وی. (فایل جداگانه دستوری)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>حساب</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(برچسب ندارد)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>رمز/پَس فرِیز را وارد کنید</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>رمز/پَس فرِیز جدید را وارد کنید</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>رمز/پَس فرِیز را دوباره وارد کنید</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>رمز/پَس فرِیز جدید را در wallet وارد کنید. برای انتخاب رمز/پَس فرِیز از 10 کاراکتر تصادفی یا بیشتر و یا هشت کلمه یا بیشتر استفاده کنید. </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>wallet را رمزگذاری کنید</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>برای انجام این عملکرد به رمز/پَس فرِیزِwallet نیاز است تا آن را از حالت قفل درآورد.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>باز کردن قفل wallet </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>برای کشف رمز wallet، به رمز/پَس فرِیزِwallet نیاز است.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>کشف رمز wallet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>تغییر رمز/پَس فرِیز</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>رمز/پَس فرِیزِ قدیم و جدید را در wallet  وارد کنید</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>رمزگذاری wallet را تایید کنید</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>تایید رمزگذاری</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin برای اتمام فرایند رمزگذاری بسته خواهد شد. به خاطر داشته باشید که رمزگذاری WALLET شما،  کامپیوتر شما را از آلودگی به بدافزارها مصون نمی دارد.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>رمزگذاری تایید نشد</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>رمزگذاری به علت خطای داخلی تایید نشد. wallet شما رمزگذاری نشد</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>رمزهای/پَس فرِیزهایِ وارد شده با هم تطابق ندارند</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>قفل wallet  باز نشد</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>رمزهای/پَس فرِیزهایِ وارد شده wallet برای کشف رمز اشتباه است.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>کشف رمز wallet انجام نشد</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,363 +255,287 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>امضا و پیام</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>به روز رسانی با شبکه...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>و بازبینی</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>نمای کلی از wallet را نشان بده</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>و تراکنش</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>تاریخچه تراکنش را باز کن</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>خروج</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>از &quot;درخواست نامه&quot;/ application خارج شو</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>اطلاعات در مورد Bitcoin را نشان بده</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>درباره و QT</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>نمایش اطلاعات درباره QT</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>و انتخابها</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>و رمزگذاری wallet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>و گرفتن نسخه پیشتیبان از wallet</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>تغییر رمز/پَس فرِیز</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>اصلاح انتخابها برای پیکربندی Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>گرفتن نسخه پیشتیبان در آدرسی دیگر</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>رمز مربوط به رمزگذاریِ wallet را تغییر دهید</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>کیف پول</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;نمایش/ عدم نمایش و</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>و فایل</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>و تنظیمات</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>و راهنما</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>نوار ابزار</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>مشتری bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n ارتباط فعال به شبکه Bitcoin
 %n ارتباط فعال به شبکه Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>خطا</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>روزآمد</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>در حال روزآمد سازی..</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>ارسال تراکنش</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>تراکنش دریافتی</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -689,17 +545,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>wallet رمزگذاری شد و در حال حاضر از حالت قفل در آمده است</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>wallet رمزگذاری شد و در حال حاضر قفل است</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -707,7 +560,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>هشدار شبکه</translation>
     </message>
@@ -715,291 +567,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>میزان وجه:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>میزان</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>حساب</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>تایید شده</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>آدرس را کپی کنید</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>برچسب را کپی کنید</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>میزان وجه کپی شود</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(برچسب ندارد)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1007,68 +798,55 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>ویرایش حساب</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>و برچسب</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>حساب&amp;</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>حساب دریافت کننده جدید
 </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>حساب ارسال کننده جدید</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>ویرایش حساب دریافت کننده</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>ویرایش حساب ارسال کننده</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>حساب وارد شده «1%» از پیش در دفترچه حساب ها موجود است.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>آدرس وارد شده &quot;%1&quot; یک آدرس صحیح برای bitcoin نسشت</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>عدم توانیی برای قفل گشایی wallet</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>عدم توانیی در ایجاد کلید جدید</translation>
     </message>
@@ -1076,27 +854,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1104,52 +877,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>نسخه</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>میزان استفاده:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1157,57 +924,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>خطا</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1215,27 +971,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1243,253 +994,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>انتخاب/آپشن</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>و نمایش آدرسها در فهرست تراکنش</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>و تایید</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>و رد</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>پیش فرض</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1497,69 +1201,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>فرم</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>اطلاعات نمایش داده شده ممکن است روزآمد نباشد. wallet شما به صورت خودکار بعد از برقراری اتصال با شبکه bitcoin به روز می شود اما این فرایند هنوز تکمیل نشده است.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>کیف پول</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>تراکنشهای اخیر</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>خارج از روزآمد سازی</translation>
     </message>
@@ -1567,93 +1256,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1661,23 +1327,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>یک آدرس bitcoin وارد کنید (مثال 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1685,22 +1350,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1708,192 +1369,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>نام کنسول RPC</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>ویرایش کنسول RPC</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>شبکه</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>تعداد اتصال</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>زنجیره مجموعه تراکنش ها</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>تعداد زنجیره های حاضر</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>به کنسول آر.پی.سی. BITCOIN خوش آمدید</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1901,105 +1516,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>و برچسب</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>برچسب را کپی کنید</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>میزان وجه کپی شود</translation>
     </message>
@@ -2007,67 +1599,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>حساب</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>میزان</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>پیام</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>متن وارد شده طولانی است، متنِ برچسب/پیام را کوتاه کنید</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>خطای تبدیل URI به کد QR</translation>
     </message>
@@ -2075,37 +1654,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>پیام</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>میزان</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(برچسب ندارد)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2113,247 +1685,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>سکه های ارسالی</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>میزان وجه:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>ارسال همزمان به گیرنده های متعدد</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>مانده حساب:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>تایید عملیات ارسال </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>و ارسال</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>تایید ارسال بیت کوین ها</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>میزان وجه کپی شود</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>میزان پرداخت باید بیشتر از 0 باشد</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>مقدار مورد نظر از مانده حساب بیشتر است.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(برچسب ندارد)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2361,98 +1880,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>و میزان وجه</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>پرداخت و به چه کسی</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>یک برچسب برای این آدرس بنویسید تا به دفترچه آدرسهای شما اضافه شود</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>و برچسب</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt و A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>آدرس را بر کلیپ بورد کپی کنید</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt و P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>پیام:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2460,12 +1955,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2473,186 +1966,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>و امضای پیام </translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>یک آدرس bitcoin وارد کنید (مثال 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt و A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>آدرس را بر کلیپ بورد کپی کنید</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt و P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>یک آدرس bitcoin وارد کنید (مثال 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>یک آدرس bitcoin وارد کنید (مثال 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2660,17 +2109,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2678,7 +2124,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2686,184 +2131,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>باز کن تا %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1 / تایید نشده</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 تایید</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>پیام</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>میزان</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>، هنوز با موفقیت ارسال نگردیده است</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>ناشناس</translation>
     </message>
@@ -2871,12 +2270,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>جزئیات تراکنش</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>این بخش جزئیات تراکنش را نشان می دهد</translation>
     </message>
@@ -2884,127 +2281,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>گونه</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>آدرس</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>میزان وجه</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>باز کن تا %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>تایید شده (%1 تاییدها)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>این block توسط گره های دیگری دریافت نشده است و ممکن است قبول نشود</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>تولید شده اما قبول نشده است</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>قبول با </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>دریافت شده از</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>ارسال به</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>وجه برای شما </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>استخراج شده</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>خالی</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>وضعیت تراکنش. با اشاره به این بخش تعداد تاییدها نمایش داده می شود</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>زمان و تاریخی که تراکنش دریافت شده است</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>نوع تراکنش</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>آدرس مقصد در تراکنش</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>میزان وجه کم شده یا اضافه شده به حساب</translation>
     </message>
@@ -3012,178 +2384,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>همه</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>امروز</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>این هفته</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>این ماه</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>ماه گذشته</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>این سال</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>حدود..</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>دریافت با</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>ارسال به</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>به شما</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>استخراج شده</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>دیگر</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>آدرس یا برچسب را برای جستجو وارد کنید</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>حداقل میزان وجه</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>آدرس را کپی کنید</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>برچسب را کپی کنید</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>میزان وجه کپی شود</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>برچسب را ویرایش کنید</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Comma separated file (*.csv) فایل جداگانه دستوری</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>تایید شده</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>نوع</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>برچسب</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>آدرس</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>میزان</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>شناسه کاربری</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>دامنه:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>به</translation>
     </message>
@@ -3191,7 +2527,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3199,7 +2534,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>سکه های ارسالی</translation>
     </message>
@@ -3207,42 +2541,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>صدور داده نوار جاری به یک فایل</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3250,107 +2576,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>میزان استفاده:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>فهرست دستورها</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>درخواست کمک برای یک دستور</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>انتخابها:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>فایل پیکربندیِ را مشخص کنید (پیش فرض: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>فایل pid  را مشخص کنید (پیش فرض: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>دایرکتوری داده را مشخص کن</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>حافظه بانک داده را به مگابایت تنظیم کنید (پیش فرض: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>ارتباطات را در &lt;PORT&gt; بشنوید (پیش فرض: 8333 or testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>نگهداری &lt;N&gt; ارتباطات برای قرینه سازی  (پیش فرض:125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>آستانه قطع برای قرینه سازی اشتباه (پیش فرض:100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>تعداد ثانیه ها برای اتصال دوباره قرینه های اشتباه (پیش فرض:86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>ارتباطاتِ JSON-RPC  را در &lt;port&gt;  گوش کنید (پیش فرض:8332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>command line  و JSON-RPC commands را قبول کنید</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>به عنوان daemon بک گراند را اجرا کنید و دستورات را قبول نمایید</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>از تستِ شبکه استفاده نمایید</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3365,722 +2670,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>ارسال اطلاعات پیگیری/خطایابی به کنسول به جای ارسال به فایل debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>تعیین مدت زمان وقفه (time out) به هزارم ثانیه</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>شناسه کاربری برای ارتباطاتِ JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>نسخه</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>رمز برای ارتباطاتِ JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>ارتباطاتِ JSON-RPC  را از آدرس آی.پی. مشخصی برقرار کنید.</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>دستورات را به گره اجرا شده در&lt;ip&gt; ارسال کنید (پیش فرض:127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>دستور را وقتی بهترین بلاک تغییر کرد اجرا کن (%s در دستور توسط block hash جایگزین شده است)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>wallet را به جدیدترین نسخه روزآمد کنید</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>حجم key pool  را به اندازه &lt;n&gt; تنظیم کنید (پیش فرض:100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>زنجیره بلاک را برای تراکنش جا افتاده در WALLET دوباره اسکن کنید</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>برای ارتباطاتِ JSON-RPC  از OpenSSL (https) استفاده کنید</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>فایل certificate  سرور (پیش فرض server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>رمز اختصاصی سرور  (پیش فرض: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>این پیام راهنما</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>لود شدن آدرسها..</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>خطا در هنگام لود شدن wallet.dat: Wallet corrupted</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>خطا در هنگام لود شدن wallet.dat.  به نسخه جدید Bitocin برای wallet نیاز است.</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>wallet نیاز به بازنویسی دارد. Bitcoin را برای تکمیل عملیات دوباره اجرا کنید.</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>خطا در هنگام لود شدن wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>میزان اشتباه است for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>میزان اشتباه است</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>وجوه ناکافی</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>لود شدن نمایه بلاکها..</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>یک گره برای اتصال اضافه کنید و تلاش کنید تا اتصال را باز نگاه دارید</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>wallet در حال لود شدن است...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>قابلیت برگشت به نسخه قبلی برای wallet امکان پذیر نیست</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>آدرس پیش فرض قابل ذخیره نیست</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>اسکنِ دوباره...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>اتمام لود شدن</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>برای استفاده از %s  از اختیارات</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>خطا</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_fi.ts
+++ b/src/qt/locale/bitcoin_fi.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Tietoja Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;Bitcoin Core&lt;/b&gt; versio</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -28,18 +25,14 @@ Tämä ohjelma sisältää OpenSSL projektin OpenSSL työkalupakin (http://www.o
 </translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Tekijänoikeus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Core kehittäjät</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation>(%1-bit)</translation>
     </message>
@@ -47,122 +40,98 @@ Tämä ohjelma sisältää OpenSSL projektin OpenSSL työkalupakin (http://www.o
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Kaksoisnapauta muokataksesi osoitetta tai nimeä</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Luo uusi osoite</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Uusi</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopioi valittu osoite leikepöydälle</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopioi</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>&amp;Sulje</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopioi Osoite</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Poista valittu osoite listalta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Vie auki olevan välilehden tiedot tiedostoon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Vie...</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Poista</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Valitse osoite johon lähetetään kolikoita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Valitse osoite jolla vastaanotetaan kolikoita</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Valitse</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Lähettävä osoite</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Vastaanottava osoite</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Nämä ovat sinun Bitcoin osoitteita maksujen lähetykseen. Tarkista aina rahan määrä ja vastaanottajan osoite ennenkuin lähetät kolikkoja.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Nämä ovat sinun Bitcoin-osoitteesi suoritusten vastaanottamiseen. Suositellaan että annat uuden osoitteen kullekin rahansiirrolle</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopioi &amp;Nimi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Muokkaa</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Vie osoitekirja</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Comma separated file (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Vienti epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Osoitelistan tallennuksessa tapahtui virhe tiedostoon %1.</translation>
     </message>
@@ -170,17 +139,14 @@ Tämä ohjelma sisältää OpenSSL projektin OpenSSL työkalupakin (http://www.o
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(ei nimeä)</translation>
     </message>
@@ -188,140 +154,106 @@ Tämä ohjelma sisältää OpenSSL projektin OpenSSL työkalupakin (http://www.o
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Tunnuslauseen Dialogi</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Kirjoita tunnuslause</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Uusi tunnuslause</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Kirjoita uusi tunnuslause uudelleen</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Anna lompakolle uusi tunnuslause.&lt;br/&gt;Käytä tunnuslausetta, jossa on ainakin  &lt;b&gt;10 satunnaista mekkiä&lt;/b&gt; tai &lt;b&gt;kahdeksan sanaa&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Salaa lompakko</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Tätä toimintoa varten sinun täytyy antaa lompakon tunnuslause sen avaamiseksi.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Avaa lompakko</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Tätä toimintoa varten sinun täytyy antaa lompakon tunnuslause salauksen purkuun.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Pura lompakon salaus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Vaihda tunnuslause</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Anna vanha ja uusi tunnuslause.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Vahvista lompakon salaus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Varoitus: Jos salaat lompakkosi ja menetät tunnuslauseesi, &lt;b&gt;MENETÄT KAIKKI BITCOINISI&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Haluatko varmasti salata lompakkosi?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>TÄRKEÄÄ: Kaikki vanhat lompakon varmuuskopiot pitäisi korvata uusilla suojatuilla varmuuskopioilla. Turvallisuussyistä edelliset varmuuskopiot muuttuvat turhiksi, kun aloitat suojatun lompakon käytön.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Varoitus: Caps Lock on käytössä!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Lompakko salattu</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin sulkeutuu lopettaakseen salausprosessin. Muista, että salattukaan lompakko ei täysin suojaa sitä haittaohjelmien aiheuttamilta varkauksilta.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Lompakon salaus epäonnistui</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Lompakon salaaminen epäonnistui sisäisen virheen vuoksi. Lompakkoasi ei salattu.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Annetut tunnuslauseet eivät täsmää.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Lompakon avaaminen epäonnistui.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Annettu tunnuslause oli väärä.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Lompakon salauksen purku epäonnistui.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Lompakon tunnuslause vaihdettiin onnistuneesti.</translation>
     </message>
@@ -329,363 +261,286 @@ Tämä ohjelma sisältää OpenSSL projektin OpenSSL työkalupakin (http://www.o
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;Allekirjoita viesti...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synkronoidaan verkon kanssa...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Yleisnäkymä</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>Solmu</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Lompakon tilanteen yleiskatsaus</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Rahansiirrot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Selaa rahansiirtohistoriaa</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>L&amp;opeta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Sulje ohjelma</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Näytä tietoa Bitcoin-projektista</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Tietoja &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Näytä tietoja QT:ta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Asetukset...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Salaa lompakko...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Varmuuskopioi Lompakko...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Vaihda Tunnuslause...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;Lähetysosoitteet...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;Vastaanotto-osoitteet...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Avaa &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Tuodaan lohkoja levyltä</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Ladataan lohkoindeksiä...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Lähetä kolikoita Bitcoin-osoitteeseen</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Muuta Bitcoinin konfiguraatioasetuksia</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Varmuuskopioi lompakko toiseen sijaintiin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Vaihda lompakon salaukseen käytettävä tunnuslause</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Testausikkuna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Avaa debuggaus- ja diagnostiikkakonsoli</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>Varmista &amp;viesti...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Lompakko</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;Lähetä</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Vastaanota</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Näytä / Piilota</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Näytä tai piilota Bitcoin-ikkuna</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Suojaa yksityiset avaimet, jotka kuuluvat lompakkoosi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Allekirjoita viestisi omalla Bitcoin -osoitteellasi todistaaksesi, että omistat ne</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Varmista, että viestisi on allekirjoitettu määritetyllä Bitcoin -osoitteella</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Tiedosto</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Asetukset</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Apua</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Välilehtipalkki</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin-ydin</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Pyydä maksuja (Luo QR koodit ja bitcoin: URIt)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;Tietoja Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Näytä lähettämiseen käytettyjen osoitteiden ja nimien lista</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Näytä vastaanottamiseen käytettyjen osoitteiden ja nimien lista</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Avaa bitcoin: URI tai maksupyyntö</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Komentorivin valinnat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Näytä Bitcoin Core ohjeet saadaksesi listan mahdollisista Bitcoinin komentorivivalinnoista</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin-asiakas</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktiivinen yhteys Bitcoin-verkkoon</numerusform><numerusform>%n aktiivista yhteyttä Bitcoin-verkkoon</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Lohkojen lähdettä ei saatavilla...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Käsitelty %1 of %2 (arviolta) rahansiirtohistorian lohkoa.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Käsitelty %1 lohkoa rahansiirtohistoriasta</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n tunti</numerusform><numerusform>%n tuntia</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n päivä</numerusform><numerusform>%n päivää</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n viikko</numerusform><numerusform>%n viikkoa</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 ja %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n vuosi</numerusform><numerusform>%n vuotta</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 jäljessä</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Viimeisin vastaanotettu lohko tuotettu %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Tämän jälkeiset rahansiirrot eivät ole vielä näkyvissä.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Tietoa</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Rahansiirtohistoria on ajan tasalla</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Saavutetaan verkkoa...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Lähetetyt rahansiirrot</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Saapuva rahansiirto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +552,14 @@ Tyyppi: %3
 Osoite: %4</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Lompakko on &lt;b&gt;salattu&lt;/b&gt; ja tällä hetkellä &lt;b&gt;avoinna&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Lompakko on &lt;b&gt;salattu&lt;/b&gt; ja tällä hetkellä &lt;b&gt;lukittuna&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Peruuttamaton virhe on tapahtunut. Bitcoin ei voi enää jatkaa turvallisesti ja sammutetaan.</translation>
     </message>
@@ -715,7 +567,6 @@ Osoite: %4</translation>
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Verkkohälytys</translation>
     </message>
@@ -723,291 +574,230 @@ Osoite: %4</translation>
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Kolikkokontrollin osoitteen valinta</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Määrä:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Tavuja:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Määrä:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioriteetti:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Palkkio:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Pieni Tuotos</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Palkkion jälkeen:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Vaihtoraha:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(epä)valitse kaikki</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Puurakenne</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Listarakenne</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Aika</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Vahvistuksia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Vahvistettu</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioriteetti</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Kopioi osoite</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopioi nimi</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopioi määrä</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopioi siirtotunnus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Lukitse käyttämättömät</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Avaa käyttämättömät</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Kopioi määrä</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Kopioi palkkio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Kopioi palkkion jälkeen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopioi tavut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopioi prioriteetti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Kopioi pieni tuotos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopioi vaihtoraha</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>korkein</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>korkeampi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>korkea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>keski-korkea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>keskisuuri</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>pieni-keskisuuri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>pieni</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>pienempi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>pienin</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 lukittu)</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation>ei mitään</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Tomu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>kyllä</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>ei</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Tämä nimi muuttuu punaiseksi jos rahansiirron koko on suurempi kuin 1000 tavua</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Tämä tarkoittaa että vähintään %1 per kB palkkio on pakollinen.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Voi vaihdella +/- 1 tavu per syöte</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Rahansiirrot korkeammalla prioriteetilla sisällytetään varmemmin lohkoon.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Tämä nimi muuttuu punaiseksi jos prioriteetti on pienempi kuin &quot;keskisuuri&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Tämä nimi muuttuu punaiseksi jos vastaanottaja saa pienemmän määrän kuin %1</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Tämä tarkoittaa että vähintään %1 palkkio on pakollinen.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Maksumäärät alle 0.546 kertaa vähimmäispalkkion näytetään tomuna.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Tämä nimi muuttuu punaiseksi jos vaihtoraha on alle %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(ei nimeä)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation>Vaihda %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(vaihtoraha)</translation>
     </message>
@@ -1015,67 +805,54 @@ Osoite: %4</translation>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Muokkaa osoitetta</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Nimi</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>Tähän osoitteeseen liitetty nimi</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Osoite liitettynä tähän osoitekirjan alkioon. Tämä voidaan muokata vain lähetysosoitteissa.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Osoite</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Uusi vastaanottava osoite</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Uusi lähettävä osoite</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Muokkaa vastaanottajan osoitetta</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Muokkaa lähtevää osoitetta</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Osoite &quot;%1&quot; on jo osoitekirjassa.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Antamasi osoite &quot;%1&quot; ei ole validi Bitcoin-osoite.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Lompakkoa ei voitu avata.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Uuden avaimen luonti epäonnistui.</translation>
     </message>
@@ -1083,27 +860,22 @@ Osoite: %4</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation>Luodaan uusi kansio.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Hakemisto on jo olemassa. Lisää %1 jos tarkoitus on luoda hakemisto tänne.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Polku on jo olemassa, eikä se ole kansio.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Ei voida luoda data-hakemistoa tänne.</translation>
     </message>
@@ -1111,57 +883,46 @@ Osoite: %4</translation>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - Kometorivivalinnat</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin-ydin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versio</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Käyttö:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>komentorivi parametrit</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Käyttöliittymäasetukset</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Set language, for example &quot;de_DE&quot; (default: system locale)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Käynnistä pienennettynä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation>Aseta SSL root varmenne maksupyynnöille (oletus: -system-)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Näytä aloitusruutu käynnistettäessä (oletus: 1)</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Valitse data-hakemisto käynnistyksessä (oletus: 0)</translation>
     </message>
@@ -1169,57 +930,46 @@ Osoite: %4</translation>
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Tervetuloa</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Tervetuloa Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Tämän on ensimmäinen kerta kun Bitcoin Core on käynnistetty joten voit valita data-hakemiston paikan.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core lataa ja tallentaa kopion Bitcoinin lohkoketjusta. Vähintään %1GB dataa tullaan tallentamaan tähän hakemistoon ja tarve kasvaa ajan myötä. Lomakko tullaan myös tallentamaan tähän hakemistoon.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Käytä oletuskansiota</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Määritä oma kansio:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Virhe: Annettua data-hakemistoa &quot;%1&quot; ei voida luoda.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB vapaata tilaa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(tarvitaan %1GB)</translation>
     </message>
@@ -1227,27 +977,22 @@ Osoite: %4</translation>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Avaa URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Avaa maksupyyntö URI:sta tai tiedostosta</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Valitse maksupyynnön tiedosto</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Valitse maksypyynnön tiedosto avattavaksi</translation>
     </message>
@@ -1255,258 +1000,206 @@ Osoite: %4</translation>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Asetukset</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Yleiset</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Valinnainen rahansiirtopalkkio per kB auttaa varmistamaan että rahansiirtosi prosessoidaan nopeasti. Useimmat rahansiirrot ovat alle 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Maksa rahansiirtopalkkio</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Käynnistä Bitcoin kirjautumisen yhteydessä.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Käynnistä Bitcoin kirjautumisen yhteydessä</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>&amp;Tietokannan välimuistin koko</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>Script &amp;varmistuksen threadien määrä</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Yhdistä Bitcoin-verkkoon SOCKS proxyn kautta.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>&amp;Yhdistä SOCKS proxyn kautta (oletus proxy):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>IP osoite proxille (esim. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation>Aktiiviset komentorivivalinnat jotka ohittavat ylläolevat valinnat:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Palauta kaikki asetukset takaisin alkuperäisiksi.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Palauta asetukset</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Verkko</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation>(0 = auto, &lt;0 = jätä näin monta ydintä vapaaksi)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation>&amp;Lompakko</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>Expertti</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation>Ota käytöön &amp;Kolikkokontrolli-ominaisuudet</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>Jos poistat varmistamattomien vaihtorahojen käytön, rahansiirron vaihtorahaa ei voida käyttää ennen vähintään yhtä varmistusta. Tämä vaikuttaa myös kuinka taseesi lasketaan.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation>&amp;Käytä varmistamattomia vaihtorahoja</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Avaa Bitcoin-asiakasohjelman portti reitittimellä automaattisesti. Tämä toimii vain, jos reitittimesi tukee UPnP:tä ja se on käytössä.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Portin uudelleenohjaus &amp;UPnP:llä</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxyn &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Portti</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Proxyn Portti (esim. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Versio:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Proxyn SOCKS-versio (esim. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Ikkuna</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Näytä ainoastaan ilmaisinalueella ikkunan pienentämisen jälkeen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Pienennä ilmaisinalueelle työkalurivin sijasta</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Ikkunaa suljettaessa vain pienentää Bitcoin-ohjelman ikkunan lopettamatta itse ohjelmaa. Kun tämä asetus on valittuna, ohjelman voi sulkea vain valitsemalla Lopeta ohjelman valikosta.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>P&amp;ienennä suljettaessa</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Käyttöliittymä</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Käyttöliittymän kieli</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Tässä voit määritellä käyttöliittymän kielen. Muutokset astuvat voimaan seuraavan kerran, kun Bitcoin käynnistetään.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Yksikkö jona bitcoin-määrät näytetään</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Valitse mitä yksikköä käytetään ensisijaisesti bitcoin-määrien näyttämiseen.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Näytetäänkö Bitcoin-osoitteet rahansiirrot listassa vai ei.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Näytä osoitteet rahansiirrot listassa</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Näytetäänkö kolikkokontrollin ominaisuuksia vai ei</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Peruuta</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>oletus</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>ei mitään</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation>Varmista asetusten palautus</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Ohjelman uudelleenkäynnistys aktivoi muutokset.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>Ohjelma lopetetaan. Haluatko jatkaa?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Tämä muutos vaatii ohjelman uudelleenkäynnistyksen.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Antamasi proxy-osoite on virheellinen.</translation>
     </message>
@@ -1514,69 +1207,54 @@ Osoite: %4</translation>
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Lomake</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Näytetyt tiedot eivät välttämättä ole ajantasalla. Lompakkosi synkronoituu Bitcoin-verkon kanssa automaattisesti yhteyden muodostamisen jälkeen, mutta synkronointi on vielä meneillään.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Lompakko</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Käytettävissä:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Nykyinen käytettävissä oleva tase</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>Odotetaan:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Varmistamattomien rahansiirtojen summa, jota ei lasketa käytettävissä olevaan taseeseen.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Epäkypsää:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Louhittu saldo, joka ei ole vielä kypsynyt</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Yhteensä:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Tililläsi tällä hetkellä olevien Bitcoinien määrä</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Viimeisimmät rahansiirrot&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>Ei ajan tasalla</translation>
     </message>
@@ -1584,93 +1262,70 @@ Osoite: %4</translation>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI käsittely</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URIa ei voitu jäsentää! Tämä voi johtua kelvottomasta Bitcoin-osoitteesta tai virheellisistä URI parametreista.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Maksupyyntö %1 on liian pieni (huomioidaan tomuna).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Maksupyyntövirhe</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Ei voida käynnistää bitcoin: klikkaa-maksu käsittelijää</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Verkkohallinnan varoitus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>Aktiivinen proxy ei tue SOCKS5, joka on pakollinen maksupyynnöissä proxyn kautta.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>Maksupyynnön haku URL on virheellinen: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Maksupyynnön tiedoston käsittely</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>Maksupyynnön tiedostoa ei voida lukea tai prosessoida! Tämä voi johtua virheellisestä maksupyyntötiedostosta.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Varmistamattomia maksupyyntöjä kustomoituun maksupalveluun ei tueta.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Maksupalautus %1:sta</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Virhe kommunikoidessa %1n kanssa: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>Maksupyyntöä ei voida jäsentää tai prosessoida!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Huono vastaus palvelimelta %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Rahansiirto tunnistettu</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Tietoverkon pyyntövirhe</translation>
     </message>
@@ -1678,29 +1333,22 @@ Osoite: %4</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Virhe: Annettu data-hakemisto &quot;%1&quot; ei ole olemassa.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation>Virhe: Ei voida jäsentää asetustiedostoa: %1. Käytä vain avain=arvo syntaksia.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Virhe: Virheellinen yhdistelmä -regtest ja -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Anna Bitcoin-osoite (esim. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1708,22 +1356,18 @@ Osoite: %4</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Tallenna kuva</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Kopioi kuva</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Tallenna QR-koodi</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG kuva (*.png)</translation>
     </message>
@@ -1731,194 +1375,146 @@ Osoite: %4</translation>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Pääteohjelman nimi</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>Ei saatavilla</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Pääteohjelman versio</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>T&amp;ietoa</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>&amp;Debug-ikkuna</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Yleinen</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Käytössä oleva OpenSSL-versio</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Käynnistysaika</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Verkko</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Yhteyksien lukumäärä</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Lohkoketju</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Nykyinen Lohkojen määrä</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Arvioitu lohkojen kokonaismäärä</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Viimeisimmän lohkon aika</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Avaa</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsoli</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Verkkoliikenne</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Tyhjennä</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Yhteensä</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>Sisään:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>Ulos:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Kääntöpäiväys</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Debug lokitiedosto</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Avaa lokitiedosto nykyisestä data-kansiosta. Tämä voi viedä useamman sekunnin, jos lokitiedosto on iso.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Tyhjennä konsoli</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Tervetuloa Bitcoin RPC konsoliin.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Ylös- ja alas-nuolet selaavat historiaa ja &lt;b&gt;Ctrl-L&lt;/b&gt; tyhjentää ruudun.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Kirjoita &lt;b&gt;help&lt;/b&gt; nähdäksesi yleiskatsauksen käytettävissä olevista komennoista.</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1926,105 +1522,82 @@ Osoite: %4</translation>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Määrä</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Nimi:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Viesti:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Uudelleenkäytä yksi vanhoista vastaanotto-osoitteista. Uudelleenkäyttössä on turvallisuus- ja yksityisyysongelmia. Älä käytä tätä ellet ole uudelleenluomassa aikaisempaa maksupyyntöä.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>&amp;Uudelleenkäytä vastaanotto-osoitetta (ei suositella)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>Valinnainen viesti liitetään maksupyyntöön ja näytetään avattaessa. Viestiä ei lähetetä Bitcoin-verkkoon.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Valinnainen nimi liitetään vastaanottavaan osoitteeseen.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Käytä lomaketta maksupyyntöihin. Kaikki kentät ovat &lt;b&gt;valinnaisia&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Valinnainen pyyntömäärä. Jätä tyhjäksi tai nollaksi jos et pyydä tiettyä määrää.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Tyhjennä lomakkeen kaikki kentät.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Tyhjennä</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Pyydettyjen maksujen historia</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Vastaanota maksu</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>Näytä valittu pyyntö (sama toiminta kuin alkion tuplaklikkaus)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Näytä</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation>Poista valitut alkiot listasta</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Poista</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Kopioi nimi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Kopioi viesti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopioi määrä</translation>
     </message>
@@ -2032,67 +1605,54 @@ Osoite: %4</translation>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR-koodi</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Kopioi &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Kopioi &amp;Osoite</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Tallenna kuva</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Vastaanota maksu %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Maksutiedot</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Viesti</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Tuloksen URI liian pitkä, yritä lyhentää otsikon tekstiä / viestiä.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Virhe käännettäessä URI:a QR-koodiksi.</translation>
     </message>
@@ -2100,37 +1660,30 @@ Osoite: %4</translation>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Aika</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Viesti</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(ei nimeä)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(ei viestiä)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(ei määrää)</translation>
     </message>
@@ -2138,247 +1691,194 @@ Osoite: %4</translation>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Lähetä Bitcoineja</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Kolikkokontrolli ominaisuudet</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Sisääntulot...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>automaattisesti valitut</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Lompakon saldo ei riitä!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Määrä:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Tavuja:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Määrä:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioriteetti:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Palkkio:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Pieni Tuotos</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Palkkion jälkeen:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Vaihtoraha:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Jos tämä aktivoidaan mutta vaihtorahan osoite on tyhjä tai virheellinen, vaihtoraha tullaan lähettämään uuteen luotuun osoitteeseen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Kustomoitu vaihtorahan osoite</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Lähetä usealla vastaanottajalle samanaikaisesti</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Lisää &amp;Vastaanottaja</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Tyhjennä lomakkeen kaikki kentät</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Tyhjennnä Kaikki</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Balanssi:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Vahvista lähetys</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Lähetä</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Hyväksy Bitcoinien lähettäminen</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 to %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Kopioi määrä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopioi määrä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Kopioi palkkio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Kopioi palkkion jälkeen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopioi tavut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopioi prioriteetti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Kopioi pieni tuotos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopioi vaihtoraha</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Yhteensä %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>tai</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Vastaanottajan osoite on virheellinen. Tarkista osoite.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Maksettavan summan tulee olla suurempi kuin 0 Bitcoinia.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Määrä ylittää käytettävissä olevan saldon.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Kokonaismäärä ylittää saldosi kun %1 maksukulu lisätään summaan.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Sama osoite toistuu useamman kerran. Samaan osoitteeseen voi lähettää vain kerran per maksu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Rahansiirron luonti epäonnistui!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Rahansiirto hylättiin! Tämä saattaa tapahtua jos lompakossa olevat kolikot on jo kulutettu, kuten jos käytät kopioita wallet.dat tiedostosta ja kolikot oli jos käytetty mutta ei merkattu täällä.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Varoitus: Virheellinen Bitcoin osoite</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ei nimeä)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Varoitus: Tuntematon vaihtorahan osoite</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Haluatko varmasti lähettää?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>lisätty rahansiirtomaksuna</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Maksupyyntö vanhentui</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Virheellinen maksuosoite %1</translation>
     </message>
@@ -2386,98 +1886,74 @@ Osoite: %4</translation>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>M&amp;äärä:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Maksun saaja:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Osoite, johon Bitcoinit lähetetään  (esim. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Anna nimi tälle osoitteelle, jos haluat lisätä sen osoitekirjaan</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Nimi:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Valitse aikaisemmin käytetty osoite</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Tämä on normaali maksu.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Liitä osoite leikepöydältä</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Poista tämä alkio</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Viesti:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Tämä on varmistettu maksupyyntö.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Aseta nimi tälle osoitteelle lisätäksesi sen käytettyjen osoitteiden listalle.</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>Viesti joka liitettiin bitcoin: URI:iin tallennetaan rahansiirtoon viitteeksi. Tätä viestiä ei lähetetä Bitcoin-verkkoon.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Tämä on varmistamaton maksupyyntö</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Saaja:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Muistio:</translation>
     </message>
@@ -2485,12 +1961,10 @@ Osoite: %4</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin core sulkeutuu...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Älä sammuta tietokonetta ennenkuin tämä ikkuna katoaa.</translation>
     </message>
@@ -2498,186 +1972,142 @@ Osoite: %4</translation>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Allekirjoitukset - Allekirjoita / Varmista viesti</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Allekirjoita viesti</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Voit allekirjoittaa viestit omalla osoitteellasi todistaaksesi että omistat ne. Ole huolellinen, että et allekirjoita mitään epämääräistä, phishing-hyökkääjät voivat huijata sinua allekirjoittamaan luovuttamalla henkilöllisyytesi. Allekirjoita selvitys täysin yksityiskohtaisesti mihin olet sitoutunut.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Osoite, jolla viesti allekirjoitetaan (esimerkiksi 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Valitse aikaisemmin käytetty osoite</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Liitä osoite leikepöydältä</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Kirjoita tähän viesti minkä haluat allekirjoittaa</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Allekirjoitus</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Kopioi tämänhetkinen allekirjoitus leikepöydälle</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Allekirjoita viesti todistaaksesi, että omistat tämän Bitcoin-osoitteen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Allekirjoita &amp;viesti</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Tyhjennä kaikki allekirjoita-viesti-kentät</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Tyhjennä Kaikki</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Varmista viesti</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Syötä allekirjoittava osoite, viesti ja allekirjoitus alla oleviin kenttiin varmistaaksesi allekirjoituksen aitouden. Varmista että kopioit kaikki kentät täsmälleen oikein, myös rivinvaihdot, välilyönnit, tabulaattorit, jne.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Osoite, jolla viesti allekirjoitettiin (esimerkiksi 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Tarkista viestin allekirjoitus varmistaaksesi, että se allekirjoitettiin tietyllä Bitcoin-osoitteella</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Varmista &amp;viesti...</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Tyhjennä kaikki varmista-viesti-kentät</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Anna Bitcoin-osoite (esim. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Klikkaa &quot;Allekirjoita Viesti luodaksesi allekirjoituksen </translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Syötetty osoite on virheellinen.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Tarkista osoite ja yritä uudelleen.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Syötetyn osoitteen avainta ei löydy.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Lompakon avaaminen peruttiin.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Yksityistä avainta syötetylle osoitteelle ei ole saatavilla.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Viestin allekirjoitus epäonnistui.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Viesti allekirjoitettu.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Allekirjoitusta ei pystytty tulkitsemaan.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Tarkista allekirjoitus ja yritä uudelleen.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Allekirjoitus ei täsmää viestin tiivisteeseen.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Viestin varmistus epäonnistui.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Viesti varmistettu.</translation>
     </message>
@@ -2685,17 +2115,14 @@ Osoite: %4</translation>
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin-ydin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Core kehittäjät</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2703,7 +2130,6 @@ Osoite: %4</translation>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2711,184 +2137,138 @@ Osoite: %4</translation>
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Avoinna %1 asti</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>ristiriitainen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/vahvistamaton</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 vahvistusta</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Tila</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>lähetetty %n noodin läpi</numerusform><numerusform>lähetetty %n noodin läpi</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Päivämäärä</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Lähde</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generoitu</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Lähettäjä</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Saaja</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>oma osoite</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>nimi</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Credit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>kypsyy %n lohkon kuluttua</numerusform><numerusform>kypsyy %n lohkon kuluttua</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>ei hyväksytty</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debit</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Maksukulu</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Netto määrä</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Viesti</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Viesti</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Siirtotunnus</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Kauppias</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Luodut kolikot täytyy kypsyttää %1 lohkoa kunnes ne voidaan käyttää. Kun loit tämän lohkon, se lähetettiin verkkoon lisänä lohkoketjuun. Jos se epäonnistuu pääsemään ketjuun sen tila tulee muuttumaan &quot;ei hyväksytty&quot; ja sitä ei voida käyttää. Tämä voi ajoittain tapahtua kun toisen solmun lohko luodaan samanaikaisesti omasi kanssa.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Debug tiedot</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Rahansiirto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Sisääntulot</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>tosi</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>epätosi</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, ei ole vielä onnistuneesti lähetetty</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Avoinna %n lisälohkolle</numerusform><numerusform>Avoinna %n lisälohkolle</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>tuntematon</translation>
     </message>
@@ -2896,12 +2276,10 @@ Osoite: %4</translation>
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Rahansiirron yksityiskohdat</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Tämä ruutu näyttää yksityiskohtaisen tiedon rahansiirrosta</translation>
     </message>
@@ -2909,127 +2287,102 @@ Osoite: %4</translation>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Päivämäärä</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Laatu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>Epäkypsä (%1 varmistusta, saatavilla %2 jälkeen)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Avoinna %n lisälohkolle</numerusform><numerusform>Avoinna %n lisälohkolle</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Avoinna %1 asti</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Vahvistettu (%1 vahvistusta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Tätä lohkoa ei vastaanotettu mistään muusta solmusta ja sitä ei mahdollisesti hyväksytä!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generoitu mutta ei hyväksytty</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Offline</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Varmistamaton</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Varmistetaan (%1 kehoitetusta %2 varmistuksesta)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>Ristiriitainen</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Vastaanotettu osoitteella</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Vastaanotettu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Saaja</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Maksu itsellesi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Louhittu</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(ei saatavilla)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Rahansiirron tila. Siirrä osoitin kentän päälle nähdäksesi vahvistusten lukumäärä.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Rahansiirron vastaanottamisen päivämäärä ja aika.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Rahansiirron laatu.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Rahansiirron kohteen Bitcoin-osoite</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Saldoon lisätty tai siitä vähennetty määrä.</translation>
     </message>
@@ -3037,178 +2390,142 @@ Osoite: %4</translation>
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Kaikki</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Tänään</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Tällä viikolla</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Tässä kuussa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Viime kuussa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Tänä vuonna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Alue...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Vastaanotettu osoitteella</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Saaja</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Itsellesi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Louhittu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Muu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Anna etsittävä osoite tai tunniste</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimimäärä</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopioi osoite</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopioi nimi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopioi määrä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopioi siirtotunnus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Muokkaa nimeä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Näytä rahansiirron yksityiskohdat</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Vie rahansiirtohistoria</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Vienti epäonnistui</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Rahansiirron historian tallentamisessa tapahtui virhe paikkaan %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Vienti onnistui</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>Rahansiirron historia tallennettiin onnistuneesti paikkaan %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Comma separated file (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Vahvistettu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Aika</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Laatu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Nimi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Osoite</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Määrä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Alue:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>kenelle</translation>
     </message>
@@ -3216,7 +2533,6 @@ Osoite: %4</translation>
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Lomakkoa ei ole ladattu.</translation>
     </message>
@@ -3224,7 +2540,6 @@ Osoite: %4</translation>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Lähetä Bitcoineja</translation>
     </message>
@@ -3232,42 +2547,34 @@ Osoite: %4</translation>
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation>&amp;Vie...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Vie auki olevan välilehden tiedot tiedostoon</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation>Varmuuskopioi lompakko</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Lompakkodata (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Varmuuskopio epäonnistui</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Lompakon tallennuksessa tapahtui virhe %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Lompakko tallennettiin onnistuneesti tiedostoon %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Varmuuskopio Onnistui</translation>
     </message>
@@ -3275,107 +2582,86 @@ Osoite: %4</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>Käyttö:</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>Lista komennoista</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Hanki apua käskyyn</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>Asetukset:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Määritä asetustiedosto (oletus: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Määritä pid-tiedosto (oletus: bitcoin.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Määritä data-hakemisto</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Kuuntele yhteyksiä portista &lt;port&gt; (oletus: 8333 tai testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Pidä enintään &lt;n&gt; yhteyttä verkkoihin (oletus: 125)</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Yhdistä noodiin hakeaksesi naapurien osoitteet ja katkaise yhteys</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation>Määritä julkinen osoitteesi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Kynnysarvo aikakatkaisulle heikosti toimiville verkoille (oletus: 100)</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Sekuntien määrä, kuinka kauan uudelleenkytkeydytään verkkoihin (oletus: 86400)</translation>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Virhe valmisteltaessa RPC-portin %u avaamista kuunneltavaksi: %s</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Kuuntele JSON-RPC -yhteyksiä portista &lt;port&gt; (oletus: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Hyväksy merkkipohjaiset- ja JSON-RPC-käskyt</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation>Bitcoin Core RPC asiakasversio</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Aja taustalla daemonina ja hyväksy komennot</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>Käytä test -verkkoa</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Hyväksy yhteyksiä ulkopuolelta (vakioasetus: 1 jos -proxy tai -connect ei määritelty)</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3400,852 +2686,682 @@ esimerkiksi: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Hyväksytyt koodit (oletus: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Virhe ilmennyt asetettaessa RPC-porttia %u IPv6:n kuuntelemiseksi, palataan takaisin IPv4:ään %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Kytkeydy annettuun osoitteeseen ja pidä linja aina auki. Käytä [host]:portin merkintätapaa IPv6:lle.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation>Yhtäaikaisesti rajaa vapaat rahansiirrot &lt;n&gt;*1000 tavua per minuutti (oletus: 15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Aloita regressio testimoodi joka käyttää erikoisketjua missä lohkot voidaan ratkaista välittömästi. Tämä on tarkoitettu regressiotestien työkaluksi ja ohjelman kehittämiseen.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>Aloita regression testimoodi joka käyttää erikoisketjua jossa lohkoja voidaan ratkaista välittömästi.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation>Virhe: Odottaessa sisääntulevia yhteyksiä epäonnistui (listen palautti virheen %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Virhe: Rahansiirto hylättiin! Tämä saattaa tapahtua jos jotkut kolikot lompakossa on jo käytetty. Esimerkiksi jos kopioit wallet.dat tiedoston ja kolikot on käytetty mutta ei merkattu täällä.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Virhe: Tämä rahansiirto vaatii rahansiirtopalkkion vähintään %s johtuen sen määrästä, monimutkaisuudesta tai hiljattain vastaanotettujen summien käytöstä</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Suorita käsky kun lompakossa rahansiirto muuttuu (%s cmd on vaihdettu TxID kanssa)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation>Tätä pienemmät palkkiot huomioidaan tyhjäksi (rahansiirron luonnissa) (oletus:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation>Aja tietokannan toimet muistivarannosta kovalevylogiin joka &lt;n&gt; megatavu (oletus: 100)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation>Kuinka vaativa lohkonvarmistus -checkblocks on (0-4, oletus:  3)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation>Tässä moodissa -genproclimit ohjaa kuinka monta lohkoa luodaan välittömästi.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation>Aseta script varmistuksen threadien lukumäärä (%u - %d, 0= auto, &lt;0 = jätä näin monta ydintä vapaaksi, oletus: %d)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation>Aseta prosessorin raja kun luonti on päällä (-1 = rajoittamaton, oletus: -1)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Tämä on esi-julkaistu testiversio - Käytä omalla riskillä - Ei saa käytää louhimiseen tai kauppasovelluksiin.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation>Ei voida yhdistää %s tässä tietokoneessa. Bitcoin Core on luultavasti jo käynnissä.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Käytä erillistä SOCKS5 proxya tavoittaaksesi vertaiset Tor palvelun kautta (oletus: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Varoitus: -paytxfee on asetettu erittäin korkeaksi! Tämä on maksukulu jonka tulet maksamaan kun lähetät siirron.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Varoitus: Tarkista että tietokoneesi kellonaika ja päivämäärä ovat paikkansapitäviä! Bitcoin ei toimi oikein väärällä päivämäärällä ja/tai kellonajalla.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Varoitus: Tietoverkko ei ole sovussa! Luohijat näyttävät kokevan virhetilanteita.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Varoitus: Olemme vertaisverkon kanssa ristiriidassa! Sinun tulee päivittää tai toisten solmujen tulee päivitää.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Varoitus: virhe luettaessa wallet.dat-lompakkotiedostoa. Kaikki avaimet luettiin onnistuneesti, mutta siirtohistoria tai osoitekirja saattavat olla kadonneet tai virheellisiä.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Varoitus: wallet.dat -lompakkotiedosto on korruptoitunut, tiedot pelastettu. Alkuperäinen wallet.dat -lompakkotiedosto on tallennettu wallet.{timestamp}.bak kansioon %s; jos balanssisi tai siirtohistoria on virheellinen, sinun tulisi palauttaa lompakkotiedosto varmuuskopiosta.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation>(oletus: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation>(oletus: wallet.dat)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; voi olla:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Yritetään palauttaa privaattiavaimia korruptoituneesta wallet.dat -lompakkotiedostosta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Bitcoin Core taustapalvelin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation>Lohkon luonnin asetukset:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Tyhjennä lompakon rahansiirtojen lista (diagnostiikka työkalu; olettaa -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Yhidstä ainoastaan määrättyihin noodeihin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Yhdistä SOCKS proxin kautta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Yhdistä JSON-RPC portissa &lt;port&gt; (oletus: 8332 tai testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation>Yhteyden valinnat:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation>Vioittunut lohkotietokanta havaittu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation>Debuggaus/Testauksen valinnat:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation>Poista safemode, ohita oikea turvallinen mooditapahtuma (oletus: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Hae oma IP osoite (vakioasetus: 1 kun kuuntelemassa ja ei -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Älä lataa lompakkoa ja poista lompakon RPC kutsut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Haluatko uudelleenrakentaa lohkotietokannan nyt?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Virhe alustaessa lohkotietokantaa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Virhe alustaessa lompakon tietokantaympäristöä %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Virhe avattaessa lohkoketjua</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Virhe avattaessa lohkoindeksiä</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Varoitus: Levytila on vähissä!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Virhe: Lompakko on lukittu, rahansiirtoa ei voida luoda</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Virhe: Järjestelmävirhe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Ei onnistuttu kuuntelemaan missään portissa. Käytä -listen=0 jos haluat tätä.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Lohkotietojen luku epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Lohkon luku epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Lohkoindeksin synkronointi epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Lohkoindeksin kirjoitus epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Lohkotiedon kirjoitus epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Lohkon kirjoitus epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Tiedoston tietojen kirjoitus epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Kolikkotietokannan kirjoitus epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Rahasiirtojen indeksin kirjoitus epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Palautustiedon kirjoitus epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>palkkio per kB lisätty lähettämiisi rahansiirtoihin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation>Tätä pienemmät palkkiot huomioidaan tyhjäksi (välittämisessä) (oletus:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Hae naapureita DNS hauilla (vakioasetus: 1 paitsi jos -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation>Pakota safe moodi (oletus: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation>Generoi kolikoita (vakio: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Kuinka monta lohkoa tarkistetaan käynnistettäessä (oletus: 288, 0 = kaikki)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>Jos &lt;kategoria&gt; ei annettu, tulosta kaikki debuggaustieto.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Virheellinen tai olematon alkulohko löydetty. Väärä data-hakemisto verkolle?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Virheellinen -onion osoite: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation>Ei tarpeeksi tiedostomerkintöjä vapaana.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>Lisää aikamerkki debug tulosteen eteen (oletus: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation>RPC asiakas valinnat:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Uudelleenrakenna lohkoketjuindeksi nykyisistä blk000??.dat tiedostoista</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Valitse SOCKS versio -proxy:lle (4 tai 5, oletus: 5)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation>Aseta tietokannan välimuistin koko megatavuissa (%d - %d, oletus: %d</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Aseta lohkon maksimikoko tavuissa (oletus: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Aseta threadien lukumäärä RPC kutsuille (oletus: 4)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Aseta lompakkotiedosto (data-hakemiston sisällä)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Käytä varmistamattomia vaihtorahoja lähetettäessä rahansiirtoja (oletus: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>Tämä on tarkoitettu regression testityökaluille ja ohjelman kehittämiseen.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Käyttö (vanhentunut, käytä bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Varmistetaan lohkoja...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Varmistetaan lompakko...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Odota RPC palvelimen käynnistystä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Lompakko %s sijaitsee data-hakemiston ulkopuolella %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Lompakon valinnat:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Varoitus: Vanhentunut argumentti -debugnet sivutettu, käytä debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Sinun tulee uudelleenrakentaa tietokanta käyttäen -reindex vaihtaen -txindex</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Tuodaan lohkoja ulkoisesta blk000??.dat tiedostosta</translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation>Ei voida lukita data-hakemistoa %s. Bitcoin Core on luultavasti jo käynnissä.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Aja komento kun olennainen hälytys vastaanotetaan tai nähdään todella pitkä haara (%s komennossa korvataan viestillä)</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Tulosta debuggaustieto (oletus: 0, annettu &lt;kategoria&gt; valinnainen)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Aseta maksimikoko korkea prioriteetti/pieni palkkio rahansiirtoihin tavuissa (oletus: %d)</translation>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>Tietoa</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Virheellinen määrä -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Virheellinen määrä -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation>Rajaa allekirjoituksen välimuistin koko &lt;n&gt; alkioon (oletus: 50000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation>Kirjaa rahansiirron prioriteetti ja palkkio per kB kun louhitaan lohkoja (oletus: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Ylläpidä täydellistä rahasiirtojen indeksiä (oletus: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Suurin vastaanottopuskuri yksittäiselle yhteydelle, &lt;n&gt;*1000 tavua (vakioasetus: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Suurin lähetyspuskuri yksittäiselle yhteydelle, &lt;n&gt;*1000 tavua (vakioasetus: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Hyväksy vain lohkoketjua vastaavat sisäänrakennetut varmistuspisteet (Oletus: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Yhdistä vain noodeihin verkossa &lt;net&gt; (IPv4, IPv6 tai Tor)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation>Tulosta lohko käynnistyksessä jos löydetään lohkoindeksistä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation>Tulosta lohkopuu käynnistyksessä (oletus: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>RPC SSL valinnat: (katso Bitcoin Wikistä SSL-asennuksen ohjeet)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation>RPC-palvelimen valinnat:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation>Satunnaisesti pudota 1 joka &lt;n&gt; verkkoviestistä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation>Satunnaisesti sekoita 1 joka &lt;n&gt; verkkoviestistä</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation>Aja threadi jossa tallennetaan lompakko ajoittain (oletus: 1)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL asetukset (katso Bitcoin Wikistä tarkemmat SSL ohjeet)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation>Lähetä komento Bitcoin Coreen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Lähetä jäljitys/debug-tieto konsoliin, debug.log-tiedoston sijaan</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Asetan pienin lohkon koko tavuissa (vakioasetus: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation>Asettaa DB_PRIVATE lipun lompakon tietokantaympäristössä (oletus: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation>Näytä kaikki debuggaus valinnat: (käyttö: --help -help-debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation>Näytä suorituskykytietoja (oletus: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Pienennä debug.log tiedosto käynnistyksen yhteydessä (vakioasetus: 1 kun ei -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Siirron vahvistus epäonnistui</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Määritä yhteyden aikakataisu millisekunneissa (vakioasetus: 5000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation>Käynnistä Bitcoin Core taustapalvelin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>Järjestelmävirhe:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Siirtosumma liian pieni</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Siirtosumman tulee olla positiivinen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Siirtosumma liian iso</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Käytä UPnP:tä kuunneltavan portin avaamiseen (vakioasetus: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Käytä UPnP:tä kuunneltavan portin avaamiseen (vakioasetus: 1 kun kuuntelemassa)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Käyttäjätunnus JSON-RPC-yhteyksille</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Varoitus</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Varoitus: Tämä versio on vanhentunut, päivitys tarpeen!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Tyhjennetään kaikki rahansiirrot lompakosta....</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation>käynnistyksessä</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>versio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat -lompakkotiedosto korruptoitunut, korjaaminen epäonnistui</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Salasana JSON-RPC-yhteyksille</translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Salli JSON-RPC yhteydet tietystä ip-osoitteesta</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Lähetä käskyjä solmuun osoitteessa &lt;ip&gt; (oletus: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Suorita käsky kun paras lohko muuttuu (%s cmd on vaihdettu block hashin kanssa)</translation>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Päivitä lompakko uusimpaan formaattiin</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Aseta avainpoolin koko arvoon &lt;n&gt; (oletus: 100)</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Skannaa uudelleen lohkoketju lompakon puuttuvien rahasiirtojen vuoksi</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Käytä OpenSSL:ää (https) JSON-RPC-yhteyksille</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Palvelimen sertifikaatti-tiedosto (oletus: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Palvelimen yksityisavain (oletus: server.pem)</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>Tämä ohjeviesti</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Kytkeytyminen %s tällä tietokonella ei onnistu (kytkeytyminen palautti virheen %d, %s)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Salli DNS kyselyt -addnode, -seednode ja -connect yhteydessä</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>Ladataan osoitteita...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Virhe ladattaessa wallet.dat-tiedostoa: Lompakko vioittunut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Virhe ladattaessa wallet.dat-tiedostoa: Tarvitset uudemman version Bitcoinista</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Lompakko tarvitsee uudelleenkirjoittaa: käynnistä Bitcoin uudelleen</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>Virhe ladattaessa wallet.dat-tiedostoa</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Virheellinen proxy-osoite &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Tuntematon verkko -onlynet parametrina: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Tuntematon -socks proxy versio pyydetty: %i</translation>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>-bind osoitteen &apos;%s&apos; selvittäminen epäonnistui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>-externalip osoitteen &apos;%s&apos; selvittäminen epäonnistui</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-paytxfee=&lt;amount&gt;: &apos;%s&apos; on virheellinen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Virheellinen määrä</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Lompakon saldo ei riitä</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>Ladataan lohkoindeksiä...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Linää solmu mihin liittyä pitääksesi yhteyden auki</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>Ladataan lompakkoa...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation>Et voi päivittää lompakkoasi vanhempaan versioon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Oletusosoitetta ei voi kirjoittaa</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>Skannataan uudelleen...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>Lataus on valmis</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>Käytä %s optiota</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>Virhe</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_fr.ts
+++ b/src/qt/locale/bitcoin_fr.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>À propos de Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>Version de &lt;b&gt;Bitcoin Core&lt;/b&gt; </translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ This product includes software developed by the OpenSSL Project for use in the O
  Ce produit comprend des logiciels développés par le projet OpenSSL afin d&apos;être utilisés dans la boîte à outils OpenSSL (http://www.openssl.org/), un logiciel de chiffrement écrit par Eric Young (eay@cryptsoft.com), et un logiciel UPnP développé par Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Tous droits réservés</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Les développeurs Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
-        <translation> (%1-bit)</translation>
+        <source>(%1-bit)</source>
+        <translation>(%1-bit)</translation>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Double cliquer afin de modifier l&apos;adresse ou l&apos;étiquette</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Créer une nouvelle adresse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nouveau</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copier l&apos;adresse courante sélectionnée dans le presse-papier</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copier</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>&amp;Fermer</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copier l&apos;adresse</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Effacer l&apos;adresse actuellement sélectionnée de la liste</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exporter les données de l&apos;onglet courant vers un fichier</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exporter</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Supprimer</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Choisir l&apos;adresse à laquelle envoyer des pièces</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Choisir l&apos;adresse avec laquelle recevoir des pîèces</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>C&amp;hoisir</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Adresses d&apos;envoi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Adresses de réception</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Voici vos adresses Bitcoin pour envoyer des paiements. Vérifiez toujours le montant et l&apos;adresse du destinataire avant d&apos;envoyer des pièces.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Voici vos adresses Bitcoin pour recevoir des paiements. Il est recommandé d&apos;utiliser une nouvelle adresse de réception pour chaque transaction.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copier l&apos;é&amp;tiquette</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Modifier</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exporter la liste d&apos;adresses</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Valeurs séparées par des virgules (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>L&apos;exportation a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Une erreur est survenue lors de l&apos;enregistrement de la liste d&apos;adresses vers %1.</translation>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(aucune étiquette)</translation>
     </message>
@@ -187,140 +153,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Dialogue de phrase de passe</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Saisir la phrase de passe</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nouvelle phrase de passe</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Répéter la phrase de passe</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Saisir la nouvelle phrase de passe pour le portefeuille. &lt;br/&gt;Veuillez utiliser une phrase de passe de &lt;b&gt;10 caractères aléatoires ou plus&lt;/b&gt;, ou de &lt;b&gt;huit mots ou plus&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Chiffrer le portefeuille</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Cette opération nécessite votre phrase de passe pour déverrouiller le portefeuille.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Déverrouiller le portefeuille</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Cette opération nécessite votre phrase de passe pour déchiffrer le portefeuille.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Déchiffrer le portefeuille</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Changer la phrase de passe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Saisir l’ancienne phrase de passe pour le portefeuille ainsi que la nouvelle.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmer le chiffrement du portefeuille</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Attention : Si vous chiffrez votre portefeuille et perdez votre phrase de passe, vous &lt;b&gt;PERDREZ TOUS VOS BITCOINS&lt;/b&gt; !</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Êtes-vous sûr de vouloir chiffrer votre portefeuille ?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>IMPORTANT : Toute sauvegarde précédente de votre fichier de portefeuille devrait être remplacée par le nouveau fichier de portefeuille chiffré. Pour des raisons de sécurité, les sauvegardes précédentes de votre fichier de portefeuille non chiffré deviendront inutilisables dès que vous commencerez à utiliser le nouveau portefeuille chiffré.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Attention : la touche Verr. Maj. est activée !</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Portefeuille chiffré</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin va à présent se fermer pour terminer le chiffrement. N&apos;oubliez pas que le chiffrement de votre portefeuille n&apos;est pas une protection totale contre le vol par des logiciels malveillants qui infecteraient votre ordinateur.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Le chiffrement du portefeuille a échoué</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Le chiffrement du portefeuille a échoué en raison d&apos;une erreur interne. Votre portefeuille n&apos;a pas été chiffré.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Les phrases de passe saisies ne correspondent pas.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Le déverrouillage du portefeuille a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La phrase de passe saisie pour déchiffrer le portefeuille était incorrecte.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Le déchiffrage du portefeuille a échoué</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>La phrase de passe du portefeuille a été modifiée avec succès.</translation>
     </message>
@@ -328,362 +260,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;Signer le message...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synchronisation avec le réseau en cours…</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vue d&apos;ensemble</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation>Nœud</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Afficher une vue d’ensemble du portefeuille</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transactions</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Parcourir l&apos;historique des transactions</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>Q&amp;uitter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Quitter l’application</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Afficher des informations à propos de Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>À propos de &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Afficher des informations sur Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Options…</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Chiffrer le portefeuille...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>Sauvegarder le &amp;portefeuille...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Changer la phrase de passe...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>Adresses d&apos;&amp;envoi...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>Adresses de &amp;réception...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Ouvrir un &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importation des blocs depuis le disque...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Réindexation des blocs sur le disque...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Envoyer des pièces à une adresse Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modifier les options de configuration de Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Sauvegarder le portefeuille vers un autre emplacement</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Modifier la phrase de passe utilisée pour le chiffrement du portefeuille</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Fenêtre de &amp;débogage</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Ouvrir une console de débogage et de diagnostic</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Vérifier un message...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Portefeuille</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Envoyer</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Recevoir</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Afficher / Cacher</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Afficher ou masquer la fenêtre principale</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Chiffrer les clefs privées de votre portefeuille</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Signer les messages avec vos adresses Bitcoin pour prouver que vous les détenez</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Vérifier les messages pour vous assurer qu&apos;ils ont été signés avec les adresses Bitcoin spécifiées</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Réglages</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barre d&apos;outils des onglets</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Demander des paiements (génère des codes QR et des URIs bitcoin:)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>À &amp;propos de Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Afficher la liste d&apos;adresses d&apos;envoi et d&apos;étiquettes utilisées</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Afficher la liste d&apos;adresses de réception et d&apos;étiquettes utilisées</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Ouvrir un URI bitcoin: ou une demande de paiement</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>Options de ligne de &amp;commande</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Afficher le message d&apos;aide de Bitcoin Core pour obtenir une liste des options de ligne de commande Bitcoin possibles.</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Client Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n connexion active avec le réseau Bitcoin</numerusform><numerusform>%n connexions actives avec le réseau Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Aucune source de blocs disponible...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>À traité %1 blocs sur %2 (estimés) de l&apos;historique des transactions.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>À traité %1 blocs de l&apos;historique des transactions.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n heure</numerusform><numerusform>%n heures</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n jour</numerusform><numerusform>%n jours</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n semaine</numerusform><numerusform>%n semaines</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 et %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n an</numerusform><numerusform>%n ans</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 en retard</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Le dernier bloc reçu avait été généré il y a %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Les transactions après ceci ne sont pas encore visibles.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>À jour</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Rattrapage en cours…</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transaction envoyée</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transaction entrante</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +552,14 @@ Adresse : %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Le portefeuille est &lt;b&gt;chiffré&lt;/b&gt; et est actuellement &lt;b&gt;déverrouillé&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Le portefeuille est &lt;b&gt;chiffré&lt;/b&gt; et actuellement &lt;b&gt;verrouillé&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Une erreur fatale est survenue. Bitcoin ne peut plus continuer de façon sûre et va s&apos;arrêter.</translation>
     </message>
@@ -714,7 +567,6 @@ Adresse : %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Alerte réseau</translation>
     </message>
@@ -722,291 +574,230 @@ Adresse : %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Sélection de l&apos;adresse de contrôle des pièces</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Quantité :</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Octets :</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Montant :</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Priorité :</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Frais :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Sortie faible :</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Après les frais :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Monnaie :</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>Tout (dé)sélectionner</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Mode arborescence</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Mode liste</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Confirmations</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmée</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Priorité</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Copier l’adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copier l’étiquette</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copier le montant</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Copier l&apos;ID de la transaction</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Verrouiller ce qui n&apos;est pas dépensé</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Déverrouiller ce qui n&apos;est pas dépensé</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Copier la quantité</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Copier les frais</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copier le montant après les frais</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copier les octets</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copier la priorité</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copier la sortie faible</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copier la monnaie</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation>la plus élevée</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>plus élevée</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>élevée</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>moyennement-élevée</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>moyenne</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>moyennement-basse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>basse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>plus basse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>la plus basse</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 verrouillé)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>aucun</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Poussière</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>oui</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>non</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Cette étiquette devient rouge si la taille de la transaction est plus grande que 1 000 octets.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Signifie que des frais d&apos;au moins 1% par ko sont requis.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Peut varier +/- 1 octet par entrée.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Les transactions à priorité plus haute sont plus à même d&apos;être incluses dans un bloc.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Cette étiquette devient rouge si la priorité est plus basse que « moyenne »</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Cette étiquette devient rouge si un destinataire reçoit un montant inférieur à 1%.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Signifie que des frais d&apos;au moins %1 sont requis.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Les montants inférieurs à 0,546 fois les frais minimums de relais sont affichés en tant que poussière.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Cette étiquette devient rouge si la monnaie rendue est inférieure à %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(aucune étiquette)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>monnaie de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(monnaie)</translation>
     </message>
@@ -1014,67 +805,54 @@ Adresse : %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Modifier l&apos;adresse</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Étiquette</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>L&apos;étiquette associée à cette entrée de la liste d&apos;adresses</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>L&apos;adresse associée à cette entrée de la liste d&apos;adresses. Ceci ne peut être modifié que pour les adresses d&apos;envoi.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adresse</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nouvelle adresse de réception</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nouvelle adresse d’envoi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Modifier l’adresse de réception</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Modifier l’adresse d&apos;envoi</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>L’adresse fournie « %1 » est déjà présente dans le carnet d&apos;adresses.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>L&apos;adresse fournie « %1 » n&apos;est pas une adresse Bitcoin valide.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Impossible de déverrouiller le portefeuille.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Échec de génération de la nouvelle clef.</translation>
     </message>
@@ -1082,27 +860,22 @@ Adresse : %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Un nouveau répertoire de données sera créé.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nom</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Le répertoire existe déjà. Ajoutez %1 si vous voulez créer un nouveau répertoire ici.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Le chemin existe déjà et n&apos;est pas un répertoire.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Impossible de créer un répertoire de données ici.</translation>
     </message>
@@ -1110,52 +883,46 @@ Adresse : %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - Options de ligne de commande</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>version</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Utilisation :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>options de ligne de commande</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Options de l&apos;interface utilisateur</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Définir la langue, par exemple « fr_CA » (par défaut : la langue du système)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Démarrer minimisé</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>Définir les certificats SSL racine pour les requêtes de paiement (par défaut : -système-)</translation>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Afficher l&apos;écran d&apos;accueil au démarrage (par défaut : 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Choisir un répertoire de données au démarrage (par défaut : 0)</translation>
     </message>
@@ -1163,57 +930,46 @@ Adresse : %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Bienvenue</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Bienvenue à Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Comme c&apos;est la première fois que le logiciel est lancé, vous pouvez choisir où Bitcoin Core stockera ses données.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core va télécharger et stocker une copie de la chaîne de blocs Bitcoin. Au moins %1Go de données seront stockées dans ce répertoire et cela augmentera avec le temps. Le portefeuille sera également stocké dans ce répertoire.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Utiliser le répertoire de données par défaut</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Utiliser un répertoire de données personnalisé :</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Erreur : le répertoire de données spécifié « %1 » ne peut pas être créé.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>Go d&apos;espace libre disponible</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(sur %1Go nécessaires)</translation>
     </message>
@@ -1221,27 +977,22 @@ Adresse : %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Ouvrir un URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Ouvrir une demande de paiement à partir d&apos;un URI ou d&apos;un fichier</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI :</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Choisir le fichier de demande de paiement</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Choisir le fichier de demande de paiement à ouvrir</translation>
     </message>
@@ -1249,253 +1000,206 @@ Adresse : %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>Réglages &amp;principaux</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Frais de transaction optionnel par ko qui aident à garantir un traitement rapide des transactions. La plupart des transactions utilisent 1 ko.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Payer des &amp;frais de transaction</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Démarrer Bitcoin automatiquement après avoir ouvert une session sur l&apos;ordinateur.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Démarrer Bitcoin lors de l&apos;ouverture d&apos;une session</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>Taille du cache de la base de &amp;données</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>Mo</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>Nombre d&apos;exétrons de &amp;vérification de script</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Défini le nombre d&apos;exétrons de vérification de script (jusqu&apos;à 16, 0 = auto, &lt;0 = laisse autant de cœurs libre, par défaut : 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation>&amp;Dépenser la monnaie non confirmée (experts seulement)</translation>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Se connecter au réseau Bitcoin par un mandataire SOCKS.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>Se &amp;connecter par un mandataire SOCKS (mandataire par défaut) :</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>Adresse IP du mandataire (par ex. IPv4 : 127.0.0.1 / IPv6 : ::1)</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation>Options actives de ligne de commande qui annulent les options ci-dessus :</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Réinitialiser toutes les options du client aux valeurs par défaut.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Réinitialisation des options</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Réseau</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation>(0 = auto, &lt; 0 = laisser ce nombre de cœurs inutilisés)</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation>&amp;Portefeuille</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation>Expert</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>Activer les fonctions de &amp;contrôle des pièces </translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>Si vous désactivé la dépense de la monnaie non confirmée, la monnaie d&apos;une transaction ne peut pas être utilisée tant que cette transaction n&apos;a pas reçu au moins une confirmation. Ceci affecte aussi comment votre solde est calculé.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>&amp;Dépenser la monnaie non confirmée</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Ouvrir le port du client Bitcoin automatiquement sur le routeur. Ceci ne fonctionne que si votre routeur supporte l&apos;UPnP et si la fonctionnalité est activée.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapper le port avec l&apos;&amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP du serveur mandataire :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Port du serveur mandataire (par ex. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Version SOCKS :</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Version SOCKS du serveur mandataire (par ex. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Fenêtre</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Afficher uniquement une icône système après minimisation.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimiser dans la barre système au lieu de la barre des tâches</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimiser au lieu de quitter l&apos;application lorsque la fenêtre est fermée. Si cette option est activée, l&apos;application ne pourra être fermée qu&apos;en sélectionnant Quitter dans le menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimiser lors de la fermeture</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Affichage</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Langue de l&apos;interface utilisateur :</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>La langue de l&apos;interface utilisateur peut être définie ici. Ce réglage sera pris en compte après redémarrage de Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unité d&apos;affichage des montants :</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Choisissez la sous-unité par défaut pour l&apos;affichage dans l&apos;interface et lors de l&apos;envoi de pièces.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Détermine si les adresses Bitcoin seront affichées sur la liste des transactions.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Afficher les adresses sur la liste des transactions</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Afficher ou non les fonctions de contrôle des pièces.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation>Afficher les fonctions de &amp;contrôle des pièces (experts seulement)</translation>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>A&amp;nnuler</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>par défaut</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>aucune</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Confirmer la réinitialisation des options</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Le redémarrage du client est nécessaire pour activer les changements.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>Le client sera arrêté, voulez-vous continuer?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Ce changement nécessite un redémarrage du client.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>L&apos;adresse de serveur mandataire fournie est invalide.</translation>
     </message>
@@ -1503,69 +1207,54 @@ Adresse : %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulaire</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Les informations affichées peuvent être obsolètes. Votre portefeuille est automatiquement synchronisé avec le réseau Bitcoin lorsque la connexion s&apos;établit, or ce processus n&apos;est pas encore terminé.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Portefeuille</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Disponible :</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Votre solde actuel pouvant être dépensé</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>En attente :</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Total des transactions qui doivent encore être confirmées et qu&apos;il n&apos;est pas encore possible de dépenser</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Immature :</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Le solde généré n&apos;est pas encore mûr</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total :</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Votre solde total actuel</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transactions récentes&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>désynchronisé</translation>
     </message>
@@ -1573,93 +1262,70 @@ Adresse : %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Gestion des URIs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>L&apos;URI ne peut être analysé ! Ceci peut être causé par une adresse Bitcoin invalide ou par des paramètres d&apos;URI mal composé.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Le paiement demandé d&apos;un montant de %1 est trop faible (considéré comme de la poussière).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Erreur de demande de paiement</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Impossible de démarrer le gestionnaire de cliquer-pour-payer bitcoin :</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Avertissement du gestionnaire de réseau</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>Votre serveur mandataire actif ne prend pas en charge SOCKS5 ce qui est exigé pour les demandes de paiements par serveur mandataire.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>L&apos;URL de récupération de la demande de paiement est invalide : %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Gestion des fichiers de demande de paiement</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>Le fichier de demande de paiement ne peut pas être lu ou traité ! Ceci peut être causé par un fichier de demande de paiement invalide.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Les demandes de paiements non vérifiées à des scripts de paiement personnalisés ne sont pas prises en charge.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Remboursement de %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Erreur de communication avec %1 : %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>La demande de paiement ne peut pas être analysée ou traitée !</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Mauvaise réponse du serveur %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Le paiement a été confirmé</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Erreur de demande réseau</translation>
     </message>
@@ -1667,23 +1333,22 @@ Adresse : %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Erreur : le répertoire de données spécifié « %1 » n&apos;existe pas.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Erreur : impossible d&apos;analyser le fichier de configuration : %1. N’utilisez que la syntaxe clef=valeur.</translation>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Erreur : combinaison invalide de -regtest et de -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Saisir une adresse Bitcoin (par ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1691,22 +1356,18 @@ Adresse : %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Sauvegarder l&apos;image...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Copier l&apos;image</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Sauvegarder le code QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>Image PNG (*.png)</translation>
     </message>
@@ -1714,192 +1375,146 @@ Adresse : %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nom du client</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N.D.</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Version du client</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informations</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Fenêtre de débogage</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Version d&apos;OpenSSL utilisée</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Heure de démarrage</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Réseau</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nom</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Nombre de connexions</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Chaîne de blocs</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Nombre actuel de blocs</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Nombre total estimé de blocs</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Horodatage du dernier bloc</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Ouvrir</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Console</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>Trafic &amp;réseau</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Nettoyer</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totaux</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>Entrant :</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>Sortant :</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Date de compilation</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Journal de débogage</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Ouvrir le journal de débogage de Bitcoin depuis le répertoire de données actuel. Ceci peut prendre quelques secondes pour les journaux de grande taille.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Nettoyer la console</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bienvenue sur la console RPC de Bitcoin.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Utiliser les touches de curseur pour naviguer dans l&apos;historique et &lt;b&gt;Ctrl-L&lt;/b&gt; pour effacer l&apos;écran.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Taper &lt;b&gt;help&lt;/b&gt; pour afficher une vue générale des commandes disponibles.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 o</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 Ko</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 Mo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 Go</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 min</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 min</translation>
     </message>
@@ -1907,105 +1522,82 @@ Adresse : %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Montant :</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Étiquette :</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>M&amp;essage :</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Réutilise une adresse de réception précédemment utilisée. Réutiliser une adresse pose des problèmes de sécurité et de vie privée. N&apos;utilisez pas cette option sauf si vous générez à nouveau une demande de paiement déjà faite.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>Ré&amp;utiliser une adresse de réception existante (non recommandé)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>Un message optionnel à joindre à la demande de paiement qui sera affiché à l&apos;ouverture de celle-ci. Note : le message ne sera pas envoyé avec le paiement par le réseau Bitcoin.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Un étiquette optionnelle à associer à la nouvelle adresse de réception</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Utiliser ce formulaire pour demander des paiements. Tous les champs sont  &lt;b&gt;optionnels&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Un montant optionnel à demander. Laisser ceci vide ou à zéro pour ne pas demander de montant spécifique.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Effacer tous les champs du formulaire.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Effacer</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Historique des paiements demandés</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Demande de paiement</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>Afficher la demande choisie (identique à un double-clic sur une entrée)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation>Enlever les entrées sélectionnées de la liste</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Enlever</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Copier l’étiquette</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Copier le message</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copier le montant</translation>
     </message>
@@ -2013,67 +1605,54 @@ Adresse : %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Code QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Copier l&apos;&amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Copier l&apos;&amp;adresse</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Sauvegarder l&apos;image...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Demande de paiement à %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Informations de paiement</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>L&apos;URI résultant est trop long, essayez de réduire le texte d&apos;étiquette / de message.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Erreur d&apos;encodage de l&apos;URI en code QR.</translation>
     </message>
@@ -2081,37 +1660,30 @@ Adresse : %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(pas d&apos;étiquette)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(pas de message)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(aucun montant)</translation>
     </message>
@@ -2119,247 +1691,194 @@ Adresse : %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Envoyer des pièces</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Fonctions de contrôle des pièces</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Entrants...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>choisi automatiquement</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Fonds insuffisants !</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Quantité :</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Octets :</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Montant :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Priorité :</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Frais :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Sortie faible</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Après les frais :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Monnaie :</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Si ceci est actif mais l&apos;adresse de monnaie rendue est vide ou invalide, la monnaie sera envoyée vers une adresse nouvellement générée.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Adresse personnalisée de monnaie rendue</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Envoyer à plusieurs destinataires à la fois</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Ajouter un &amp;destinataire</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Effacer tous les champs du formulaire.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Tout nettoyer</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Solde :</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Confirmer l’action d&apos;envoi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>E&amp;nvoyer</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirmer l’envoi des pièces</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 à %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Copier la quantité</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copier le montant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Copier les frais</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copier le montant après les frais</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copier les octets</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copier la priorité</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copier la sortie faible</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copier la monnaie</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Montant total %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>ou</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>L&apos;adresse du destinataire n’est pas valide, veuillez la vérifier.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Le montant à payer doit être supérieur à 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Le montant dépasse votre solde.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Le montant dépasse votre solde lorsque les frais de transaction de %1 sont inclus.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Adresse indentique trouvée, il n&apos;est possible d&apos;envoyer qu&apos;une fois à chaque adresse par opération d&apos;envoi.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>La création de la transaction a échoué !</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>La transaction a été rejetée ! Ceci peut arriver si certaines pièces de votre portefeuille étaient déjà dépensées, par exemple si vous avez utilisé une copie de wallet.dat et que des pièces ont été dépensées dans la copie sans être marquées comme telles ici.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Attention : adresse Bitcoin invalide</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(pas d&apos;étiquette)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Attention : adresse de monnaie rendue inconnue</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Êtes-vous sûr de vouloir envoyer ?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>ajouté en tant que frais de transaction</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>La demande de paiement a expiré</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Adresse de paiement invalide %1</translation>
     </message>
@@ -2367,98 +1886,74 @@ Adresse : %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Montant :</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Payer à :</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>L&apos;adresse à laquelle le paiement sera envoyé (par ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Saisir une étiquette pour cette adresse afin de l’ajouter à votre carnet d’adresses</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>É&amp;tiquette :</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Choisir une adresse déjà utilisée</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Ceci est un paiement normal.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Coller l&apos;adresse depuis le presse-papier</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Enlever cette entrée</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Message :</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Ceci est une demande de paiement vérifiée.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Saisir une étiquette pour cette adresse afin de l&apos;ajouter à la liste d&apos;adresses utilisées</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>Un message qui était joint à l&apos;URI Bitcoin et qui sera stocké avec la transaction pour référence. Note : ce message ne sera pas envoyé par le réseau Bitcoin.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Ceci est une demande de paiement non vérifiée.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Payer à :</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Mémo :</translation>
     </message>
@@ -2466,12 +1961,10 @@ Adresse : %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Arrêt de Bitcoin Core...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Ne pas fermer l&apos;ordinateur jusqu&apos;à la disparition de cette fenêtre.</translation>
     </message>
@@ -2479,186 +1972,142 @@ Adresse : %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Signatures - Signer / Vérifier un message</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Signer un message</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Vous pouvez signer des messages avec vos adresses pour prouver que vous les détenez. Faites attention de ne pas signer de vague car des attaques d&apos;hameçonnage peuvent essayer d&apos;usurper votre identité par votre signature. Ne signez que des déclarations entièrement détaillées et avec lesquelles vous serez d&apos;accord.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>L&apos;adresse avec laquelle le message sera signé (par ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Choisir une adresse précédemment utilisée</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Coller une adresse depuis le presse-papier</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Saisir ici le message que vous désirez signer</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Signature</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copier la signature actuelle dans le presse-papier</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Signer le message pour prouver que vous détenez cette adresse Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Signer le &amp;message</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Réinitialiser tous les champs de signature de message</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Tout nettoyer</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Vérifier un message</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Saisir ci-dessous l&apos;adresse de signature, le message (assurez-vous d&apos;avoir copié exactement les retours à la ligne, les espaces, tabulations etc...) et la signature pour vérifier le message. Faire attention à ne pas déduire davantage de la signature que ce qui est contenu dans le message signé lui-même pour éviter d&apos;être trompé par une attaque d&apos;homme du milieu.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>L&apos;adresse avec laquelle le message a été signé (par ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Vérifier le message pour vous assurer qu&apos;il a bien été signé par l&apos;adresse Bitcoin spécifiée</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Vérifier le &amp;message</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Réinitialiser tous les champs de vérification de message</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Saisir une adresse Bitcoin (par ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Cliquez sur « Signer le message » pour générer la signature</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>L&apos;adresse saisie est invalide.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Veuillez vérifier l&apos;adresse et réessayer.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>L&apos;adresse saisie ne fait pas référence à une clef.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Le déverrouillage du portefeuille a été annulé.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La clef privée pour l&apos;adresse indiquée n&apos;est pas disponible.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>La signature du message a échoué.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Le message a été signé.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>La signature n&apos;a pu être décodée.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Veuillez vérifier la signature et réessayer.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>La signature ne correspond pas à l&apos;empreinte du message.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Échec de la vérification du message.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Message vérifié.</translation>
     </message>
@@ -2666,17 +2115,14 @@ Adresse : %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Les développeurs Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2684,7 +2130,6 @@ Adresse : %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>Ko/s</translation>
     </message>
@@ -2692,184 +2137,138 @@ Adresse : %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Ouvert jusqu&apos;à %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>en conflit</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/hors ligne</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/non confirmée</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmations</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>État</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, diffusée à travers %n nœud</numerusform><numerusform>, diffusée à travers %n nœuds</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Source</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Généré</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>À</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>votre propre adresse</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>étiquette</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Crédit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>arrive à maturité dans %n bloc de plus</numerusform><numerusform>arrive à maturité dans %n blocs de plus</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>refusé</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Débit</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Frais de transaction</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Montant net</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Message</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Commentaire</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID de la transaction</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Marchand</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Les pièces générées doivent mûrir pendant %1 blocs avant de pouvoir être dépensées. Lorsque vous avez généré ce bloc, il a été diffusé sur le réseau pour être ajouté à la chaîne de blocs. S’il échoue a intégrer la chaîne, son état sera modifié en « non accepté » et il ne sera pas possible de le dépenser. Ceci peut arriver occasionnellement si un autre nœud génère un bloc à quelques secondes du votre.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Informations de débogage</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transaction</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Entrants</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>vrai</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>faux</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, n’a pas encore été diffusée avec succès</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Ouvert pour %n bloc de plus</numerusform><numerusform>Ouvert pour %n blocs de plus</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>inconnu</translation>
     </message>
@@ -2877,12 +2276,10 @@ Adresse : %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Détails de la transaction</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Ce panneau affiche une description détaillée de la transaction</translation>
     </message>
@@ -2890,127 +2287,102 @@ Adresse : %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>Immature (%1 confirmations, sera disponible après %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Ouvert pour %n bloc de plus</numerusform><numerusform>Ouvert pour %n blocs de plus</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Ouvert jusqu&apos;à %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmée (%1 confirmations)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Ce bloc n’a été reçu par aucun autre nœud et ne sera probablement pas accepté !</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Généré mais pas accepté</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Hors ligne</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Non confirmé</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Confirmation (%1 sur %2 confirmations recommandées)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>En conflit</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Reçue avec</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Reçue de</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Envoyée à</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Paiement à vous-même</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Extrait</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n.d)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>État de la transaction. Laissez le pointeur de la souris sur ce champ pour voir le nombre de confirmations.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Date et heure de réception de la transaction.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Type de transaction.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>L’adresse de destination de la transaction.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Montant ajouté ou enlevé au solde.</translation>
     </message>
@@ -3018,178 +2390,142 @@ Adresse : %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Toutes</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Aujourd’hui</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Cette semaine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Ce mois-ci</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Le mois dernier</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Cette année</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Intervalle…</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Reçue avec</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Envoyée à</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>À vous-même</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Extrait</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Autres</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Saisir une adresse ou une étiquette à rechercher</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Montant min.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copier l’adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copier l’étiquette</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copier le montant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copier l&apos;ID de la transaction</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Modifier l’étiquette</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Afficher les détails de la transaction</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation>Exporter l&apos;historique des transactions</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>L&apos;exportation a échoué</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Une erreur est survenue lors de l&apos;enregistrement de l&apos;historique des transactions vers %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Exportation réussie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>L&apos;historique des transactions a été sauvegardée avec succès vers %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Valeurs séparées par des virgules (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmée</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Date</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Étiquette</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Montant</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Intervalle :</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>à</translation>
     </message>
@@ -3197,7 +2533,6 @@ Adresse : %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Aucun portefeuille de chargé.</translation>
     </message>
@@ -3205,7 +2540,6 @@ Adresse : %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Envoyer des pièces</translation>
     </message>
@@ -3213,42 +2547,34 @@ Adresse : %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Exporter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exporter les données de l&apos;onglet courant vers un fichier</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Sauvegarder le portefeuille</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Données de portefeuille (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Échec de la sauvegarde</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Une erreur est survenue lors de l&apos;enregistrement des données de portefeuille vers %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Les données de portefeuille ont été enregistrées avec succès vers %1</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Sauvegarde réussie</translation>
     </message>
@@ -3256,107 +2582,86 @@ Adresse : %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Utilisation :</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Lister les commandes</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Obtenir de l’aide pour une commande</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Options :</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Spécifier le fichier de configuration (par défaut : bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Spécifier le fichier PID (par défaut : bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Spécifier le répertoire de données</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Définir la taille du tampon en mégaoctets (par défaut : 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Écouter les connexions sur le &lt;port&gt; (par défaut : 8333 ou testnet : 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Garder au plus &lt;n&gt; connexions avec les pairs (par défaut : 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Se connecter à un nœud pour obtenir des adresses de pairs puis se déconnecter</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Spécifier votre propre adresse publique</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Seuil de déconnexion des pairs de mauvaise qualité (par défaut : 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Délai en secondes de refus de reconnexion aux pairs de mauvaise qualité (par défaut : 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Une erreur est survenue lors du réglage du port RPC %u pour écouter sur IPv4 : %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Écouter les connexions JSON-RPC sur le &lt;port&gt; (par défaut : 8332 ou tesnet : 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Accepter les commandes de JSON-RPC et de la ligne de commande</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation>Version du client RPC de Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Fonctionner en arrière-plan en tant que démon et accepter les commandes</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Utiliser le réseau de test</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Accepter les connexions entrantes (par défaut : 1 si aucun -proxy ou -connect )</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,722 +2686,682 @@ par exemple : alertnotify=echo %%s | mail -s &quot;Alerte Bitcoin&quot; admin@fo
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Chiffrements acceptables (par défaut : TLSv1.2+HIGH : TLSv1+HIGH : !SSLv2 : !aNULL : !eNULL : !3DES : @STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Une erreur est survenue lors du réglage du port RPC %u pour écouter sur IPv6, retour à IPv4 : %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Se lier à l&apos;adresse donnée et toujours l&apos;écouter. Utilisez la notation [host]:port pour l&apos;IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Impossible d’obtenir un verrou sur le répertoire de données %s. Bitcoin fonctionne probablement déjà.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation>Limiter continuellement les transactions gratuites à &lt;n&gt;*1000 octets par minute (par défaut : 15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Entrer dans le mode de test de régression qui utilise une chaîne spéciale dans laquelle les blocs peuvent être résolus instantanément. Ceci est destiné aux outils de test de régression et au développement d&apos;applications.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>Passer en mode de test de régression qui utilise une chaîne spéciale dans laquelle les blocs sont résolus instantanément.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation>Erreur : l&apos;écoute des connexions entrantes a échoué (l&apos;écoute a retourné l&apos;erreur %d)</translation>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Erreur : La transaction a été rejetée ! Ceci peut arriver si certaines pièces de votre portefeuille étaient déjà dépensées, par exemple si vous avez utilisé une copie de wallet.dat et les pièces ont été dépensées avec cette copie sans être marquées comme tel ici.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Erreur : Cette transaction nécessite des frais de transaction d&apos;au moins %s en raison de son montant, de sa complexité ou de l&apos;utilisation de fonds reçus récemment !</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Exécuter la commande lorsqu&apos;une transaction de portefeuille change (%s dans la commande est remplacée par TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation>Les frais inférieurs à ce seuil sont considérés comme nuls (pour la création de transactions) (par défaut :</translation>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation>Purger l’activité de la base de données de la mémoire vers le journal sur disque tous les &lt;n&gt; mégaoctets (par défaut : 100)</translation>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation>À quel point la vérification des blocs -checkblocks est approfondie (0-4, par défaut : 3)</translation>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation>Dans ce mode -genproclimit contrôle combien de blocs sont générés immédiatement.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation>Définir le nombre d&apos;exétrons de vérification des scripts (%u à %d, 0 = auto, &lt; 0 = laisser ce nombre de cœurs inutilisés, par défaut : %d)</translation>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation>Définir la limite processeur définissant quand la génération est en fonction (-1 = illimité, par défaut : -1)</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Ceci est une pré-version de test - l&apos;utiliser à vos risques et périls - ne pas l&apos;utiliser pour miner ou pour des applications marchandes</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation>Impossible de se lier à %s sur cet ordinateur. Bitcoin Core fonctionne probablement déjà.</translation>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Utiliser un serveur mandataire SOCKS5 séparé pour atteindre les pairs par les services cachés de Tor (par défaut : -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Attention : -paytxfee est réglée sur un montant très élevé ! Il s&apos;agit des frais de transaction que vous payerez si vous envoyez une transaction.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Attention : Veuillez vérifier que la date et l&apos;heure de votre ordinateur sont justes ! Si votre horloge n&apos;est pas à l&apos;heure, Bitcoin ne fonctionnera pas correctement.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Attention : Le réseau ne semble pas totalement d&apos;accord ! Quelques mineurs semblent éprouver des difficultés.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Attention : Nous ne semblons pas être en accord complet avec nos pairs ! Vous pourriez avoir besoin d&apos;effectuer une mise à niveau, ou d&apos;autres nœuds du réseau pourraient avoir besoin d&apos;effectuer une mise à niveau.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Avertissement : une erreur est survenue lors de la lecture de wallet.dat ! Toutes les clefs ont été lues correctement mais les données de transaction ou les entrées du carnet d&apos;adresses sont peut-être incorrectes ou manquantes.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Avertissement : wallet.dat corrompu, données récupérées ! Le fichier wallet.dat original a été enregistré en tant que wallet.{timestamp}.bak dans %s ; si votre solde ou transactions sont incorrects vous devriez effectuer une restauration depuis une sauvegarde.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation>(par défaut : 1)</translation>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation>(par défaut : wallet.dat)</translation>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; peut être :</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Tenter de récupérer les clefs privées d&apos;un wallet.dat corrompu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Démon Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Version du client RPC Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Options de création de bloc :</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Effacer la liste des transactions du portefeuille (outil de diagnostic, implique un nouveau balayage -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Ne se connecter qu&apos;au(x) nœud(s) spécifié(s)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Connexion à travers un serveur mandataire SOCKS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Se connecter à JSON-RPC sur le &lt;port&gt; (par défaut : 8332 ou testnet : 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>Options de connexion :</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Base corrompue de données des blocs détectée</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation>Options de test/de débogage :</translation>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation>Désactiver le mode sans échec, passer outre un événement sans échec réel (par défaut : 0)</translation>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Découvrir sa propre adresse IP (par défaut : 1 lors de l&apos;écoute et si aucun -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Ne pas charger le portefeuille et désactiver les appels RPC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Voulez-vous reconstruire la base de données des blocs maintenant ?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Erreur lors de l&apos;initialisation de la base de données des blocs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Erreur lors de l&apos;initialisation de l&apos;environnement de la base de données du portefeuille %s !</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Erreur du chargement de la base de données des blocs</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Erreur lors de l&apos;ouverture de la base de données des blocs</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Erreur : l&apos;espace disque est faible !</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Erreur : Portefeuille verrouillé, impossible de créer la transaction !</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Erreur : erreur système :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Échec de l&apos;écoute sur un port quelconque. Utilisez -listen=0 si vous voulez ceci.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>La lecture des informations de bloc a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>La lecture du bloc a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>La synchronisation de l&apos;index des blocs a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>L&apos;&apos;écriture de l&apos;index des blocs a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>L&apos;écriture des informations du bloc a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>L&apos;écriture du bloc a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>L&apos;écriture des informations de fichier a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>L&apos;écriture dans la base de données des pièces a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>L&apos;écriture de l&apos;index des transactions a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>L&apos;écriture des données d&apos;annulation a échoué</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Frais par ko à ajouter aux transactions que vous envoyez</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation>Les frais inférieurs à ce seuil sont considérés comme nuls (pour le relayage) (par défaut :</translation>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Trouver des pairs en utilisant la recherche DNS (par défaut : 1 sauf si -connect est utilisé)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation>Forcer le mode sans échec (par défaut : 0)</translation>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Générer des pièces (défaut : 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Nombre de blocs à vérifier au démarrage (par défaut : 288, 0 = tout)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Niveau d&apos;approfondissement de la vérification des blocs (0-4, par défaut : 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>Si &lt;category&gt; n&apos;est pas indiqué, extraire toutes les données de débogage.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Bloc de genèse incorrect ou introuvable. Mauvais répertoire de données pour le réseau ?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Adresse -onion invalide : « %s »</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Pas assez de descripteurs de fichiers de disponibles.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>Ajouter l&apos;horodatage au début des résultats de débogage (par défaut : 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>Options du client RPC :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Reconstruire l&apos;index de la chaîne de blocs à partir des fichiers blk000??.dat courants</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Choisir la version SOCKS pour -proxy (4 ou 5, par défaut : 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Envoyer une commande au serveur Bitcoin</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation>Définir la taille du cache de la base de données en mégaoctets (%d to %d, default: %d)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Définir la taille minimale de bloc en octets (par défaut : %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Définir le nombre d&apos;exétrons pour desservir les appels RPC (par défaut : 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Spécifiez le fichier de portefeuille (dans le répertoire de données)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Dépenser la monnaie non confirmée lors de l&apos;envoi de transactions (par défaut : 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Démarrer le serveur Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>Ceci est à l&apos;intention des outils de test de régression et du développement applicatif.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Utilisation (obsolète, utiliser bitcoin-cli) :</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Vérification des blocs en cours...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Vérification du portefeuille en cours...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Attendre le démarrage du serveur RPC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Le portefeuille %s réside en dehors du répertoire de données %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Options du portefeuille :</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Attention : l&apos;argument obsolète -debugnet a été ignoré, utiliser -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Vous devez reconstruire la base de données en utilisant -reindex afin de modifier -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importe des blocs depuis un fichier blk000??.dat externe</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation>Impossible d’obtenir un verrou sur le répertoire de données %s. Bitcoin Core fonctionne probablement déjà.</translation>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Exécuter une commande lorsqu&apos;une alerte pertinente est reçue ou si nous voyons une bifurcation vraiment étendue (%s dans la commande est remplacé par le message)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Informations du résultat de débogage (par défaut : 0, fournir &lt;category&gt; est optionnel)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Définir la taille maximale en octets des transactions prioritaires/à frais modiques (par défaut : %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Définir le nombre d&apos;exétrons de vérification des scripts (maximum 16, 0 = auto, &lt; 0 = laisser ce nombre de cœurs libres, par défaut : 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informations</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Montant invalide pour -minrelayfee=&lt;montant&gt; : « %s »</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Montant invalide pour -mintxfee=&lt;montant&gt; : « %s »</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation>Limiter la taille du cache des signatures à &lt;n&gt; entrées (par défaut : 50000)</translation>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation>Journaliser la priorité des transactions et les frais par ko lors du minage (par défaut : 0) </translation>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Maintenir un index complet des transactions (par défaut : 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Tampon maximal de réception par « -connection » &lt;n&gt;*1 000 octets (par défaut : 5 000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Tampon maximal d&apos;envoi par « -connection », &lt;n&gt;*1 000 octets (par défaut : 1 000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>N&apos;accepter que la chaîne de blocs correspondant aux points de vérification internes (par défaut : 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Se connecter uniquement aux nœuds du réseau &lt;net&gt; (IPv4, IPv6 ou Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation>Imprimer le bloc au démarrage s&apos;il est trouvé dans l&apos;index des blocs</translation>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation>Imprimer l&apos;arborescence des blocs au démarrage (par défaut : 0)</translation>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>Options RPC SSL : (voir le wiki Bitcoin pour les instructions de configuration de SSL)</translation>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>Options du serveur RPC :</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation>Abandonner aléatoirement 1 message du réseau sur &lt;n&gt;</translation>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation>Tester aléatoirement 1 message du réseau sur &lt;n&gt;</translation>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation>Exécuter un exétron pour purger le portefeuille périodiquement (par défaut : 1) </translation>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Options SSL : (voir le Wiki de Bitcoin pour les instructions de configuration du SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation>Envoyer une commande à Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Envoyer les informations de débogage/trace à la console au lieu du fichier debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Définir la taille minimale de bloc en octets (par défaut : 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation>Définit le drapeau DB_PRIVATE dans l&apos;environnement de la base de données du portefeuille (par défaut : 1)</translation>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>Montrer toutes les options de débogage (utilisation : --help --help-debug)</translation>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation>Afficher les infos du test de performance (par défaut : 0)</translation>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Réduire le fichier debug.log lors du démarrage du client (par défaut : 1 lorsque -debug n&apos;est pas présent)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>La signature de la transaction a échoué</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Spécifier le délai d&apos;expiration de la connexion en millisecondes (par défaut : 5 000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation>Démarrer le démon Bitcoin Core</translation>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Erreur système :</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Montant de la transaction trop bas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Les montants de transaction doivent être positifs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transaction trop volumineuse</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Utiliser l&apos;UPnP pour rediriger le port d&apos;écoute (par défaut : 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Utiliser l&apos;UPnP pour rediriger le port d&apos;écoute (par défaut : 1 lors de l&apos;écoute)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nom d&apos;utilisateur pour les connexions JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Avertissement : cette version est obsolète, une mise à niveau est nécessaire !</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Supprimer toutes les transactions du portefeuille...</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>au démarrage</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>version</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corrompu, la récupération a échoué</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Mot de passe pour les connexions JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Autoriser les connexions JSON-RPC depuis l&apos;adresse IP spécifiée</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Envoyer des commandes au nœud fonctionnant sur &lt;ip&gt; (par défaut : 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Exécuter la commande lorsque le meilleur bloc change (%s dans cmd est remplacé par le hachage du bloc)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Mettre à niveau le portefeuille vers le format le plus récent</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Régler la taille de la réserve de clefs sur &lt;n&gt; (par défaut : 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Réanalyser la chaîne de blocs pour les transactions de portefeuille manquantes</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Utiliser OpenSSL (https) pour les connexions JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Fichier de certificat serveur (par défaut : server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Clef privée du serveur (par défaut : server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Ce message d&apos;aide</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Impossible de se lier à %s sur cet ordinateur (bind a retourné l&apos;erreur %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Autoriser les recherches DNS pour -addnode, -seednode et -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Chargement des adresses…</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Erreur lors du chargement de wallet.dat : portefeuille corrompu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Erreur lors du chargement de wallet.dat : le portefeuille exige une version plus récente de Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Le portefeuille devait être réécrit : redémarrer Bitcoin pour terminer l&apos;opération.</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Erreur lors du chargement de wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Adresse -proxy invalide : « %s »</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Réseau inconnu spécifié sur -onlynet : « %s »</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Version inconnue de serveur mandataire -socks demandée : %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Impossible de résoudre l&apos;adresse -bind : « %s »</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Impossible de résoudre l&apos;adresse -externalip : « %s »</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Montant invalide pour -paytxfee=&lt;montant&gt; : « %s »</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Montant invalide</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Fonds insuffisants</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Chargement de l’index des blocs…</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Ajouter un nœud auquel se connecter et tenter de garder la connexion ouverte</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Impossible de se lier à %s sur cet ordinateur. Bitcoin fonctionne probablement déjà.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Chargement du portefeuille…</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Impossible de revenir à une version inférieure du portefeuille</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Impossible d&apos;écrire l&apos;adresse par défaut</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Nouvelle analyse…</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Chargement terminé</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Pour utiliser l&apos;option %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_fr_CA.ts
+++ b/src/qt/locale/bitcoin_fr_CA.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Distribué sous licence MIT/X11, voir le fichier COPYING ou http://www.opensourc
 Ce produit comprend des logiciels développés par le projet OpenSSL pour être utilisés dans la boîte à outils OpenSSL (http://www.openssl.org/), un logiciel cryptographique écrit par Eric Young (eay@cryptsoft.com) et un logiciel UPnP écrit par Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Double-cliquez afin de modifier l&apos;adress ou l&apos;étiquette</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Créer une nouvelle adresse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copier l&apos;adresse surligné a votre presse-papier</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Supprimer</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ Ce produit comprend des logiciels développés par le projet OpenSSL pour être 
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -187,140 +153,106 @@ Ce produit comprend des logiciels développés par le projet OpenSSL pour être 
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -328,362 +260,286 @@ Ce produit comprend des logiciels développés par le projet OpenSSL pour être 
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -692,17 +548,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -710,7 +563,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -718,291 +570,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1010,67 +801,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1078,27 +856,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1106,52 +879,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1159,57 +926,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1217,27 +973,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1245,253 +996,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1499,69 +1203,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1569,93 +1258,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1663,23 +1329,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1687,22 +1352,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1710,192 +1371,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1903,105 +1518,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2009,67 +1601,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2077,37 +1656,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2115,247 +1687,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2363,98 +1882,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2462,12 +1957,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2475,186 +1968,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2662,17 +2111,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2680,7 +2126,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2688,184 +2133,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2873,12 +2272,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2886,127 +2283,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3014,178 +2386,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3193,7 +2529,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3201,7 +2536,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3209,42 +2543,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3252,107 +2578,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3367,722 +2672,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_gl.ts
+++ b/src/qt/locale/bitcoin_gl.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Sobre Bitcoin core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;Bitcoin core&lt;/b&gt; versión</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,18 +24,14 @@ Distribuído baixo a licencia de software MIT/X11, véxase o arquivo que acompa�
 Este produto inclúe software desenvolvido polo OpenSSL Project para o uso no OpenSSL Toolkit (http://www.openssl.org/) e software criptográfico escrito por Eric Young (eay@cryptsoft.com) e software UPnP escrito por Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Os desarrolladores de Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -46,122 +39,98 @@ Este produto inclúe software desenvolvido polo OpenSSL Project para o uso no Op
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Doble click para editar a dirección ou a etiqueta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crear unha nova dirección</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Novo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copiar a dirección seleccionada ao cartafol</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiar</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>&amp;Pechar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copiar Dirección</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Borrar a dirección actualmente seleccionada da listaxe</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar os datos da pestaña actual a un arquivo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Borrar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Escolle a dirección á que enviar moedas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Escolle a dirección da que recibir moedas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Escoller</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Direccións para enviar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Direccións para recibir</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Estas son as túas direccións Bitcoin para enviar pagos. Revisa sempre a cantidade e a dirección receptora antes de enviar moedas.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Estas son as túas direccións Bitcoin para recibir pagos. Recoméndase empregar unha nova dirección de recepción por cada transacción.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar &amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Modificar</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exportar Lista de Direccións</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Arquivo separado por comas (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Exportación falida</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ Este produto inclúe software desenvolvido polo OpenSSL Project para o uso no Op
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(sen etiqueta)</translation>
     </message>
@@ -187,140 +153,106 @@ Este produto inclúe software desenvolvido polo OpenSSL Project para o uso no Op
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Diálogo de Contrasinal</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Introduce contrasinal</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Novo contrasinal</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repite novo contrasinal</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introduce o novo contrasinal ao moedeiro.&lt;br/&gt;Por favor empregue un contrasinal de &lt;b&gt;10 ou máis caracteres aleatorios&lt;/b&gt;, ou &lt;b&gt;oito ou máis palabras&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Encriptar moedeiro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Esta operación precisa o contrasinal do teu moedeiro para desbloquear o moedeiro.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desbloquear moedeiro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Esta operación precisa o contrasinal do teu moedeiro para desencriptar o moedeiro.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Desencriptar moedeiro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Cambiar contrasinal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Introduce o vello e novo contrasinais no moedeiro.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar encriptación de moedeiro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Precaución: Se encriptas o teu moedeiro e perdes o teu contrasinal, ti &lt;b&gt;PERDERÁS TÓDOLOS TEUS BITCOINS&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Estás seguro de que desexas encriptar o teu moedeiro?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>IMPORTANTE: Calquera copia de seguridade previa que fixeses do teu arquivo de moedeiro debería ser substituída polo recén xerado arquivo encriptado de moedeiro. Por razóns de seguridade, as copias de seguridade previas de un arquivo de moedeiro desencriptado tornaránse inútiles no momento no que comeces a emprega-lo novo, encriptado, moedeiro.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Precaución: A tecla de Bloqueo de Maiúsculas está activada!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Moedeiro encriptado</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin se pechará agora para rematar o proceso de encriptación. Lembra que encriptar o teu moedeiro non protexe totalmente os teus bitcoins de ser robados por malware que infecte o teu ordenador.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Encriptación de moedeiro fallida</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>A encriptación do moedeiro fallou por mor dun erro interno. O teu moedeiro non foi encriptado.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Os contrasinais suministrados non coinciden.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Desbloqueo de moedeiro fallido</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>O contrasinal introducido para a desencriptación do moedeiro foi incorrecto.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Desencriptación de moedeiro fallida</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Cambiouse con éxito o contrasinal do moedeiro.</translation>
     </message>
@@ -328,363 +260,286 @@ Este produto inclúe software desenvolvido polo OpenSSL Project para o uso no Op
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;Asinar mensaxe...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sincronizando coa rede...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Vista xeral</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Amosar vista xeral do moedeiro</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transacciones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Navegar historial de transaccións</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Saír</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Saír da aplicación</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Amosar información sobre Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Acerca de &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Amosar información acerca de Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opcións...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Encriptar Moedeiro...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>Copia de &amp;Seguridade do Moedeiro...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Cambiar contrasinal...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importando bloques de disco...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Reindexando bloques no disco...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Enviar moedas a unha dirección Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modificar opcións de configuración para Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Facer copia de seguridade do moedeiro noutra localización</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cambiar o contrasinal empregado para a encriptación do moedeiro</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Ventana de &amp;Depuración</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Abrir consola de depuración e diagnóstico</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verificar mensaxe...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Moedeiro</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Recibir</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Amosar/Agachar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Amosar ou agachar a ventana principal</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Encriptar as claves privadas que pertencen ao teu moedeiro</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Asina mensaxes coas túas direccións Bitcoin para probar que te pertencen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verificar mensaxes para asegurar que foron asinados con direccións Bitcoin dadas.</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Arquivo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>Axus&amp;tes</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>A&amp;xuda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra de ferramentas</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Core de Bitcoin</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Solicitar pagos (xenera códigos QR e bitcoin: URIs)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;Sobre Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Amosar a listaxe de direccións e etiquetas para enviar empregadas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Amosar a listaxe de etiquetas e direccións para recibir empregadas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Abrir un bitcoin: URI ou solicitude de pago</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Cliente Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n conexión activa coa rede Bitcoin</numerusform><numerusform>%n conexións activas coa rede Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Non hai orixe de bloques dispoñible...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Procesados %1 de %2 bloques (estimados) del historial de transacciones.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Procesados %1 bloques do historial de transacccións.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hora</numerusform><numerusform>%n horas</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n día</numerusform><numerusform>%n días</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n semana</numerusform><numerusform>%n semanas</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 detrás</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>O último bloque recibido foi xerado fai %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>As transaccións despois desta non serán todavía visibles.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Precaución</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Actualizado</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Poñendo ao día...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transacción enviada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transacción entrante</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +552,14 @@ Dirección: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>O moedeiro está &lt;b&gt;encriptado&lt;/b&gt; e actualmente &lt;b&gt;desbloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>O moedeiro está &lt;b&gt;encriptado&lt;/b&gt; e actualmente &lt;b&gt;bloqueado&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Ocorriu un erro fatal. Bitcoin non pode continuar en condicións de seguridade e pecharáse.</translation>
     </message>
@@ -715,7 +567,6 @@ Dirección: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Alerta de Rede</translation>
     </message>
@@ -723,291 +574,230 @@ Dirección: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Cantidade:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Importe:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioridade:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Pago:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Cambiar:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(des)selecciona todo</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Modo árbore</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Modo lista</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Cantidade</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Confirmacións</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioridade</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copiar cantidade</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID de transacción</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Bloquear o aforrado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Desbloquear o aforrado</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidade</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Copiar pago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copiar despóis do pago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copiar prioridade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiar cambio</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>O máis alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>Máis alto que</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>medio-alto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>medio-baixo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>baixo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>máis baixo que</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>o máis baixo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 bloqueado)</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Limpar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>Si</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>non</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>As transacción con maior prioridade teñen máis posibilidades de ser incluidas nun bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(sen etiqueta)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(cambio)</translation>
     </message>
@@ -1015,67 +805,54 @@ Dirección: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Modificar Dirección</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiqueta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>A etiqueta asociada con esta entrada da listaxe de direccións</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>A dirección asociada con esta entrada na listaxe de dirección. Esta so pode ser modificada por direccións para enviar.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Dirección</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nova dirección para recibir</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nova dirección para enviar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Modificar dirección para recibir</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Modificar dirección para enviar</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>A dirección introducida &quot;%1&quot; xa está no libro de direccións.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>A dirección introducida &apos;%1&apos; non é unha dirección Bitcoin válida.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Non se puido desbloquear o moedeiro.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>A xeración de nova clave fallou.</translation>
     </message>
@@ -1083,27 +860,22 @@ Dirección: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation>Crearáse un novo directorio de datos.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nome</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>O directorio xa existe. Engade %1 se queres crear un novo directorio aquí.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>A ruta xa existe e non é un directorio.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Non se pode crear directorio de datos aquí</translation>
     </message>
@@ -1111,57 +883,46 @@ Dirección: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Core de Bitcoin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versión</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Emprego:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>opcións da liña de comandos</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>opcións de UI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Fixar idioma, por exemplo &quot;de_DE&quot; (por defecto: locale del sistema)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Comezar minimizado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Amosar pantalla splash no arranque (por defecto: 1)</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Escolle directorio de datos ao arrancar (por defecto: 0)</translation>
     </message>
@@ -1169,57 +930,46 @@ Dirección: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Benvido</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Empregar o directorio de datos por defecto</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Empregar un directorio de datos personalizado</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Erro: O directorio de datos especificado &quot;%1&quot; non pode ser creado.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB de espacio libre dispoñible</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(de %1 GB precisados)</translation>
     </message>
@@ -1227,27 +977,22 @@ Dirección: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Abrir URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Abrir solicitude de pago dende URI ou ficheiro</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Seleccionar ficheiro de solicitude de pago</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Seleccione ficheiro de solicitude de pago para abrir</translation>
     </message>
@@ -1255,258 +1000,206 @@ Dirección: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opcións</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Principal</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Tarifa por kB de transacción opcional que axuda a asegurar que as túas transaccións son procesadas rapidamente. A maioría das transaccións son 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Pagar &amp;tarifa da transacción</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Comezar Bitcoin automáticamente despois de loguearse no sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Comezar Bitcoin ao facer login no sistema</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Restaurar todas as opcións de cliente ás por defecto</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>Opcións de &amp;Restaurar</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Rede</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Abrir automáticamente o porto do cliente Bitcoin no router. Esto so funciona se o teu router soporta UPnP e está habilitado.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapear porto empregando &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP do Proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Porto:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Porto do proxy (exemplo: 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Version de SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Versión SOCKS del proxy (exemplo: 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Xanela</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Amosar so un icono na bandexa tras minimiza-la xanela.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimizar á bandexa en lugar de á barra de tarefas.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimizar en lugar de saír da aplicación cando se pecha a xanela. Cando se habilita esta opción, a aplicación so se pechará tras seleccionar Saír no menú.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimizar ao pechar</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Visualización</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Linguaxe de interface de usuario:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>A linguaxe de interface de usuario pode fixarse aquí. Esta configuración terá efecto tras reiniciar Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unidade na que amosar as cantidades:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Escolle a unidade de subdivisión por defecto para amosar na interface e ao enviar moedas.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Se se amosan ou non as direccións Bitcoin na listaxe de transaccións.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Visualizar direccións na listaxe de transaccións</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>por defecto</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation>Confirmar opcións de restaurar</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>A dirección de proxy suministrada é inválida.</translation>
     </message>
@@ -1514,69 +1207,54 @@ Dirección: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulario</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>A información amosada por estar desactualizada. O teu moedeiro sincronízase automáticamente coa rede Bitcoin despois de que se estableza unha conexión, pero este proceso non está todavía rematado.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Moedeiro</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>O teu balance actualmente dispoñible</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Total de transaccións que aínda teñen que ser confirmadas, e non contan todavía dentro do balance gastable</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Inmaduro:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>O balance minado todavía non madurou</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>O teu balance actual total</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transaccións recentes&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>non sincronizado</translation>
     </message>
@@ -1584,93 +1262,70 @@ Dirección: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Manexo de URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>Non se pode parsear a URI! Esto pode ser causado por unha dirección Bitcoin inválida ou parámetros da URI malformados.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>A cantidade de %1 na solicitude de pado é moi pequena (considerada po).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Erro na petición de pago</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Devolución dende %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Erro comunicando con %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Responsa errónea do servidor %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Pago admitido</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Erro de solicitude de rede</translation>
     </message>
@@ -1678,29 +1333,22 @@ Dirección: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Erro: O directorio de datos especificado &quot;%1&quot; non existe.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Erro: combinación inválida de -regtest e -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduce unha dirección Bitcoin (exemplo: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1708,22 +1356,18 @@ Dirección: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Gardar Imaxe...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Copiar Imaxe</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Gardar Código QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1731,194 +1375,146 @@ Dirección: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nome do cliente</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versión do cliente</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Información</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Usar versión OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Tempo de arranque</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Rede</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Número de conexións</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Cadea de bloques</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Número actual de bloques</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Bloques totais estimados</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Hora do último bloque</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Consola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Tráfico de Rede</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Limpar</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totais</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>Dentro:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>Fóra:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Data de construción</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Arquivo de log de depuración</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Abrir o arquivo de log de depuración de Bitcoin dende o directorio actual de datos. Esto pode levar uns cantos segundos para grandes arquivos de log.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Limpar consola</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Benvido á consola RPC de Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Emprega as flechas arriba e abaixo para navegar polo historial, e &lt;b&gt;Ctrl-L&lt;/b&gt; para limpar a pantalla.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Escribe &lt;b&gt;axuda&lt;/b&gt; para unha vista xeral dos comandos dispoñibles.</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1926,105 +1522,82 @@ Dirección: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Cantidade:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Mensaxe:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Reutilizar unha das direccións para recibir previas. Reutilizar direccións ten problemas de seguridade e privacidade. Non empregues esto agás que antes se fixese unha solicitude de rexeneración dun pago.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>R&amp;eutilizar unha dirección para recibir existente (non recomendado)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Limpar todos os campos do formulario</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Limpar</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Solicitar pago</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar cantidade</translation>
     </message>
@@ -2032,67 +1605,54 @@ Dirección: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Copiar &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Copiar &amp;Dirección</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Gardar Imaxe...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Solicitar pago a %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Información de Pago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Cantidade</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mensaxe</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>A URI resultante é demasiado larga, tenta reducir o texto para a etiqueta / mensaxe.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Erro codificando URI nun Código QR.</translation>
     </message>
@@ -2100,37 +1660,30 @@ Dirección: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mensaxe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Cantidade</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(sen etiqueta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2138,247 +1691,194 @@ Dirección: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Moedas Enviadas</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Cantidade:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Importe:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioridade:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Pago:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Cambiar:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Enviar a múltiples receptores á vez</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Engadir &amp;Receptor</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Limpar tódolos campos do formulario</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Limpar &amp;Todo</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Balance:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Confirmar a acción de envío</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirmar envío de moedas</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 a %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Copiar cantidade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar cantidade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Copiar pago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copiar despóis do pago</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copiar prioridade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiar cambio</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>A dirección de recepción non é válida, por favor compróbea.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>A cantidade a pagar debe ser maior que 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>A cantidade sobrepasa o teu balance.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>O total sobrepasa o teu balance cando se inclúe a tarifa de transacción %1.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Atopouse dirección duplicada, so se pode enviar a cada dirección unha vez por operación.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Atención:  Enderezo Bitcoin non válido</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(sen etiqueta)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Atención: Enderezo de cambio desconocido</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Seguro que queres enviar?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>engadido como tarifa de transacción</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>A petición de pago expirou</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Dirección de pago %1 inválida</translation>
     </message>
@@ -2386,98 +1886,74 @@ Dirección: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Cantidade:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Pagar &amp;A:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>A dirección á que enviar o pago (exemplo: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Introduce unha etiqueta para esta dirección para engadila ao teu libro de direccións</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiqueta:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Escoller dirección previamente empregada</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Este é un pago normal</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar dirección dende portapapeis</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Eliminar esta entrada</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Esta é unha solicitude de pago verificada</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Introduce unha etiqueta para esta dirección para engadila á listaxe de direccións empregadas</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Esta é unha solicitude de pago non verificada</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Pagar A:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memo:</translation>
     </message>
@@ -2485,12 +1961,10 @@ Dirección: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2498,186 +1972,142 @@ Dirección: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Sinaturas - Asinar / Verificar unha Mensaxe</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Asinar Mensaxe</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Podes asinar mensaxes coas túas direccións para probar que ti as posees. Ten conta de non asinar nada vago, xa que hai ataques de phishing que tentarán que asines coa túa identidade por riba deles. Asina únicamente declaracións totalmente detalladas coas que esteas de acordo.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>A dirección coa que asinar a mensaxe (exemplo: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Escoller dirección previamente empregada</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Pegar dirección dende portapapeis</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Introduce a mensaxe que queres asinar aquí</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Sinatura</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copiar a sinatura actual ao portapapeis do sistema</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Asina a mensaxe para probar que posees esta dirección Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Asinar &amp;Mensaxe</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Restaurar todos os campos de sinatura de mensaxe</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Limpar &amp;Todo</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verificar Mensaxe</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Introduce a dirección coa que asinar, a mensaxe (asegúrate de copiar exactamente os saltos de liña, espacios, tabulacións, etc.) e a sinatura debaixo para verificar a mensaxe. Ten coidado de non ler máis na sinatura do que hai no mensaxe asinado mesmo, a fin de evitar ser cazado nun ataque de home no medio.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>A dirección coa que foi firmada a mensaxe (exemplo: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verificar a mensaxe para asegurar que foi asinada coa dirección Bitcoin especificada</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verificar &amp;Mensaxe</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Restaurar todos os campos de verificación de mensaxe</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduza unha dirección Bitcoin (exemplo: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Click en &quot;Asinar Mensaxe&quot; para xerar sinatura</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>A dirección introducida é inválida.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Por favor comproba a dirección e proba de novo.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>A dirección introducida non se refire a ninguna clave.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Cancelouse o desbloqueo do moedeiro.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>A clave privada da dirección introducida non está dispoñible.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Fallou a sinatura da mensaxe.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Mensaxe asinada.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>A sinatura non puido ser decodificada.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Por favor revise a sinatura e probe de novo.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>A sinatura non coincide co resumo da mensaxe.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>A verificación da mensaxe fallou.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Mensaxe verificada.</translation>
     </message>
@@ -2685,17 +2115,14 @@ Dirección: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation>Core de Bitcoin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Os desarrolladores de Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2703,7 +2130,6 @@ Dirección: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2711,184 +2137,138 @@ Dirección: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Aberto ata %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/fóra de liña</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/sen confirmar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmacións</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, propagado a % nodo</numerusform><numerusform>, propagado a % nodos</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Orixe</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Xerado</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Dende</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>dirección propia</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etiqueta</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Crédito</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>madura nun bloque máis</numerusform><numerusform>madura en %n bloques máis</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>non aceptado</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Débito</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Tarifa de transacción</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Cantidade neta</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mensaxe</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Comentario</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID de Transacción</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Comerciante</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>As moedas xeradas deben madurar %1 bloques antes de que poidan ser gastadas. Cando xeraste este bloque, foi propagado á rede para ser engadido á cadeas de bloques. Se falla ao tentar meterse na cadea, o seu estado cambiará a &quot;non aceptado&quot; e non poderá ser gastado. Esto pode ocorrir ocasionalmente se outro nodo xera un bloque en poucos segundos de diferencia co teu.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Información de depuración</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transacción</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Entradas</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Cantidade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>verdadeiro</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, non foi propagado con éxito todavía</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abrir para %s bloque máis</numerusform><numerusform>Abrir para %n bloques máis</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>descoñecido</translation>
     </message>
@@ -2896,12 +2276,10 @@ Dirección: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detalles de transacción</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Este panel amosa unha descripción detallada da transacción</translation>
     </message>
@@ -2909,127 +2287,102 @@ Dirección: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Cantidade</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abrir para %n bloque máis</numerusform><numerusform>Abrir para %n bloques máis</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Aberto ata %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmacións)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Este bloque non foi recibido por ningún outro nodo e probablemente non será aceptado!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Xerado pero non aceptado</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Recibido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Recibido de</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Enviado a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pago a ti mesmo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Estado da transacción. Pasa por riba deste campo para amosar o número de confirmacións.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Data e hora na que foi recibida a transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipo de transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Dirección de destino da transacción.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Cantidade borrada ou engadida no balance.</translation>
     </message>
@@ -3037,178 +2390,142 @@ Dirección: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Todo</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hoxe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Esta semana</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Este mes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>O último mes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Este ano</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Periodo...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Recibido con</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Enviado a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>A ti mesmo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Outro</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Introduce dirección ou etiqueta para buscar</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Cantidade mínima</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copiar dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar cantidade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID de transacción</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Modificar etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Amosar detalles da transacción</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Exportar Historial de Transaccións</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Exportación falida</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Houbo un erro intentando salvar o historial  de transaccións a %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Exportado correctamente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>O historial de transaccións foi salvado correctamente en %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Arquivo separado por comas (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiqueta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Dirección</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Cantidade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Periodo:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>a</translation>
     </message>
@@ -3216,7 +2533,6 @@ Dirección: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Ningún moedeiro cargado</translation>
     </message>
@@ -3224,7 +2540,6 @@ Dirección: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Moedas Enviadas</translation>
     </message>
@@ -3232,42 +2547,34 @@ Dirección: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar os datos da pestaña actual a un arquivo.</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation>Copia de Seguridade de Moedeiro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Datos de Moedeiro (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Copia de Seguridade Fallida</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Houbo un erro intentando gardar os datos de moedeiro en %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Os datos do moedeiro foron gardados correctamente en %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Copia de Seguridade Correcta</translation>
     </message>
@@ -3275,107 +2582,86 @@ Dirección: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>Emprego:</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>Listar comandos</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Obter axuda para un comando</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>Opcións:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Especificar arquivo de configuración (por defecto: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Especificar arquivo de pid (por defecto: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Especificar directorio de datos</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Escoitar conexións no &lt;porto&gt; (por defecto: 8333 ou testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Manter como moito &lt;n&gt; conexións con pares (por defecto: 125)</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Conectar a nodo para recuperar direccións de pares, e desconectar</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation>Especificar a túa propia dirección pública</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Umbral para desconectar pares con mal comportamento (por defecto: 100)</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Número de segundos para manter sen reconectar aos pares con mal comportamento (por defecto: 86400)</translation>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Ocorreu un erro mentres se establecía o porto RPC %u para escoitar sobre IPv4: %s</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Escoitar conexións JSON-RPC no &lt;porto&gt; (por defecto: 8332 ou testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Aceptar liña de comandos e comandos JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Executar no fondo como un demo e aceptar comandos</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>Empregar a rede de proba</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Aceptar conexións de fóra (por defecto: 1 se non -proxy ou -connect)</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3400,852 +2686,682 @@ por exemplo: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Cifradores aceptables (por defecto: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ocorreu un erro mentres se establecía o porto RPC %u para escoitar sobre IPv6, voltando a IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Enlazar a unha dirección dada e escoitar sempre nela. Emprega a notación [host]:post para IPv6</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Entra en modo de test de regresión, que emprega unha cadea especial na que os bloques poden ser resoltos instantáneamente. Esto está pensado para ferramentes de testing de regresión e desenvolvemento de aplicacións.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Erro: A transacción foi rexeitada! Esto podería suceder se unha das moedas do teu moedeiro xa foi gastada, como se usas unha copia de wallet.dat e hai moedas que se gastaron na copia pero non foron marcadas como gastadas aquí.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Erro: Esta transacción require unha tarifa de transacción de alomenos %s debido á súa cantidade, complexidade ou emprego de fondos recentemente recibidos!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Executar comando cando unha transacción do moedeiro cambia (%s no comando é substituído por TxID)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Esta é unha build de test pre-lanzamento - emprégaa baixo o teu propio risco - non empregar para minado ou aplicacións de comerciantes</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Precaución: -paytxfee está posto moi algo! Esta é a tarifa de transacción que ti pagarás se envías unha transacción.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Precaución; Por favor revisa que a data e hora do teu ordenador son correctas! Se o teu reloxo está equivocato Bitcoin non funcionará adecuadamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Precaución: A rede non parece estar totalmente de acordo! Algúns mineitos parecen estar experimentando problemas.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Precaución: Non parece que esteamos totalmente de acordo cos nosos pares! Pode que precises actualizar, ou outros nodos poden precisar actualizarse.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Precaución: erro lendo wallet.dat! Tódalas claves lidas correctamente, pero os datos de transacción ou as entradas do libro de direccións podrían estar ausentes ou incorrectos.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Precaución: wallet.dat corrupto, datos salvagardados! O wallet.dat orixinal foi gardado como wallet.{timestamp}.bak en %s; se o teu balance ou transaccións son incorrectas deberías restauralas dende unha copia de seguridade.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;categoría&gt; pode ser:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Tentar recuperar claves privadas dende un wallet.dat corrupto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation>Opcións de creación de bloque:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Conectar so ao(s) nodo(s) especificado(s)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Conectar a JSON-RPC no &lt;porto&gt; (por defecto: 8332 ou testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation>Detectada base de datos de bloques corrupta.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Descobrir dirección IP propia (por defecto: 1 se á escoita e non -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Queres reconstruír a base de datos de bloques agora?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Erro inicializando a base de datos de bloques</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Erro inicializando entorno de base de datos de moedeiro %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Erro cargando base de datos do bloque</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Erro abrindo base de datos de bloques</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Erro: Espacio en disco escaso!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Erro: Moedeiro bloqueado, imposible crear transacción!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Erro: erro do sistema:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Fallou escoitar en calquera porto. Emprega -listen=0 se queres esto.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Fallou a lectura da información do bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Fallou a lectura do bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Fallou a sincronización do índice do bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Fallou a escritura do índice do bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Fallou a escritura da información do bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Fallou a escritura do bloque</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Fallou a escritura da información do arquivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Fallou a escritura na base de datos de moedas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Fallou a escritura do índice de transaccións</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Fallou a escritura dos datos para desfacer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Atopar pares usando lookup DNS (por defecto: 1 agás -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation>Xerar moedas (por defecto: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Cantos bloques para chequear ao arrancar (por defecto: 288, 0 = todos)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Bloque genesis incorrecto o no existente. Datadir erróneo para a rede?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Dirección -onion inválida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation>Non hai suficientes descritores de arquivo dispoñibles.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Reconstruír índice de cadea de bloque dende os ficheiros actuais blk000??.dat</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Fixar o número de fíos para as chamadas aos servicios RPC (por defecto: 4)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Especificar arquivo do moedeiro (dentro do directorio de datos)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Emprego (desaconsellado, usar bitcoin-cli)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verificando bloques...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Verificando moedeiro...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>O moedeiro %s reside fóra do directorio de datos %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Precisas reconstruír a base de datos empregando -reindex para cambiar -txindex</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importa bloques dende arquivos blk000??.dat externos</translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Executar comando cando se recibe unha alerta relevante ou vemos un fork realmente longo (%s no cmd é substituído pola mensaxe)</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>Información</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidade inválida para -minrelaytxfee=&lt;cantidade&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidade inválida para -mintxfee=&lt;cantidade&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Manter un índice completo de transaccións (por defecto: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Máximo buffer por-conexión para recibir, &lt;n&gt;*1000 bytes (por defecto: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Máximo buffer por-conexión para enviar, &lt;n&gt;*1000 bytes (por defecto: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Aceptar so cadeas de bloques coincidentes con check-points incorporados (por defecto: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Conectar so a nodos na rede &lt;net&gt; (IPv4, IPv6 ou Tor)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Opcións SSL: (ver ńa Wiki Bitcoin as instrucción de configuración de SSL)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Enviar traza/información de depuración á consola en lugar de ao arquivo debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Fixar tamaño mínimo de bloque en bytes (por defecto: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Recortar o arquivo debug.log ao arrancar o cliente (por defecto: 1 cando no-debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Fallou a sinatura da transacción</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Especificar tempo límite da conexión en milisegundos (por defecto: 5000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>Erro do sistema:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>A cantidade da transacción é demasiado pequena</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>As cantidades da transacción deben ser positivas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>A transacción é demasiado grande</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Usar UPnP para mapear o porto de escoita (por defecto: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Usar UPnP para mapear o porto de escoita (por defecto: 1 se á escoita)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nome de usuario para conexións JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Precaución</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Precaución: Esta versión é obsoleta, precísase unha actualización!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>versión</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corrupto, fallou o gardado</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Contrasinal para conexións JSON-RPC</translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permitir conexións JSON-RPC dende direccións IP especificadas</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Enviar comandos a nodo executando na &lt;ip&gt; (por defecto: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Executar comando cando o mellor bloque cambie (%s no comando é sustituído polo hash do bloque)</translation>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Actualizar moedeiro ao formato máis recente</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Fixar tamaño do pool de claves a &lt;n&gt; (por defecto: 100)</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Rescanear transaccións ausentes na cadea de bloques</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Empregar OpenSSL (https) para conexións JSON-RPC</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Arquivo de certificado do servidor (por defecto: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Clave privada do servidor (por defecto: server.perm)</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>Esta mensaxe de axuda</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Imposible enlazar con %s neste ordenador (enlace devolveu erro %d, %s)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permitir lookup de DNS para -addnote, -seednote e -connect</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>Cargando direccións...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Erro cargando wallet.dat: Moedeiro corrupto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Erro cargando wallet.dat: O moedeiro precisa unha versión máis nova de Bitcoin</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Precísase rescribir o moedeiro: reinicie Bitcoin para completar</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>Erro cargando wallet.dat</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Dirección -proxy inválida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Rede descoñecida especificada en -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Versión solicitada de proxy -socks descoñecida: %i</translation>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Non se pode resolver a dirección -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Non se pode resolver dirección -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Cantidade inválida para -paytxfee=&lt;cantidade&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Cantidade inválida</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Fondos insuficientes</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>Cargando índice de bloques...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Engadir un nodo ao que conectarse e tentar manter a conexión aberta</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>Cargando moedeiro...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation>Non se pode desactualizar o moedeiro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Non se pode escribir a dirección por defecto</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>Rescaneando...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>Carga completa</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>Empregar a opción %s</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_gu_IN.ts
+++ b/src/qt/locale/bitcoin_gu_IN.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_he.ts
+++ b/src/qt/locale/bitcoin_he.ts
@@ -1,18 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="he" version="2.1">
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="he" version="2.0">
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>על אודות ליבת ביטקוין</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
-        <translation type="unfinished"/>
+        <translation>&lt;b&gt;קליינט ביטקוין&lt;/b&gt; גירסאת</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ This product includes software developed by the OpenSSL Project for use in the O
 המוצר הזה כולל תוכנה שפותחה ע&quot;י פרויקט OpenSSL לשימוש בתיבת הכלים OpenSSL (http://www.openssl.org/) ותוכנה קריפטוגרפית שנכתבה ע&quot;י אריק יאנג (eay@cryptsoft.com) ותוכנת UPnP שנכתבה ע&quot;י תומס ברנרד.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>זכויות יוצרים</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>לחץ לחיצה כפולה לערוך כתובת או תוית</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>יצירת כתובת חדשה</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;חדש</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>העתק את הכתובת המסומנת ללוח העריכה</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
-        <translation type="unfinished"/>
+        <translation>&amp;העתק</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
-        <translation type="unfinished"/>
+        <translation>סגירה</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>העתק כתובת</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>מחק את הכתובת שנבחרה מהרשימה</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>יצוא הנתונים בטאב הנוכחי לקובץ</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;ייצא</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;מחק</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>בחר את הכתובת אליה תרצה לשלוח את המטבעות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>בחר את הכתובת איתה תרצה לקבל את המטבעות</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
-        <translation type="unfinished"/>
+        <translation>בחר</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>כתובת לשליחה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>קבל כתובות</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>אלה כתובת הביטקוין שלך עבור שליחת תשלומים. תמיד בדוק את מספר ואת כתובות מקבלי התשלומים לפני שליחת מטבעות.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>אלה כתובות הביטקוין שלך עבור קבלת תשלומים. מומלץ להשתמש בכתובת חדשה לכל פעולה.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>העתק תוית</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>עריכה</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>ייצוא רשימת כתובות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>קובץ מופרד בפסיקים (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>הייצוא נכשל</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>תוית</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>כתובת</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(ללא תוית)</translation>
     </message>
@@ -187,140 +153,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>שיח סיסמא</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>הכנס סיסמה</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>סיסמה חדשה</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>חזור על הסיסמה החדשה</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>הכנס את הסיסמה החדשה לארנק. &lt;br/&gt;אנא השתמש בסיסמה המכילה &lt;b&gt;10 תוים אקראיים או יותר&lt;/b&gt;, או &lt;b&gt;שמונה מילים או יותר&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>הצפן ארנק</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>הפעולה הזו דורשת את סיסמת הארנק שלך בשביל לפתוח את הארנק.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>פתיחת ארנק</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>הפעולה הזו דורשת את סיסמת הארנק שלך בשביל לפענח את הארנק.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>פענוח ארנק</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>שינוי סיסמה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>הכנס את הסיסמות הישנה והחדשה לארנק.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>אשר הצפנת ארנק</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>אזהרה: אם אתה מצפין את הארנק ומאבד את הסיסמא, אתה &lt;b&gt;תאבד את כל הביטקוינים שלך&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>האם אתה בטוח שברצונך להצפין את הארנק?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>חשוב! כל גיבוי קודם שעשית לארנק שלך יש להחליף עם קובץ הארנק המוצפן שזה עתה נוצר. מסיבות אבטחה, גיבויים קודמים של קובץ הארנק הלא-מוצפן יהפכו לחסרי שימוש ברגע שתתחיל להשתמש בארנק החדש המוצפן.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>זהירות: מקש Caps Lock מופעל!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>הארנק הוצפן</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>ביטקוין ייסגר עכשיו כדי להשלים את תהליך ההצפנה. זכור שהצפנת הארנק שלך אינו יכול להגן באופן מלא על הביטקוינים שלך מתוכנות זדוניות המושתלות על המחשב.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>הצפנת הארנק נכשלה</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>הצפנת הארנק נכשלה עקב שגיאה פנימית. הארנק שלך לא הוצפן.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>הסיסמות שניתנו אינן תואמות.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>פתיחת הארנק נכשלה</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>הסיסמה שהוכנסה לפענוח הארנק שגויה.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>פענוח הארנק נכשל</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>סיסמת הארנק שונתה בהצלחה.</translation>
     </message>
@@ -328,363 +260,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>חתום על הודעה</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>מסתנכרן עם הרשת...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;סקירה</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>הצג סקירה כללית של הארנק</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;פעולות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>דפדף בהיסטוריית הפעולות</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>י&amp;ציאה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>סגור תוכנה</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>הצג מידע על ביטקוין</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>אודות Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>הצג מידע על Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;אפשרויות</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>הצפן ארנק</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>גיבוי ארנק</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>שנה סיסמא</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>מייבא בלוקים מהדיסק...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>מחדש את אינדקס הבלוקים בדיסק...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>שלח מטבעות לכתובת ביטקוין</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>שנה אפשרויות תצורה עבור ביטקוין</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>גיבוי הארנק למקום אחר</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>שנה את הסיסמה להצפנת הארנק</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>חלון ניפוי</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>פתח את לוח הבקרה לאבחון וניפוי</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>אמת הודעה...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>ביטקוין</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>ארנק</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;שלח</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>וקבל</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>הצג / הסתר</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>הצג או הסתר את החלון הראשי</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>הצפן את המפתחות הפרטיים ששייכים לארנק שלך</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>חתום על הודעות עם כתובות הביטקוין שלך כדי להוכיח שהן בבעלותך</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>אמת הודעות כדי להבטיח שהן נחתמו עם כתובת ביטקוין מסוימות</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;קובץ</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>ה&amp;גדרות</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;עזרה</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>סרגל כלים טאבים</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[רשת-בדיקה]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>ליבת ביטקוין</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>בקש תשלומים (מייצר קודיי QR וסכימות URI של :bitcoin)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>&amp;אודות קליינט ביטקוין</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>הצג את רשימת הכתובות לשליחה שהיו בשימוש לרבות התוויות</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>הצג את רשימת הכתובות והתויות המשומשות</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>תוכנת ביטקוין</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>חיבור פעיל אחד לרשת הביטקוין</numerusform><numerusform>%n חיבורים פעילים לרשת הביטקוין</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>אין קוד נתון</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>%1 מתוך %2 (משוער) בלוקים של הסטוריית פעולות עובדו.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>הושלם עיבוד של %1 בלוקים של היסטוריית פעולות.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n שעה</numerusform><numerusform>%n שעות</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n יום</numerusform><numerusform>%n ימים</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n שבוע</numerusform><numerusform>%n שבועות</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>1% מאחור</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>הבלוק האחרון שהתקבל נוצר לפני %1</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>לאחר זאת פעולות נספות טרם יהיו גלויות</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>אזהרה</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>מידע</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>עדכני</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>מתעדכן...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>פעולה שנשלחה</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>פעולה שהתקבלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +551,14 @@ Address: %4
 כתובת: %4</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>הארנק &lt;b&gt;מוצפן&lt;/b&gt; וכרגע &lt;b&gt;פתוח&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>הארנק &lt;b&gt;מוצפן&lt;/b&gt; וכרגע &lt;b&gt;נעול&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+441"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>שגיאה סופנית אירעה. ביטקוין אינו יכול להמשיך לפעול בבטחה ולכן ייסגר.</translation>
     </message>
@@ -714,7 +566,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>אזעקת רשת</translation>
     </message>
@@ -722,291 +573,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>כמות:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>בייטים:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>כמות:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>קדימות:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>תשלום:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>לאחר עמלה:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>שינוי:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(מחק)(בחר) הכל</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>מצב עץ</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>מצר רשימה</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>כמות</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>כתובת</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>אישורים</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>מאושר</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>קדימות</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>העתק כתובת</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>העתק תוית</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>העתק כמות</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>העתק מזהה פעולה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>העתק כמות</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>העתק מחיר</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation type="unfinished"/>
+        <translation>העתק אחרי עמלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
-        <translation type="unfinished"/>
+        <translation>העתק בייטים</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>העתק קדימות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
-        <translation type="unfinished"/>
+        <translation>העתק עודף</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>הכי גבוה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>גבוהה יותר</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>גבוה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>בנוני גבוה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>בינוני</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>בינוני - נמוך</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>נמוך</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>נמוך יותר</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>הכי נמוך</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>אבק</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>כן</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>לא</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>תווית זו מאדימה במידה וגודל הפעולה עולה על 1000 בייט</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>זאת אומרת שנחוצה עמלה של לא פחות מ־%1 לכל קילו בייט.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
-        <translation type="unfinished"/>
+        <translation>הערך יכול להיות +/- בייט 1 פר כניסה</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
-        <translation type="unfinished"/>
+        <translation>העברות עם עדיפות גבוהה, יותר סיכוי שיכנסו לתוך הבלוק</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
-        <translation type="unfinished"/>
+        <translation>התווית הזו הופכת לאדומה, אם אחד מהנמענים מקבל סכום אשר קטן מ 1%</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
-        <translation type="unfinished"/>
+        <translation>זה אומר שצריך לפחות 1% עמלה</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+63"/>
         <source>(no label)</source>
         <translation>(ללא תוית)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>עודף מ־%1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(עודף)</translation>
     </message>
@@ -1014,67 +804,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>ערוך כתובת</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>ת&amp;וית</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>התוית המשויכת לרשומה הזו ברשימת הכתובות</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>הכתובת המשויכת עם רשומה זו ברשימת הכתובות. ניתן לשנות זאת רק עבור כתובות לשליחה.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;כתובת</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>כתובת חדשה לקבלה</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>כתובת חדשה לשליחה</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>ערוך כתובת לקבלה</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>ערוך כתובת לשליחה</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>הכתובת שהכנסת &quot;%1&quot; כבר נמצאת בפנקס הכתובות.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>הכתובת שהוכנסה &quot;%1&quot; אינה כתובת ביטקוין תקינה.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>פתיחת הארנק נכשלה.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>יצירת מפתח חדש נכשלה.</translation>
     </message>
@@ -1082,27 +859,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>ספריית מידע חדשה תיווצר.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>הספריה כבר קיימת. הוסף %1 אם ברצונך ליצור ספריה חדשה כאן.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>הנתיב כבר קיים ואינו מצביע על ספרייה.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>לא ניתן ליצור ספריית מידע כאן.</translation>
     </message>
@@ -1110,52 +882,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>ליבת ביטקוין</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>שימוש:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>אפשרויות שורת פקודה</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>אפשרויות ממשק</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>קבע שפה, למשל &quot;he_il&quot; (ברירת מחדל: שפת המערכת)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>התחל ממוזער</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>הצג מסך פתיחה בעת הפעלה (ברירת מחדל: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1163,57 +929,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>ברוך בואך</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
-        <translation type="unfinished"/>
+        <translation>ברוך הבא לקליינט ביטקוין</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>מכיוון שזאת הפעם הראשונה שהתוכנה הופעלה תוכל לבחור איפה ביטקויין קור תאכסן את </translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
-        <translation type="unfinished"/>
+        <translation>קליינט ביטקוין יוריד וישמור העתק של שרשרת הבלוקים של ביטקוין. לפחות %1GB מהנתונים יאוכסנו בתיקיה הזו, ויגדל עם הזמן. הארנק גם יאוחסן בתיקיה הזו.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>השתמש בברירת המחדל עבור ספריית המידע.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>השתמש בספריית מידע מותאמת אישית:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>ביטקוין</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
-        <translation type="unfinished"/>
+        <translation>שגיאה: אי אפשר ליצור את התיקיה &quot;%1&quot;</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>ג&quot;ב של שטח אחסון פנוי</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(מתוך %1 ג&quot;ב נחוצים)</translation>
     </message>
@@ -1221,27 +976,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
-        <translation type="unfinished"/>
+        <translation>פתח URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
-        <translation type="unfinished"/>
+        <translation>כתובת:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>בחירת קובץ בקשת תשלום</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>בחירת קובץ בקשת תשלום לפתיחה</translation>
     </message>
@@ -1249,258 +999,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>ראשי</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>עמלת פעולה אופציונלית לכל kB תבטיח שהפעולה שלך תעובד בזריזות. רוב הפעולות הן 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>שלם &amp;עמלת פעולה</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>הפעל את ביטקוין באופן עצמאי לאחר התחברות למערכת.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>התחל את ביטקוין בעת התחברות למערכת</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>מגה בייט</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>קבע את מספר תהליכוני אימות הסקריפטים (1-16, 0 = אוטומטי, ברירת מחדל: 0)</translation>
-    </message>
-    <message>
-        <location line="+153"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>אפס כל אפשרויות התוכנה לברירת המחדל.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>איפוס אפשרויות</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>רשת</translation>
     </message>
     <message>
-        <location line="-95"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>פתח את פורט ביטקוין בנתב באופן אוטומטי. עובד רק אם UPnP מאופשר ונתמך ע&quot;י הנתב.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>מיפוי פורט באמצעות UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>כתובת IP של פרוקסי:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>פורט:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>הפורט של הפרוקסי (למשל 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>גרסת SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>גרסת SOCKS של הפרוקסי (למשל 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>חלון</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>הצג סמל מגש בלבד לאחר מזעור החלון.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>מ&amp;זער למגש במקום לשורת המשימות</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>מזער את התוכנה במקום לצאת ממנה כשהחלון נסגר. כשאפשרות זו פעילה, התוכנה תיסגר רק לאחר בחירת יציאה מהתפריט.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>מזער בעת סגירה</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>תצוגה</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>שפת ממשק המשתמש:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>ניתן לקבוע כאן את שפת ממשק המשתמש. הגדרה זו תחול לאחר הפעלה מחדש של ביטקוין.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>יחידת מדידה להצגת כמויות:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>בחר את ברירת המחדל ליחידת החלוקה אשר תוצג בממשק ובעת שליחת מטבעות.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>האם להציג כתובות ביטקוין ברשימת הפעולות או לא.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>הצג כתובות ברשימת הפעולות</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>אישור</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>ברירת מחדל</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>אשר את איפוס האפשרויות</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>כתובת הפרוקסי שסופקה אינה תקינה.</translation>
     </message>
@@ -1508,69 +1206,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>טופס</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>המידע המוצג עשוי להיות מיושן. הארנק שלך מסתנכרן באופן אוטומטי עם רשת הביטקוין לאחר כינון חיבור, אך התהליך טרם הסתיים.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>ארנק</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>היתרה הזמינה הנוכחית</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>הסכום הכולל של פעולות שטרם אושרו, ועוד אינן נספרות בחישוב היתרה הזמינה</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>לא בשל:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>מאזן שנכרה וטרם הבשיל</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>סך הכול:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>סך כל היתרה הנוכחית שלך</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;פעולות אחרונות&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>לא מסונכרן</translation>
     </message>
@@ -1578,93 +1261,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>תפעול URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>לא ניתן לנתח URI! זה יכול להיגרם כתוצאה מכתובת ביטקוין לא תקינה או פרמטרי URI חסרי צורה תקינה.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>הסכום הנדרש לתשלום %1 קטן מדי (נחשב לאבק)</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>שגיאה בבקשת תשלום</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>לא ניתן להתחיל את ביטקוין: מפעיל לחץ-לתשלום </translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>בקשות לתשלום לסקריפטיי תשלום מותאמים אישית אינן נתמכות.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>החזר מ־%1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>שגיאה בתקשורת עם %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>מענה שגוי משרת %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>התשלום התקבל</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>שגיאת בקשת שרת</translation>
     </message>
@@ -1672,23 +1332,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+14"/>
         <source>Bitcoin</source>
         <translation>ביטקוין</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>שגיאה: הספריה &quot;%1&quot; לא קיימת.</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>שגיאה: שילוב בלתי חוקי של regtest- ו testnet-.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>הכנס כתובת ביטקוין (למשל 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1696,22 +1355,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;שמור תמונה..</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
-        <translation type="unfinished"/>
+        <translation>&amp;העתק תמונה</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>שמור קוד QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>תמונת PNG (*.png)</translation>
     </message>
@@ -1719,194 +1374,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>שם ממשק</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>גרסת ממשק</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>מידע</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
-        <translation type="unfinished"/>
+        <translation>חלון דיבאג</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>כללי</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>משתמש ב-OpenSSL גרסה</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>זמן אתחול</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>רשת</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>שם</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>מספר חיבורים</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>שרשרת הבלוקים</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>מספר הבלוקים הנוכחי</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>מספר כולל משוער של בלוקים</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>זמן הבלוק האחרון</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>לוח בקרה</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
-        <translation type="unfinished"/>
+        <translation>&amp;תעבורת רשת</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
-        <translation type="unfinished"/>
+        <translation>&amp; נקה</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>סכומים</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>נכנס:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>יוצא:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>תאריך בניה</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>קובץ יומן ניפוי</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>פתח את קובץ יומן הניפוי מתיקיית הנתונים הנוכחית. זה עשוי לקחת מספר שניות עבור קובצי יומן גדולים.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>נקה לוח בקרה</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>ברוכים הבאים ללוח בקרת RPC של ביטקוין</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>השתמש בחיצים למעלה ולמטה כדי לנווט בהיסטוריה, ו- &lt;b&gt;Ctrl-L&lt;/b&gt; כדי לנקות את המסך.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>הקלד &lt;b&gt;help&lt;/b&gt; בשביל סקירה של הפקודות הזמינות.</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 בייט</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 קילו בייט</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 מגה בייט</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 ג&apos;יגה בייט</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>1% דקות</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 שעות</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 שעות %2 דקות</translation>
     </message>
@@ -1914,105 +1521,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
-        <translation type="unfinished"/>
+        <translation>&amp;סכום:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>ת&amp;וית:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
-        <translation type="unfinished"/>
+        <translation>&amp;הודעה:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>השתמש שוב באחת מכתובות הקבלה שכבר נעשה בהן שימוש. לשימוש חוזר בכתובות ישהן השלכות אבטחה ופרטיות. השתמש בזה רק אם אתה מייצר מחדש בקשת תשלום שכבר נעשתה.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
-        <translation type="unfinished"/>
+        <translation>ש&amp;ימוש חוזר בכתובת קבלה קיימת(לא מומלץ)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>נקה את כל השדות</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>נקה</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
-        <translation type="unfinished"/>
+        <translation>&amp;בקש תשלום</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>הצג</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>הסר</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>העתק תוית</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>העתק כמות</translation>
     </message>
@@ -2020,67 +1604,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished"/>
+        <translation>העתק &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished"/>
+        <translation>התעק &amp;כתובת</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;שמור תמונה..</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
-        <translation type="unfinished"/>
+        <translation>בקש תשלום ל %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>אנפרומצייה על התשלום</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>כתובת (אתר או משאב)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>כתובת</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>כמות</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>תוית</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>הודעה</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>המזהה המתקבל ארוך מדי, נסה להפחית את הטקסט בתוית / הודעה.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>שגיאה בקידוד URI לקוד QR</translation>
     </message>
@@ -2088,37 +1659,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>תוית</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>הודעה</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>כמות</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(ללא תוית)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(אין הודעות)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2126,247 +1690,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>שלח מטבעות</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>ה</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
-        <translation type="unfinished"/>
+        <translation>כניסות...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>נבחר אוטומאטית</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>אין מספיק כספים!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>כמות:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>בייטים:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>כמות:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>קדימות:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>תשלום:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>לאחר עמלה:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>שינוי:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>כתובת לעודף מותאמת אישית</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>שלח למספר מקבלים בו-זמנית</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>הוסף מקבל</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>נקה את כל השדות</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>נקה הכל</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>יתרה:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>אשר את פעולת השליחה</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>שלח</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>אשר שליחת מטבעות</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 אל %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>העתק כמות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>העתק כמות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>העתק מחיר</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation type="unfinished"/>
+        <translation>העתק אחרי עמלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
-        <translation type="unfinished"/>
+        <translation>העתק בייטים</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>העתק קדימות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
-        <translation type="unfinished"/>
+        <translation>העתק עודף</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>או</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>כתובת המקבל אינה תקינה, אנא בדוק שנית.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>הכמות לשלם חייבת להיות גדולה מ-0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>הכמות עולה על המאזן שלך.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>הכמות הכוללת, ובכללה עמלת פעולה בסך %1, עולה על המאזן שלך.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>כתובת כפולה נמצאה, ניתן לשלוח לכל כתובת רק פעם אחת בכל פעולת שליחה.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>יצירת הפעולה נכשלה!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ללא תוית)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>האם אכן לשלוח?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>הוסף מחיר טיפול</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>תוקף בקשת תשלום פג</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>כתובת תשלום שגויה %1</translation>
     </message>
@@ -2374,98 +1885,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>כ&amp;מות:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>שלם &amp;ל:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>הכתובת שאליה ישלח התשלום (למשל 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>הכנס תוית לכתובת הזאת כדי להכניס לפנקס הכתובות</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>ת&amp;וית:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>בחר כתובת שהייתה בשימוש</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>זהו תשלום רגיל.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>הדבר כתובת מהלוח</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>הודעה:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>זוהי בקשה מאומתת לתשלום.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>הקלד תווית עבור כתובת זו בכדי להוסיף אותה לרשימת הכתובות בשימוש</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>זוהי בקשת תשלום בלתי־מאומתת.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>תשלום ל:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>תזכורת:</translation>
     </message>
@@ -2473,12 +1960,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>אין לכבות את המחשב עד שחלון זה נעלם.</translation>
     </message>
@@ -2486,186 +1971,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>חתימות - חתום או אמת הודעה</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>חתום על הו&amp;דעה</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>אתה יכול לחתום על הודעות עם הכתובות שלך כדי להוכיח שהן בבעלותך. היזהר לא לחתום על משהו מעורפל, שכן התקפות פישינג עשויות לגרום לך בעורמה למסור את זהותך. חתום רק על אמרות מפורטות לחלוטין שאתה מסכים עימן.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>הכתובת איתה לחתום על ההודעה (למשל 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>בחר כתובת שהייתה בשימוש</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>הדבק כתובת מהלוח</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>הכנס כאן את ההודעה שעליך ברצונך לחתום</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>חתימה</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>העתק את החתימה הנוכחית ללוח המערכת</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>חתום על ההודעה כדי להוכיח שכתובת הביטקוין הזו בבעלותך.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>חתום על הודעה</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>אפס את כל שדות החתימה על הודעה</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>נקה הכל</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>אמת הודעה</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>הכנס למטה את הכתובת החותמת, ההודעה (ודא שאתה מעתיק מעברי שורה, רווחים, טאבים וכו&apos; באופן מדויק) והחתימה כדי לאמת את ההודעה. היזהר לא לפרש את החתימה כיותר ממה שמופיע בהודעה החתומה בעצמה, כדי להימנע מליפול קורבן למתקפת איש-באמצע.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>הכתובת איתה ההודעה נחתמה (למשל 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>אמת את ההודעה כדי להבטיח שהיא נחתמה עם כתובת הביטקוין הנתונה</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>אימות הודעה</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>אפס את כל שדות אימות הודעה</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>הכנס כתובת ביטקוין (למשל 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>לחץ &quot;חתום על ההודעה&quot; כדי לחולל חתימה</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>הכתובת שהוכנסה אינה תקינה.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>אנא בדוק את הכתובת ונסה שנית.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>הכתובת שהוכנסה אינה מתייחסת למפתח.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>פתיחת הארנק בוטלה.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>המפתח הפרטי עבור הכתובת שהוכנסה אינו זמין.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>החתימה על ההודעה נכשלה.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>ההודעה נחתמה.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>לא ניתן לפענח את החתימה.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>אנא בדוק את החתימה ונסה שנית.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>החתימה לא תואמת את תקציר ההודעה.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>אימות ההודעה נכשל.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>ההודעה אומתה.</translation>
     </message>
@@ -2673,17 +2114,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>ליבת ביטקוין</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[רשת-בדיקה]</translation>
     </message>
@@ -2691,7 +2129,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>קילו בייט לשניה</translation>
     </message>
@@ -2699,184 +2136,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>פתוח עד %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/מנותק</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/ממתין לאישור</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 אישורים</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>מצב</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, הופץ דרך צומת אחד</numerusform><numerusform>, הופץ דרך %n צמתים</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>מקור</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>נוצר</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>מאת</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>אל</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>כתובת עצמית</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>תוית</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>זיכוי</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>מבשיל בעוד בלוק אחד</numerusform><numerusform>מבשיל בעוד %n בלוקים</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>לא התקבל</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>חיוב</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>עמלת פעולה</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>כמות נקיה</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>הודעה</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>הערה</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>זיהוי פעולה</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>סוחר</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>מטבעות חדשים שנוצרו חייבים להבשיל במשך %1 בלוקים לפני שניתן לנצל אותם. כשבלוק זה נוצר הוא שודר ברשת על מנת שייכנס לשרשרת הבלוקים. במקרה והוא לא ייכנס לשרשרת, מצבו ישתנה ל&quot;לא התקבל&quot; ולא ניתן יהיה לנצלו. זה יכול לקרות מדי פעם אם במקרה צומת אחרת ייצרה בלוק בהבדל של שניות בודדות ממך.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>מידע ניפוי</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>פעולה</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>קלטים</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>כמות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>אמת</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>שקר</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, טרם שודר בהצלחה</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>פתח למשך בלוק %n יותר</numerusform><numerusform>פתח למשך %n בלוקים נוספים</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>לא ידוע</translation>
     </message>
@@ -2884,12 +2275,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>פרטי הפעולה</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>חלונית זו מציגה תיאור מפורט של הפעולה</translation>
     </message>
@@ -2897,127 +2286,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>סוג</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>כתובת</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>כמות</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>פתח למשך בלוק %n יותר</numerusform><numerusform>פתח למשך %n בלוקים נוספים</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>פתוח עד %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>מאושר (%1 אישורים)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>הבלוק הזה לא נקלט על ידי אף צומת אחר, וכנראה לא יתקבל!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>נוצר אך לא התקבל</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>התקבל עם</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>התקבל מאת</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>נשלח ל</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>תשלום לעצמך</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>נכרה</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>מצב הפעולה. השהה את הסמן מעל שדה זה כדי לראות את מספר האישורים.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>התאריך והשעה בה הפעולה הזאת התקבלה.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>סוג הפעולה.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>כתובת היעד של הפעולה.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>הכמות שהתווספה או הוסרה מהיתרה.</translation>
     </message>
@@ -3025,178 +2389,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>הכל</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>היום</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>השבוע</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>החודש</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>החודש שעבר</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>השנה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>טווח...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>התקבל עם</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>נשלח ל</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>לעצמך</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>נכרה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>אחר</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>הכנס כתובת או תוית לחפש</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>כמות מזערית</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>העתק כתובת</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>העתק תוית</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>העתק כמות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>העתק מזהה פעולה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>ערוך תוית</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>הצג פרטי פעולה</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>יצוא היסטוריית פעולות</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>הייצוא נכשל</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>הייצוא בוצע בהצלחה</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>היסטוריית הפעולות נשמרה ל־%1 בהצלחה.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>קובץ מופרד בפסיקים (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>מאושר</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>תאריך</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>סוג</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>תוית</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>כתובת</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>כמות</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>מזהה</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>טווח:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>אל</translation>
     </message>
@@ -3204,7 +2532,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>לא נטען ארנק</translation>
     </message>
@@ -3212,7 +2539,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>שלח מטבעות</translation>
     </message>
@@ -3220,42 +2546,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;ייצא</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>יצוא הנתונים בטאב הנוכחי לקובץ</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>גבה ארנק</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>נתוני ארנק (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>גיבוי נכשל</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>גיבוי הושלם בהצלחה</translation>
     </message>
@@ -3263,102 +2581,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+226"/>
         <source>Usage:</source>
         <translation>שימוש:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>רשימת פקודות</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>קבל עזרה עבור פקודה</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>אפשרויות:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>ציין קובץ הגדרות (ברירת מחדל: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>ציין קובץ pid (ברירת מחדל: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>ציין תיקיית נתונים</translation>
     </message>
     <message>
-        <location line="-35"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>האזן לחיבורים ב&lt;פורט&gt; (ברירת מחדל: 8333 או ברשת הבדיקה: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>החזק לכל היותר &lt;n&gt; חיבורים לעמיתים (ברירת מחדל: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>התחבר לצומת כדי לדלות כתובות עמיתים, ואז התנתק</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>ציין את הכתובת הפומבית שלך</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>סף להתנתקות מעמיתים הנוהגים שלא כהלכה (ברירת מחדל: 100)</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>מספר שניות למנוע מעמיתים הנוהגים שלא כהלכה מלהתחבר מחדש (ברירת מחדל: 86400)</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>אירעה שגיאה בעת הגדרת פורט RPC %u להאזנה ב-IPv4: %s</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>האזן לחיבורי JSON-RPC ב- &lt;port&gt; (ברירת מחדל: 8332 או רשת בדיקה: 18332)</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>קבל פקודות משורת הפקודה ו- JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>רוץ ברקע כדימון וקבל פקודות</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>השתמש ברשת הבדיקה</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>קבל חיבורים מבחוץ (ברירת מחדל: 1 ללא -proxy או -connect)</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3383,732 +2685,682 @@ rpcpassword=%s
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>צפנים קבילים (ברירת מחדל: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>אירעה שגיאה בעת הגדרת פורט RPC %u להאזנה ב-IPv6, נסוג ל-IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>קשור עם כתובת נתונה והאזן לה תמיד. השתמש בסימון [host]:port עבוד IPv6.</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>כניסה למצב בדיקת רגרסיה, בה נעשה שימוש בשרשרת מיוחדת המאפשרת פתרון מיידי של בלוקים. מצב זה מיועד לכלי בדיקת רגרסיה ופיתוח תוכנה.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>שגיאה: הפעולה נדחתה! זה עלול לקרות אם כמה מהמטבעות בארנק שלך כבר נוצלו, למשל אם השתמשת בעותק של wallet.dat ומטבעות נשלחו בעותק אך לא סומנו כמנוצלות כאן.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>שגיאה: הפעולה הזאת דורשת עמלת פעולה של לפחות %s עקב הכמות, המורכבות, או השימוש בכספים שהתקבלו לאחרונה!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>בצע פקודה כאשר פעולת ארנק משתנה (%s ב cmd יוחלף ב TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>זוהי בניית ניסיון טרום-שחרור - השימוש בה על אחריותך - אין להשתמש לצורך כריה או יישומי מסחר</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>אזהרה: -paytxfee נקבע לערך מאד גבוה! זוהי עמלת הפעולה שתשלם אם אתה שולח פעולה.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>אזהרה: אנא בדוק שהתאריך והשעה של המחשב שלך נכונים! אם השעון שלך אינו נכון ביטקוין לא יעבוד כראוי.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>אזהרה: נראה שלא כל הרשת מסכימה! נראה שישנם כורים אשר נתקלים בבעיות.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>אזהרה: נראה שאנחנו לא מסכימים לחלוטין עם העמיתים שלנו! ייתכן ואנחנו צריכים לשדרג, או שצמתים אחרות צריכות לשדרג.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>אזהרה: שגיאה בקריאת wallet.dat! כל המתפחות נקראו באופן תקין, אך נתוני הפעולות או ספר הכתובות עלולים להיות חסרים או שגויים.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>אזהרה: קובץ wallet.dat מושחת, המידע חולץ! קובץ wallet.dat המקורח נשמר כ - wallet.{timestamp}.bak ב - %s; אם המאזן או הפעולות שגויים עליך לשחזר גיבוי.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>נסה לשחזר מפתחות פרטיים מקובץ wallet.dat מושחת.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>גרסת לקוח RPC של ביטקוין</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>אפשרויות יצירת בלוק:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>התחבר רק לצמתים המצוינים</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>התחבר ל JSON-RPC ב &lt;port&gt; (ברירת מחדל: 8332 או ברשת בדיקה: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>הגדרות חיבור:</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>התגלה מסד נתוני בלוקים לא תקין</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>גלה את כתובת ה-IP העצמית (ברירת מחדל: 1 כשמאזינים וללא -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>האם תרצה כעט לבנות מחדש את מסד נתוני הבלוקים?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>שגיאה באתחול מסד נתוני הבלוקים</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>שגיאה באתחול סביבת מסד נתוני הארנקים %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>שגיאה בטעינת מסד נתוני הבלוקים</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>שגיאה בטעינת מסד נתוני הבלוקים</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>שגיאה: מעט מקום פנוי בדיסק!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>שגיאה: הארנק נעול, אין אפשרות ליצור פעולה!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>שגיאה: שגיאת מערכת:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>האזנה נכשלה בכל פורט. השתמש ב- -listen=0 אם ברצונך בכך.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>קריאת מידע הבלוקים נכשלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>קריאת הבלוק נכשלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>סנכרון אינדקס הבלוקים נכשל</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>כתיבת אינדקס הבלוקים נכשל</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>כתיבת מידע הבלוקים נכשל</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>כתיבת הבלוק נכשלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>כתיבת מידע הקבצים נכשלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>כתיבת מסד נתוני המטבעות נכשלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>כתיבת אינדקס הפעולות נכשלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>כתיבת נתוני ביטול נכשלה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>עמלה לכל kB להוסיף לפעולות שאתה שולח</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>מצא עמיתים ע&quot;י חיפוש DNS (ברירת מחדל: 1 ללא -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>ייצר מטבעות (ברגיל: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>מספר הבלוקים לבדוק בעת אתחול (ברירת מחדל: 288, 0 = כולם)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>מידת היסודיות של אימות הבלוקים (0-4, ברירת מחדל: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>בלוק בראשית הינו שגוי או לא נמצא. ספריית מידע לא נכונה עבור הרשת?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>כתובת onion- שגויה: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>אין מספיק מידע על הקובץ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>בנה מחדש את אינדק שרשרת הבלוקים מקבצי ה-blk000??.dat הנוכחיים.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>שליחת פקודה לשרת הביטקוין</translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>קבע את מספר תהליכוני לשירות קריאות RPC (ברירת מחדל: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>ציין קובץ ארנק (בתוך ספריית המידע)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>הפעל ביטקוין סרוור</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>שימוש (מיושן, השתמש ב bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>מאמת את שלמות מסד הנתונים...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>מאמת את יושרת הארנק...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>הארנק %s יושב מחוץ לספריית המידע %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>עליך לבנות מחדש את מסד הנתונים תוך שימוש ב- -reindex על מנת לשנות את -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>מייבא בלוקים מקובצי blk000??.dat חיצוניים</translation>
     </message>
     <message>
-        <location line="-126"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>הרץ פקודה כאשר ההתראה הרלוונטית מתקבלת או כשאנחנו עדים לפיצול ארוך מאוד (%s בשורת הפקודה יוחלף ע&quot;י ההודעה)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>קבע את מספר תהליכוני אימות הסקריפטים (1-16, 0 = אוטומטי, ברירת מחדל: 0)</translation>
-    </message>
-    <message>
-        <location line="+91"/>
         <source>Information</source>
         <translation>מידע</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>כמות לא תקינה עבור -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>כמות לא תקינה עבור -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>תחזק אינדקס פעולות מלא (ברירת מחדל: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>חוצץ קבלה מירבי לכל חיבור, &lt;n&gt;*1000 בתים (ברירת מחדל: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>חוצץ שליחה מירבי לכל חיבור, &lt;n&gt;*1000 בתים (ברירת מחדל: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>קבל רק שרשרת בלוקים התואמת נקודות ביקורת מובנות (ברירת מחדל: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>התחבר רק לצמתים ברשת &lt;net&gt; (IPv4, IPv6 או Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>הגדרות שרת RPC</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>אפשרויות SSL: (ראה את הויקי של ביטקוין עבור הוראות הגדרת SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>שלח מידע דיבאג ועקבה לקונסולה במקום לקובץ debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>קבע את גודל הבלוק המינימלי בבתים (ברירת מחדל: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>כווץ את קובץ debug.log בהפעלת הקליינט (ברירת מחדל: 1 ללא -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>פעולה העברה נכשלה</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>ציין הגבלת זמן לחיבור במילישניות (ברירת מחדל: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>שגיאת מערכת:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>סכום העברה קטן מדי</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>סכום ההעברה חייב להיות חיובי</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>סכום העברה גדול מדי</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>השתמש ב-UPnP כדי למפות את הפורט להאזנה (ברירת מחדל: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>השתמש ב-UPnP כדי למפות את הפורט להאזנה (ברירת מחדל: 1 בעת האזנה)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>שם משתמש לחיבורי JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>אזהרה</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>אזהרה: הגרסה הזאת מיושנת, יש צורך בשדרוג!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>בפתיחה</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>גרסה</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>קובץ wallet.dat מושחת, החילוץ נכשל</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>סיסמה לחיבורי JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>אפשר חיבורי JSON-RPC מכתובת האינטרנט המצוינת</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>שלח פקודות לצומת ב-&lt;ip&gt; (ברירת מחדל: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-134"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>בצע פקודה זו כשהבלוק הטוב ביותר משתנה (%s בפקודה יוחלף בגיבוב הבלוק)</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Upgrade wallet to latest format</source>
         <translation>שדרג את הארנק לפורמט העדכני</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>קבע את גודל המאגר ל -&lt;n&gt; (ברירת מחדל: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>סרוק מחדש את שרשרת הבלוקים למציאת פעולות חסרות בארנק</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>השתמש ב-OpenSSL (https( עבור חיבורי JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>קובץ תעודת שרת (ברירת מחדל: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>מפתח פרטי של השרת (ברירת מחדל: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>הודעת העזרה הזו</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>לא מסוגל לקשור ל-%s במחשב זה (הקשירה החזירה שגיאה %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>אפשר בדיקת DNS עבור -addnode, -seednode ו- -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>טוען כתובות...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>שגיאה בטעינת הקובץ wallet.dat: הארנק מושחת</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>שגיאה בטעינת הקובץ wallet.dat: הארנק דורש גרסה חדשה יותר של ביטקוין</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>יש לכתוב מחדש את הארנק: אתחל את ביטקוין לסיום</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>שגיאה בטעינת הקובץ wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>כתובת -proxy לא תקינה: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>רשת לא ידועה צוינה ב- -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>התבקשה גרסת פרוקסי -socks לא ידועה: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>לא מסוגל לפתור כתובת -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>לא מסוגל לפתור כתובת -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>כמות לא תקינה עבור -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>כמות לא תקינה</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>אין מספיק כספים</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>טוען את אינדקס הבלוקים...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>הוסף צומת להתחברות ונסה לשמור את החיבור פתוח</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Loading wallet...</source>
         <translation>טוען ארנק...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>לא יכול להוריד דרגת הארנק</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>לא יכול לכתוב את כתובת ברירת המחדל</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>סורק מחדש...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>טעינה הושלמה</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>להשתמש באפשרות %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>שגיאה</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_hi_IN.ts
+++ b/src/qt/locale/bitcoin_hi_IN.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>कापीराइट</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>दो बार क्लिक करे पता या लेबल संपादन करने के लिए !</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>नया पता लिखिए !</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>चुनिन्दा पते को सिस्टम क्लिपबोर्ड पर कापी करे !</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;पता कॉपी करे</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;मिटाए !!</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>&amp;लेबल कॉपी करे </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;एडिट</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Comma separated file (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>लेबल</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>पता</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(कोई लेबल नही !)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>पहचान शब्द/अक्षर डालिए !</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>नया पहचान शब्द/अक्षर डालिए !</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>दोबारा नया पहचान शब्द/अक्षर डालिए !</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>नया पहचान शब्द/अक्षर वॉलेट मे डालिए ! &lt;br/&gt; कृपा करके पहचान शब्द में &lt;br&gt; 10 से ज़्यादा अक्षॉरों का इस्तेमाल करे &lt;/b&gt;,या &lt;b&gt;आठ या उससे से ज़्यादा शब्दो का इस्तेमाल करे&lt;/b&gt; !</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>एनक्रिप्ट वॉलेट !</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>वॉलेट खोलने के आपका वॉलेट पहचान शब्द्‌/अक्षर चाईए !</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>वॉलेट खोलिए</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>वॉलेट डीक्रिप्ट( विकोड) करने के लिए आपका वॉलेट पहचान शब्द्‌/अक्षर चाईए !</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation> डीक्रिप्ट वॉलेट</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>पहचान शब्द/अक्षर बदलिये !</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>कृपा करके पुराना एवं नया पहचान शब्द/अक्षर वॉलेट में डालिए !</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>वॉलेट एनक्रिपशन को प्रमाणित कीजिए !</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>वॉलेट एनक्रिप्ट हो गया !</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>वॉलेट एनक्रिप्ट नही हुआ!</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>वॉलेट एनक्रिपशन नाकाम हो गया इंटर्नल एरर की वजह से! आपका वॉलेट एनक्रीपत नही हुआ है!</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>आपके द्वारा डाले गये पहचान शब्द/अक्षर मिलते नही है !</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>वॉलेट का लॉक नही खुला !</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>वॉलेट डीक्रिप्ट करने के लिए जो पहचान शब्द/अक्षर डाले गये है वो सही नही है!</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>वॉलेट का डीक्रिप्ट-ष्ण असफल !</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,363 +255,287 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>नेटवर्क से समकालिक (मिल) रहा है ...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;विवरण</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>वॉलेट का सामानया विवरण दिखाए !</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp; लेन-देन
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>देखिए पुराने लेन-देन के विवरण !</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>बाहर जायें</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>अप्लिकेशन से बाहर निकलना !</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>बीटकोइन के बारे में जानकारी !</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;विकल्प</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;बैकप वॉलेट</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>पहचान शब्द/अक्षर जो वॉलेट एनक्रिपशन के लिए इस्तेमाल किया है उसे बदलिए!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>बीटकोइन</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>वॉलेट</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;फाइल</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;सेट्टिंग्स</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;मदद</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>टैबस टूलबार</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[टेस्टनेट]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n सक्रिया संपर्क बीटकोइन नेटवर्क से</numerusform><numerusform>%n सक्रिया संपर्क बीटकोइन नेटवर्क से</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n घंटा</numerusform><numerusform>%n घंटे</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n दिन</numerusform><numerusform>%n दिनो</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n हफ़्ता</numerusform><numerusform>%n हफ्ते</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 पीछे</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>भूल</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>चेतावनी</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>जानकारी</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>नवीनतम</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>भेजी ट्रांजक्शन</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>प्राप्त हुई ट्रांजक्शन</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -691,17 +547,14 @@ Address: %4
 पता:%4\n</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>वॉलेट एन्क्रिप्टेड है तथा अभी लॉक्ड नहीं है</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>वॉलेट एन्क्रिप्टेड है तथा अभी लॉक्ड है</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -709,7 +562,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -717,291 +569,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>राशि :</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>राशि</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>पता</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>taareek</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>पक्का</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>पता कॉपी करे</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>लेबल कॉपी करे </translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>कॉपी राशि</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(कोई लेबल नही !)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1009,67 +800,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>पता एडिट करना</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;लेबल</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;पता</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>नया स्वीकार्य पता</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>नया भेजने वाला पता</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>एडिट स्वीकार्य पता </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>एडिट भेजने वाला पता</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>डाला गया पता &quot;%1&quot; एड्रेस बुक में पहले से ही मोजूद है|</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>वॉलेट को unlock नहीं किया जा सकता|</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>नयी कुंजी का निर्माण असफल रहा|</translation>
     </message>
@@ -1077,27 +855,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1105,52 +878,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>संस्करण</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>खपत :</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1158,57 +925,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>बीटकोइन</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1216,27 +972,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1244,253 +995,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;ओके</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;कैन्सल</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1498,69 +1202,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>फार्म</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>वॉलेट</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;हाल का लेन-देन&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1568,93 +1257,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1662,23 +1328,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>बीटकोइन</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin एड्रेस लिखें (उदाहरण: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1686,22 +1351,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1709,193 +1370,147 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>लागू नही
 </translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1903,105 +1518,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>लेबल:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>लेबल कॉपी करे </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>कॉपी राशि</translation>
     </message>
@@ -2009,67 +1601,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>पता</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>राशि</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>लेबल</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2077,37 +1656,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>taareek</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>लेबल</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>राशि</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(कोई लेबल नही !)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2115,247 +1687,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>सिक्के भेजें|</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>राशि :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>एक साथ कई प्राप्तकर्ताओं को भेजें</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>बाकी रकम :</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>भेजने की पुष्टि करें</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>सिक्के भेजने की पुष्टि करें</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>कॉपी राशि</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>भेजा गया अमाउंट शुन्य से अधिक होना चाहिए|</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(कोई लेबल नही !)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2363,98 +1882,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>अमाउंट:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>प्राप्तकर्ता:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>आपकी एड्रेस बुक में इस एड्रेस के लिए एक लेबल लिखें</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>लेबल:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt-A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Clipboard से एड्रेस paste करें</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt-P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2462,12 +1957,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2475,186 +1968,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt-A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Clipboard से एड्रेस paste करें</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt-P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>हस्ताक्षर</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin एड्रेस लिखें (उदाहरण: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2662,17 +2111,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2680,7 +2126,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2688,184 +2133,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>खुला है जबतक %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/अपुष्ट</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 पुष्टियाँ</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>taareek</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>राशि</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>सही</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>ग़लत</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, अभी तक सफलतापूर्वक प्रसारित नहीं किया गया है</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>अज्ञात</translation>
     </message>
@@ -2873,12 +2272,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>लेन-देन का विवरण</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation> ये खिड़की आपको लेन-देन का विस्तृत विवरण देगी !</translation>
     </message>
@@ -2886,127 +2283,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>taareek</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>टाइप</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>पता</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>राशि</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>खुला है जबतक %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>पक्के  ( %1 पक्का करना)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>यह ब्लॉक किसी भी और नोड को मिला नही है ! शायद यह ब्लॉक कोई भी नोड स्वीकारे गा नही !</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>जेनरेट किया गया किंतु स्वीकारा नही गया !</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>स्वीकारा गया</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>स्वीकार्य ओर से</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>भेजा गया</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>भेजा खुद को भुगतान</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>माइंड</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(लागू नहीं)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>ट्रांसेक्शन स्तिथि| पुष्टियों की संख्या जानने के लिए इस जगह पर माउस लायें|</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>तारीख तथा समय जब ये ट्रांसेक्शन प्राप्त हुई थी|</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>ट्रांसेक्शन का प्रकार|</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>ट्रांसेक्शन की मंजिल का पता|</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>अमाउंट बैलेंस से निकला या जमा किया गया |</translation>
     </message>
@@ -3014,178 +2386,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>सभी</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>आज</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>इस हफ्ते</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>इस महीने</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>पिछले महीने</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>इस साल</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>विस्तार...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>स्वीकार करना</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>भेजा गया</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>अपनेआप को</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>माइंड</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>अन्य</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>ढूँदने के लिए कृपा करके पता या लेबल टाइप करे !</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>लघुत्तम राशि</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>पता कॉपी करे</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>लेबल कॉपी करे </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>कॉपी राशि</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>एडिट लेबल</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Comma separated file (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>पक्का</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>taareek</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>टाइप</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>लेबल</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>पता</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>राशि</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>विस्तार:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>तक</translation>
     </message>
@@ -3193,7 +2529,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3201,7 +2536,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3209,42 +2543,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>बैकप वॉलेट</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>वॉलेट डेटा (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>बैकप असफल</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>बैकप सफल</translation>
     </message>
@@ -3252,107 +2578,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>खपत :</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>commands की लिस्ट बनाएं</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>किसी command के लिए मदद लें</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>विकल्प:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>configuraion की फाइल का विवरण दें (default: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>pid फाइल का विवरण दें (default: bitcoin.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>डेटा डायरेक्टरी बताएं </translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>बैकग्राउंड में डेमॉन बन कर रन करे तथा कमांड्स स्वीकार करें </translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>टेस्ट नेटवर्क का इस्तेमाल करे </translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3367,722 +2672,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>ब्लॉक्स जाँचे जा रहा है...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>वॉलेट जाँचा जा रहा है...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>जानकारी</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>चेतावनी</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>संस्करण</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>पता पुस्तक आ रही है...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>राशि ग़लत है</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>ब्लॉक इंडेक्स आ रहा है...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>वॉलेट आ रहा है...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>रि-स्केनी-इंग...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>लोड हो गया|</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>भूल</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_hr.ts
+++ b/src/qt/locale/bitcoin_hr.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>O Bitcoin Jezrgu</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Autorsko pravo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dvostruki klik za uređivanje adrese ili oznake</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Dodajte novu adresu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopiraj trenutno odabranu adresu u međuspremnik</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopirati adresu</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Izvoz podataka iz trenutnog taba u datoteku</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Izvoz</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Brisanje</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopirati &amp;oznaku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Izmjeniti</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Datoteka vrijednosti odvojenih zarezom (*. csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(bez oznake)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Unesite lozinku</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nova lozinka</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Ponovite novu lozinku</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Unesite novi lozinku za novčanik. &lt;br/&gt; Molimo Vas da koristite zaporku od &lt;b&gt;10 ili više slučajnih znakova,&lt;/b&gt; ili &lt;b&gt;osam ili više riječi.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Šifriranje novčanika</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Ova operacija treba lozinku vašeg novčanika kako bi se novčanik otključao.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Otključaj novčanik</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Ova operacija treba lozinku vašeg novčanika kako bi se novčanik dešifrirao.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dešifriranje novčanika.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Promjena lozinke</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Unesite staru i novu lozinku za novčanik.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Potvrdi šifriranje novčanika</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Upozorenje: Ako šifrirate vaš novčanik i izgubite lozinku, &lt;b&gt;IZGUBIT ĆETE SVE SVOJE BITCOINSE!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Jeste li sigurni da želite šifrirati svoj novčanik?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Upozorenje: Tipka Caps Lock je uključena!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Novčanik šifriran</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin će se sada zatvoriti kako bi dovršio postupak šifriranja. Zapamtite da šifriranje vašeg novčanika ne može u potpunosti zaštititi vaše bitcoine od krađe preko zloćudnog softvera koji bi bio na vašem računalu.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Šifriranje novčanika nije uspjelo</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Šifriranje novčanika nije uspjelo zbog interne pogreške. Vaš novčanik nije šifriran.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Priložene lozinke se ne podudaraju.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Otključavanje novčanika nije uspjelo</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Lozinka za dešifriranje novčanika nije točna.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Dešifriranje novčanika nije uspjelo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Lozinka novčanika je uspješno promijenjena.</translation>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;Potpišite poruku...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Usklađivanje s mrežom ...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Pregled</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Prikaži opći pregled novčanika</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transakcije</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Pretraži povijest transakcija</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Izlaz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Izlazak iz programa</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Prikaži informacije o Bitcoinu</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Više o &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Prikaži informacije o Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Postavke</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Šifriraj novčanik...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Backup novčanika...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Promijena lozinke...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importiranje blokova sa diska...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Re-indeksiranje blokova na disku...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Slanje novca na bitcoin adresu</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Promijeni postavke konfiguracije za bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Napravite sigurnosnu kopiju novčanika na drugoj lokaciji</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Promijenite lozinku za šifriranje novčanika</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Potvrdite poruku...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Novčanik</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Pošalji</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Datoteka</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Konfiguracija</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Pomoć</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Traka kartica</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Jezgra</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin klijent</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktivna veza na Bitcoin mrežu</numerusform><numerusform>%n aktivne veze na Bitcoin mrežu</numerusform><numerusform>%n aktivnih veza na Bitcoin mrežu</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Obrađeno %1 blokova povijesti transakcije.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Greška</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Upozorenje</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informacija</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Ažurno</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Ažuriranje...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Poslana transakcija</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Dolazna transakcija</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -691,17 +547,14 @@ Adresa:%4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Novčanik je &lt;b&gt;šifriran&lt;/b&gt; i trenutno &lt;b&gt;otključan&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Novčanik je &lt;b&gt;šifriran&lt;/b&gt; i trenutno &lt;b&gt;zaključan&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -709,7 +562,6 @@ Adresa:%4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -717,291 +569,230 @@ Adresa:%4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Iznos:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Iznos</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Potvrđeno</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopirati adresu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopirati oznaku</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopiraj iznos</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(bez oznake)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1009,67 +800,54 @@ Adresa:%4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Izmjeni adresu</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Oznaka</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adresa</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nova adresa za primanje</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nova adresa za slanje</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Uredi adresu za primanje</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Uredi adresu za slanje</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Upisana adresa &quot;%1&quot; je već u adresaru.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Upisana adresa &quot;%1&quot; nije valjana bitcoin adresa.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Ne mogu otključati novčanik.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Stvaranje novog ključa nije uspjelo.</translation>
     </message>
@@ -1077,27 +855,22 @@ Adresa:%4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>ime</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1105,52 +878,46 @@ Adresa:%4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Jezgra</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>verzija</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Upotreba:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI postavke</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Pokreni minimiziran</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1158,57 +925,46 @@ Adresa:%4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Dobrodošli</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Pogreška</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(od potrebnog %1GB)</translation>
     </message>
@@ -1216,27 +972,22 @@ Adresa:%4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1244,253 +995,206 @@ Adresa:%4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Postavke</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Glavno</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Plati &amp;naknadu za transakciju</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Automatski pokreni Bitcoin kad se uključi računalo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Pokreni Bitcoin kod pokretanja sustava</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Mreža</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Automatski otvori port Bitcoin klijenta na ruteru. To radi samo ako ruter podržava UPnP i ako je omogućen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapiraj port koristeći &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Port od proxy-a (npr. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Verzija:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Prozor</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Prikaži samo ikonu u sistemskoj traci nakon minimiziranja prozora</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimiziraj u sistemsku traku umjesto u traku programa</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimizirati umjesto izaći iz aplikacije kada je prozor zatvoren. Kada je ova opcija omogućena, aplikacija će biti zatvorena tek nakon odabira Izlaz u izborniku.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimiziraj kod zatvaranja</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Prikaz</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Jedinica za prikazivanje iznosa:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Izaberite željeni najmanji dio bitcoina koji će biti prikazan u sučelju i koji će se koristiti za plaćanje.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Prikaži adrese u popisu transakcija</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;U redu</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Odustani</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>standardne vrijednosti</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1498,69 +1202,54 @@ Adresa:%4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Oblik</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Novčanik</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Ukupno:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Nedavne transakcije&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1568,93 +1257,70 @@ Adresa:%4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI upravljanje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1662,23 +1328,22 @@ Adresa:%4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Unesite Bitcoin adresu (npr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1686,22 +1351,18 @@ Adresa:%4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Spremi QR kod</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1709,192 +1370,146 @@ Adresa:%4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Ime klijenta</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Verzija klijenta</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informacija</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Koristim OpenSSL verziju</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Mreža</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Ime</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Broj konekcija</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Lanac blokova</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Trenutni broj blokova</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Procjenjeni ukupni broj blokova</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Posljednje vrijeme bloka</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Otvori</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konzola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Očisti konzolu</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Dobrodošli u Bitcoin RPC konzolu.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1902,105 +1517,82 @@ Adresa:%4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Oznaka:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Pokaži</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopirati oznaku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiraj iznos</translation>
     </message>
@@ -2008,67 +1600,54 @@ Adresa:%4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR kôd</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Iznos</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Poruka</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Rezultirajući URI je predug, probajte umanjiti tekst za naslov / poruku.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2076,37 +1655,30 @@ Adresa:%4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Poruka</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Iznos</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(bez oznake)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2114,247 +1686,194 @@ Adresa:%4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Slanje novca</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Iznos:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Pošalji k nekoliko primatelja odjednom</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;Dodaj primatelja</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Obriši &amp;sve</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Stanje:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Potvrdi akciju slanja</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Pošalji</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Potvrdi slanje novca</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiraj iznos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>ili</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresa primatelja je nevaljala, molimo provjerite je ponovo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Iznos mora biti veći od 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Iznos je veći od stanja računa.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Iznos je veći od stanja računa kad se doda naknada za transakcije od %1.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Pronašli smo adresu koja se ponavlja. U svakom plaćanju program može svaku adresu koristiti samo jedanput.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(bez oznake)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2362,98 +1881,74 @@ Adresa:%4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Iznos:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Primatelj plaćanja:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Unesite oznaku za ovu adresu kako bi ju dodali u vaš adresar</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Oznaka:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Zalijepi adresu iz međuspremnika</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Poruka:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Primatelj plaćanja:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2461,12 +1956,10 @@ Adresa:%4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2474,186 +1967,142 @@ Adresa:%4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Potpišite poruku</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Možete potpisati poruke sa svojom adresom kako bi dokazali da ih posjedujete. Budite oprezni da ne potpisujete ništa mutno, jer bi vas phishing napadi mogli na prevaru natjerati da prepišete svoj identitet njima. Potpisujte samo detaljno objašnjene izjave sa kojima se slažete.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Unesite Bitcoin adresu (npr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Zalijepi adresu iz međuspremnika</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Upišite poruku koju želite potpisati ovdje</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Potpis</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Obriši &amp;sve</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Potvrdite poruku</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Unesite Bitcoin adresu (npr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Unesite Bitcoin adresu (npr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Otključavanje novčanika je otkazano.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Poruka je potpisana.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2661,17 +2110,14 @@ Adresa:%4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Jezgra</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2679,7 +2125,6 @@ Adresa:%4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2687,184 +2132,138 @@ Adresa:%4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Otvoren do %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1 nije dostupan</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepotvrđeno</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potvrda</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Izvor</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generiran</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Za</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>vlastita adresa</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>oznaka</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Uplaćeno</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>Nije prihvaćeno</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Zaduženje</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Naknada za transakciju</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Neto iznos</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Poruka</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Komentar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID transakcije</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transakcija</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Unosi</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Iznos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, još nije bio uspješno emitiran</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>nepoznato</translation>
     </message>
@@ -2872,12 +2271,10 @@ Adresa:%4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detalji transakcije</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Ova panela prikazuje detaljni opis transakcije</translation>
     </message>
@@ -2885,127 +2282,102 @@ Adresa:%4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Iznos</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Otvoren do %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Potvrđen (%1 potvrda)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Generirano - Upozorenje: ovaj blok nije bio primljen od strane bilo kojeg drugog noda i vjerojatno neće biti prihvaćen!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generirano, ali nije prihvaćeno</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Primljeno s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Primljeno od</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Poslano za</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Plaćanje samom sebi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Rudareno</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/d)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status transakcije</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Datum i vrijeme kad je transakcija primljena</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Vrsta transakcije.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Odredište transakcije</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Iznos odbijen od ili dodan k saldu.</translation>
     </message>
@@ -3013,178 +2385,142 @@ Adresa:%4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Sve</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Danas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Ovaj tjedan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Ovaj mjesec</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Prošli mjesec</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Ove godine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Raspon...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Primljeno s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Poslano za</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Tebi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Rudareno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Ostalo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Unesite adresu ili oznaku za pretraživanje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Min iznos</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopirati adresu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopirati oznaku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiraj iznos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Izmjeniti oznaku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Datoteka podataka odvojenih zarezima (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Potvrđeno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tip</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Iznos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Raspon:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>za</translation>
     </message>
@@ -3192,7 +2528,6 @@ Adresa:%4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3200,7 +2535,6 @@ Adresa:%4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Slanje novca</translation>
     </message>
@@ -3208,42 +2542,34 @@ Adresa:%4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Izvoz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Izvoz podataka iz trenutnog taba u datoteku</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Podaci novčanika (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3251,107 +2577,86 @@ Adresa:%4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Upotreba:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Prikaži komande</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Potraži pomoć za komandu</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Postavke:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Odredi konfiguracijsku datoteku (ugrađeni izbor: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Odredi proces ID datoteku (ugrađeni izbor: bitcoin.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Odredi direktorij za datoteke</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Postavi cache za bazu podataka u MB (zadano:25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Slušaj na &lt;port&gt;u (default: 8333 ili testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Održavaj najviše &lt;n&gt; veza sa članovima (default: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Prag za odspajanje članova koji se čudno ponašaju (default: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Broj sekundi koliko se članovima koji se čudno ponašaju neće dopustiti da se opet spoje (default: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Prihvaćaj JSON-RPC povezivanje na portu broj &lt;port&gt; (ugrađeni izbor: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Prihvati komande iz tekst moda i JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Izvršavaj u pozadini kao uslužnik i prihvaćaj komande</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Koristi test mrežu</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3366,722 +2671,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Upozorenje: -paytxfee je podešen na preveliki iznos.  To je iznos koji ćete platiti za obradu transakcije.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Upozorenje: Molimo provjerite jesu li datum i vrijeme na vašem računalu točni. Ako vaš sat ide krivo, Bitcoin neće raditi ispravno.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Opcije za kreiranje bloka:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Poveži se samo sa određenim nodom</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Pogreška: Nema prostora na disku!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Pogreška: sistemska pogreška:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Naknada po kB dodana transakciji koju šaljete</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importiraj blokove sa vanjskog blk000??.dat fajla</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informacija</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Prihvati samo lance blokova koji se podudaraju sa ugrađenim checkpoint-ovima (default: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL postavke: (za detalje o podešavanju SSL opcija vidi Bitcoin Wiki)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Šalji trace/debug informacije na konzolu umjesto u debug.log datoteku</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Podesite minimalnu veličinu bloka u bajtovima (default: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Odredi vremenski prozor za spajanje na mrežu u milisekundama (ugrađeni izbor: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Pogreška sistema:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Pokušaj koristiti UPnP da otvoriš port za uslugu (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Pokušaj koristiti UPnP da otvoriš port za uslugu (default: 1 when listening)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Korisničko ime za JSON-RPC veze</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Upozorenje</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>verzija</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Lozinka za JSON-RPC veze</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Dozvoli JSON-RPC povezivanje s određene IP adrese</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Pošalji komande nodu na adresi &lt;ip&gt; (ugrađeni izbor: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Izvršite naredbu kada se najbolji blok promjeni (%s u cmd je zamjenjen sa block hash)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Nadogradite novčanik u posljednji format.</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Podesi memorijski prostor za ključeve na &lt;n&gt; (ugrađeni izbor: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Ponovno pretraži lanac blokova za transakcije koje nedostaju</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Koristi OpenSSL (https) za JSON-RPC povezivanje</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Uslužnikov SSL certifikat (ugrađeni izbor: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Uslužnikov privatni ključ (ugrađeni izbor: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Ova poruka za pomoć</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Program ne može koristiti %s na ovom računalu (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Dozvoli DNS upite za dodavanje nodova i povezivanje</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Učitavanje adresa...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Greška kod učitavanja wallet.dat: Novčanik pokvaren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Greška kod učitavanja wallet.dat: Novčanik zahtjeva noviju verziju Bitcoina</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Novčanik je trebao prepravak: ponovo pokrenite Bitcoin</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Greška kod učitavanja wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Nevaljala -proxy adresa: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nevaljali iznos za opciju -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Nevaljali iznos za opciju</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Nedovoljna sredstva</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Učitavanje indeksa blokova...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Unesite nod s kojim se želite spojiti and attempt to keep the connection open</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Program ne može koristiti %s na ovom računalu.  Bitcoin program je vjerojatno već pokrenut.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Učitavanje novčanika...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Nije moguće novčanik vratiti na prijašnju verziju.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Nije moguće upisati zadanu adresu.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Rescaniranje</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Učitavanje gotovo</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Greška</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_hu.ts
+++ b/src/qt/locale/bitcoin_hu.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -26,141 +23,113 @@ MIT/X11 szoftverlicenc alatt kiadva, lásd a mellékelt fájlt COPYING vagy http
 Ez a termék az OpenSSL Project által lett kifejlesztve az OpenSSL Toolkit (http://www.openssl.org/) és kriptográfiai szoftvertben való felhasználásra,  írta Eric Young (eay@cryptsoft.com) és UPnP szoftver, írta Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dupla-kattintás a cím vagy a címke szerkesztéséhez</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Új cím létrehozása</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>A kiválasztott cím másolása a vágólapra</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Cím másolása</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Jelenlegi nézet exportálása fájlba</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportálás...</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Törlés</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Címke &amp;másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>Sz&amp;erkesztés</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Vesszővel elválasztott fájl (*. csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -168,17 +137,14 @@ Ez a termék az OpenSSL Project által lett kifejlesztve az OpenSSL Toolkit (htt
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Címke</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Cím</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(nincs címke)</translation>
     </message>
@@ -186,140 +152,106 @@ Ez a termék az OpenSSL Project által lett kifejlesztve az OpenSSL Toolkit (htt
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Kulcsszó párbeszédablak</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Add meg a jelszót</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Új jelszó</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Új jelszó újra</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Írd be az új jelszót a tárcához.&lt;br/&gt;Használj legalább 10&lt;br/&gt;véletlenszerű karaktert&lt;/b&gt; vagy &lt;b&gt;legalább nyolc szót&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Tárca kódolása</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>A tárcád megnyitásához a műveletnek szüksége van a tárcád jelszavára.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Tárca megnyitása</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>A tárcád dekódolásához a műveletnek szüksége van a tárcád jelszavára.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Tárca dekódolása</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Jelszó megváltoztatása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Írd be a tárca régi és új jelszavát.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Biztosan kódolni akarod a tárcát?</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Figyelem: Ha kódolod a tárcát, és elveszíted a jelszavad, akkor &lt;b&gt;AZ ÖSSZES BITCOINODAT IS EL FOGOD VESZÍTENI!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Biztosan kódolni akarod a tárcát?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>FONTOS: A pénztárca-fájl korábbi mentéseit ezzel az új, titkosított pénztárca-fájllal kell helyettesíteni. Biztonsági okokból a pénztárca-fájl korábbi titkosítás nélküli mentései haszontalanná válnak amint elkezdi használni az új, titkosított pénztárcát.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Tárca kódolva</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin will close now to finish the encryption process. Ne feledd, hogy a tárca titkosítása sem nyújt teljes védelmet az adathalász programok fertőzésével szemben.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Tárca kódolása sikertelen.</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Tárca kódolása belső hiba miatt sikertelen. A tárcád nem lett kódolva.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>A megadott jelszavak nem egyeznek.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Tárca megnyitása sikertelen</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Hibás jelszó.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Dekódolás sikertelen.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Jelszó megváltoztatva.</translation>
     </message>
@@ -327,362 +259,286 @@ Ez a termék az OpenSSL Project által lett kifejlesztve az OpenSSL Toolkit (htt
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Üzenet aláírása...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Szinkronizálás a hálózattal...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Áttekintés</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Tárca általános áttekintése</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Tranzakciók</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Tranzakciótörténet megtekintése</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Kilépés</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Kilépés</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Információk a Bitcoinról</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>A &amp;Qt-ról</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Információk a Qt ról</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opciók...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>Tárca &amp;kódolása...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Bisztonsági másolat készítése a Tárcáról</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>Jelszó &amp;megváltoztatása...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>A blokkok importálása lemezről...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>A blokkok lemezen történő ujraindexelése...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Érmék küldése megadott címre</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Bitcoin konfigurációs opciók</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Biztonsági másolat készítése a Tárcáról egy másik helyre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Tárcakódoló jelszó megváltoztatása</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Debug ablak</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Hibakereső és diagnosztikai konzol megnyitása</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>Üzenet &amp;valódiságának ellenőrzése</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Tárca</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Küldés</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Fogadás</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Mutat / Elrejt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>A pénztárcájához tartozó privát kulcsok titkosítása</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Üzenet aláírása a Bitcoin címmel, amivel bizonyítja, hogy a cím az ön tulajdona.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Annak ellenőrzése, hogy az üzenetek valóban a megjelölt Bitcoin címekkel vannak-e alaírva</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Fájl</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Beállítások</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Súgó</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Fül eszköztár</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[teszthálózat]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin kliens</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktív kapcsolat a Bitcoin-hálózattal</numerusform><numerusform>%n aktív kapcsolat a Bitcoin-hálózattal</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Blokk forrása ismeretlen...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>%1 blokk feldolgozva a tranzakciótörténet %2 (becsült) blokkjából</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>A tranzakció-történet %1 blokkja feldolgozva.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n óra</numerusform><numerusform>%n óra</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n nap</numerusform><numerusform>%n nap</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n hét</numerusform><numerusform>%n hét</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 lemaradás</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Az utolsóként kapott blokk kora: %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Ez utáni tranzakciók még nem lesznek láthatóak. </translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Figyelem</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Információ</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Naprakész</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Frissítés...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Tranzakció elküldve.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Beérkező tranzakció</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -695,17 +551,14 @@ Cím: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Tárca &lt;b&gt;kódolva&lt;/b&gt; és jelenleg &lt;b&gt;nyitva&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Tárca &lt;b&gt;kódolva&lt;/b&gt; és jelenleg &lt;b&gt;zárva&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -713,7 +566,6 @@ Cím: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Hálózati figyelmeztetés</translation>
     </message>
@@ -721,291 +573,230 @@ Cím: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Összeg:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Összeg</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Cím</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Megerősítve</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Cím másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Címke másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Összeg másolása</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Tranzakcióazonosító másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(nincs címke)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1013,67 +804,54 @@ Cím: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Cím szerkesztése</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>Cím&amp;ke</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Cím</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Új fogadó cím</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Új küldő cím</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Fogadó cím szerkesztése</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Küldő cím szerkesztése</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>A megadott &quot;%1&quot; cím már szerepel a címjegyzékben.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>A megadott &quot;%1&quot; cím nem egy érvényes Bitcoin-cím.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Tárca feloldása sikertelen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Új kulcs generálása sikertelen</translation>
     </message>
@@ -1081,27 +859,22 @@ Cím: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1109,53 +882,47 @@ Cím: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>verzió</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Használat:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>parancssoros opciók</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI opciók</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Nyelvbeállítás, például &quot;de_DE&quot; (alapértelmezett: rendszer nyelve)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Indítás lekicsinyítve
 </translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Indítóképernyő mutatása induláskor (alapértelmezett: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1163,57 +930,46 @@ Cím: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1221,27 +977,22 @@ Cím: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1249,253 +1000,206 @@ Cím: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opciók</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Fő</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Opcionális, kB-onkénti tranzakciós díj a tranzakcióid minél gyorsabb feldolgozásának elősegítésére.  A legtöbb tranzakció 1 kB-os.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Tranzakciós &amp;díj fizetése</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Induljon el a Bitcoin a számítógép bekapcsolásakor</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Induljon el a számítógép bekapcsolásakor</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Szkriptellenőrzési szálak számának beállítása (maximum 16, 0 = automatikus, &lt;0 = szabadon hagyott magok száma, alapértelmezett: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Minden kliensbeállítás alapértelmezettre állítása.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>Beállítások tö&amp;rlése</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Hálózat</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>A Bitcoin-kliens portjának automatikus megnyitása a routeren. Ez csak akkor működik, ha a routered támogatja az UPnP-t és az engedélyezve is van rajta.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>&amp;UPnP port-feltérképezés</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Proxy portja (pl.: 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Verzió:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>A proxy SOCKS verziója  (pl. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Ablak</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Kicsinyítés után csak eszköztár-ikont mutass</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Kicsinyítés a tálcára az eszköztár helyett</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Az alkalmazásból való kilépés helyett az eszköztárba kicsinyíti az alkalmazást az ablak bezárásakor. Ez esetben az alkalmazás csak a Kilépés menüponttal zárható be.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>K&amp;icsinyítés záráskor</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Megjelenítés</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Felhasználófelület nye&amp;lve:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Itt beállíthatod a felhasználófelület nyelvét. Ez a beállítás a Bitcoin ujraindítása után lép érvénybe.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Mértékegység:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Válaszd ki az interfészen és érmék küldésekor megjelenítendő alapértelmezett alegységet.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Mutassa-e a Bitcoin címeket a tranzakciólistában.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Címek megjelenítése a tranzakciólistában</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>Megszakítás</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>alapértelmezett</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Beállítások törlésének jóváhagyása.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>A megadott proxy cím nem érvényes.</translation>
     </message>
@@ -1503,69 +1207,54 @@ Cím: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Űrlap</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>A kijelzett információ lehet, hogy elavult. A pénztárcája automatikusan szinkronizálja magát a Bitcoin hálózattal miután a kapcsolat létrejön, de ez e folyamat még nem fejeződött be.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Tárca</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Jelenlegi egyenleg</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Még megerősítésre váró, a jelenlegi egyenlegbe be nem számított tranzakciók</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Éretlen:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Bányászott egyenleg amely még nem érett be.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Összesen:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Aktuális egyenleged</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Legutóbbi tranzakciók&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>Nincs szinkronban.</translation>
     </message>
@@ -1573,93 +1262,70 @@ Cím: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI kezelés</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>A bitcoint nem lehet elindítani: click-to-pay handler</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1667,23 +1333,22 @@ Cím: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adj meg egy Bitcoin-címet (pl.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L )</translation>
     </message>
@@ -1691,22 +1356,18 @@ Cím: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>QR kód mentése</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1714,192 +1375,146 @@ Cím: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Kliens néve</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>Nem elérhető</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Kliens verzió</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Információ</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Használt OpenSSL verzió</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Bekapcsolás ideje</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Hálózat</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Név</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Kapcsolatok száma</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Blokklánc</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Aktuális blokkok száma</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Becsült összes blokk</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Utolsó blokk ideje</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Megnyitás</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konzol</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Fordítás dátuma</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Debug naplófájl</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Konzol törlése</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Üdv a Bitcoin RPC konzoljában!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Navigálhat a fel és le nyilakkal, és &lt;b&gt;Ctrl-L&lt;/b&gt; -vel törölheti a képernyőt.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Írd be azt, hogy &lt;b&gt;help&lt;/b&gt; az elérhető parancsok áttekintéséhez.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1907,105 +1522,82 @@ Cím: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>Címke:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Címke másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Összeg másolása</translation>
     </message>
@@ -2013,67 +1605,54 @@ Cím: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>&amp;URI másolása</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>&amp;Cím másolása</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Cím</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Összeg</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Címke</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Üzenet</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>A keletkezett URI túl hosszú, próbálja meg csökkenteni a cimkeszöveg / üzenet méretét.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Hiba lépett fel az URI QR kóddá alakításakor</translation>
     </message>
@@ -2081,37 +1660,30 @@ Cím: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Címke</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Üzenet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Összeg</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(nincs címke)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2119,247 +1691,194 @@ Cím: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Érmék küldése</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Összeg:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Küldés több címzettnek egyszerre</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;Címzett hozzáadása</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Mindent &amp;töröl</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Egyenleg:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Küldés megerősítése</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Küldés</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Küldés megerősítése</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Összeg másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>A címzett címe érvénytelen, kérlek, ellenőrizd.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>A fizetendő összegnek nagyobbnak kell lennie 0-nál.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Nincs ennyi bitcoin az egyenlegeden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>A küldeni kívánt összeg és a %1 tranzakciós díj együtt meghaladja az egyenlegeden rendelkezésedre álló összeget.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Többször szerepel ugyanaz a cím. Egy küldési műveletben egy címre csak egyszer lehet küldeni.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(nincs címke)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2367,99 +1886,75 @@ Cím: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Összeg:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Címzett:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Milyen címkével kerüljön be ez a cím a címtáradba?
 </translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>Címke:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Cím beillesztése a vágólapról</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Üzenet:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2467,12 +1962,10 @@ Cím: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2480,186 +1973,142 @@ Cím: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>Üzenet aláírása...</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Aláírhat a címeivel üzeneteket, amivel bizonyíthatja, hogy a címek az önéi. Vigyázzon, hogy ne írjon alá semmi félreérthetőt, mivel a phising támadásokkal megpróbálhatják becsapni, hogy az azonosságát átírja másokra. Csak olyan részletes állításokat írjon alá, amivel egyetért.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adj meg egy Bitcoin-címet (pl.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L )</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Cím beillesztése a vágólapról</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Ide írja az aláírandó üzenetet</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Aláírás</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>A jelenleg kiválasztott aláírás másolása a rendszer-vágólapra</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation type="unfinished"/>
+        <translation>Üzenet </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Üzenet &amp;aláírása</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Mindent &amp;töröl</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>Üzenet ellenőrzése</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Írja be az aláírás címét, az üzenetet (ügyelve arra, hogy az új-sor, szóköz, tab, stb. karaktereket is pontosan) és az aláírást az üzenet ellenőrzéséhez. Ügyeljen arra, ne gondoljon többet az aláírásról, mint amennyi az aláírt szövegben ténylegesen áll, hogy elkerülje a köztes-ember (man-in-the-middle) támadást.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adj meg egy Bitcoin-címet (pl.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L )</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adj meg egy Bitcoin-címet (pl.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L )</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>A megadott cím nem érvényes.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Ellenőrizze a címet és próbálja meg újra.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Üzenet aláírása nem sikerült.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Üzenet aláírva.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Az aláírást nem sikerült dekódolni.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Ellenőrizd az aláírást és próbáld újra.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Az üzenet ellenőrzése nem sikerült.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Üzenet ellenőrizve.</translation>
     </message>
@@ -2667,17 +2116,14 @@ Cím: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[teszthálózat]</translation>
     </message>
@@ -2685,7 +2131,6 @@ Cím: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2693,184 +2138,138 @@ Cím: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Megnyitva %1-ig</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/megerősítetlen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 megerősítés</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Állapot</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Legenerálva</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Űrlap</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Címzett</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>saját cím</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>címke</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Jóváírás</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>beérik %n blokk múlva</numerusform><numerusform>beérik %n blokk múlva</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>elutasítva</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Terhelés</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Tranzakciós díj</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Nettó összeg</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Üzenet</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Megjegyzés</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Tranzakcióazonosító</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Debug információ</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Tranzakció</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Bemenetek</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Összeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>igaz</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>hamis</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, még nem sikerült elküldeni.</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>%n további blokkra megnyitva</numerusform><numerusform>%n további blokkra megnyitva</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>ismeretlen</translation>
     </message>
@@ -2878,12 +2277,10 @@ Cím: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Tranzakció részletei</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Ez a mező a tranzakció részleteit mutatja</translation>
     </message>
@@ -2891,127 +2288,102 @@ Cím: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Típus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Cím</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Összeg</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>%n további blokkra megnyitva</numerusform><numerusform>%n további blokkra megnyitva</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>%1-ig megnyitva</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Megerősítve (%1 megerősítés)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Ezt a blokkot egyetlen másik csomópont sem kapta meg, így valószínűleg nem lesz elfogadva!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Legenerálva, de még el nem fogadva.</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Erre a címre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Erről az</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Erre a címre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Magadnak kifizetve</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Kibányászva</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(nincs)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Tranzakció állapota. Húzd ide a kurzort, hogy lásd a megerősítések számát.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Tranzakció fogadásának dátuma és időpontja.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tranzakció típusa.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>A tranzakció címzettjének címe.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Az egyenleghez jóváírt vagy ráterhelt összeg.</translation>
     </message>
@@ -3019,178 +2391,142 @@ Cím: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Mind</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Mai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Ezen a héten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Ebben a hónapban</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Múlt hónapban</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Ebben az évben</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Tartomány ...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Erre a címre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Erre a címre</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Magadnak</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Kibányászva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Más</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Írd be a keresendő címet vagy címkét</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimális összeg</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Cím másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Címke másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Összeg másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Tranzakcióazonosító másolása</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Címke szerkesztése</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Tranzakciós részletek megjelenítése</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Vesszővel elválasztott fájl (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Megerősítve</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Típus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Címke</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Cím</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Összeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>Azonosító</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Tartomány:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>meddig</translation>
     </message>
@@ -3198,7 +2534,6 @@ Cím: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3206,7 +2541,6 @@ Cím: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Érmék küldése</translation>
     </message>
@@ -3214,42 +2548,34 @@ Cím: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportálás...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Jelenlegi nézet exportálása fájlba</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Biztonsági másolat készítése a Tárcáról</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Tárca fájl (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Biztonsági másolat készítése sikertelen</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Sikeres biztonsági mentés</translation>
     </message>
@@ -3257,116 +2583,95 @@ Cím: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Használat:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Parancsok kilistázása
 </translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Segítség egy parancsról
 </translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Opciók
 </translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Konfigurációs fájl (alapértelmezett: bitcoin.conf)
 </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>pid-fájl (alapértelmezett: bitcoind.pid)
 </translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Adatkönyvtár
 </translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Az adatbázis gyorsítótár mérete megabájtban (alapértelmezés: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Csatlakozásokhoz figyelendő &lt;port&gt; (alapértelmezett: 8333 or testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Maximálisan &lt;n&gt; számú kapcsolat fenntartása a peerekkel (alapértelmezés: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Kapcsolódás egy csomóponthoz a peerek címeinek megszerzése miatt, majd szétkapcsolás</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Adja meg az Ön saját nyilvános címét</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Helytelenül viselkedő peerek leválasztási határértéke (alapértelmezés: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Helytelenül viselkedő peerek kizárási ideje másodpercben (alapértelmezés: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>JSON-RPC csatlakozásokhoz figyelendő &lt;port&gt; (alapértelmezett: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Parancssoros és JSON-RPC parancsok elfogadása
 </translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Háttérben futtatás daemonként és parancsok elfogadása
 </translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Teszthálózat használata
 </translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
-        <translation type="unfinished"/>
+        <translation>Kívülről érkező kapcsolatok elfogadása (alapértelmezett: 1, ha nem használt a -proxy vagy a -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,732 +2686,692 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Az %s adatkönyvtár nem zárható.  A Bitcoin valószínűleg fut már.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Regressziós teszt mód indítása, amely egy speciális láncot használ, amelyben a blokkok azonnal feloldhatók. Ez regressziós tesztalkalmazások által és alkalmazásfejlesztéshez használható.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Hiba: a tranzakciót elutasították. Ezt az okozhatja, ha már elköltöttél valamennyi érmét a tárcádból például ha a wallet.dat-od egy másolatát használtad, és így az elköltés csak abban lett jelölve, de itt nem.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Parancs, amit akkor hajt végre, amikor egy tárca-tranzakció megváltozik  (%s a parancsban lecserélődik a blokk TxID-re)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Figyelem: a -paytxfee nagyon magas.  Ennyi tranzakciós díjat fogsz fizetni, ha elküldöd a tranzakciót.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Figyelem: Ellenőrizd, hogy helyesen van-e beállítva a gépeden a dátum és az idő.  A Bitcoin nem fog megfelelően működni, ha rosszul van beállítvaaz órád.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Csatlakozás csak a megadott csomóponthoz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Sérült blokk-adatbázis észlelve</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
+        <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
+        <translation>Saját IP-cím felfedezése (alapértelmezett: 1, amikor figyel és nem használt a -externalip)</translation>
+    </message>
+    <message>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Újra akarod építeni a blokk adatbázist most?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>A blokkadatbázis inicializálása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>A tárca-adatbázis inicializálása nem sikerült: %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Hiba a blokk adatbázis betöltése közben.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Hiba a blokk adatbázis megnyitása közben.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Hiba: rendszerhiba:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Egyik hálózati porton sem sikerül hallgatni. Használja a -listen=0 kapcsolót, ha ezt szeretné.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>A blokkinformáció olvasása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>A blokk olvasása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>A blokkindex szinkronizálása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>A blokkindex írása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>A blokkinformáció írása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>A blokk írása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>A fájlinformáció írása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Az érme-adatbázis írása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>A tranzakcióindex írása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>A stornóadatok írása nem sikerült</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Érmék generálása (alapértelmezett: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Hány blokkot ellenőrizzen induláskor (alapértelmezett: 288, 0 = mindet)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Blokkellenőrzése részletessége (0-4, alapértelmezett: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Helytelen vagy nemlétező genézis blokk. Helytelen hálózati adatkönyvtár?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Nincs elég fájlleíró. </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Blokklánc index újraalkotása az alábbi blk000??.dat fájlokból</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Parancs küldése a Bicoin szervernek</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Bitcoin szerver indítása</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Blokkok ellenőrzése...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Tárca ellenőrzése...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Az adatbázist újra kell építeni -reindex használatával (módosítás -tindex).</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Szkriptellenőrzési szálak számának beállítása (maximum 16, 0 = automatikus, &lt;0 = szabadon hagyott magok száma, alapértelmezett: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Információ</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Érvénytelen -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos; összeg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Érvénytelen -mintxfee=&lt;amount&gt;: &apos;%s&apos; összeg</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Teljes tranzakcióindex megőrzése (alapértelmezett: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Csak blokklánccal egyező beépített ellenőrző pontok elfogadása (alapértelmezés: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL-opciók: (lásd a Bitcoin Wiki SSL-beállítási instrukcióit)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>trace/debug információ küldése a konzolra a debog.log fájl helyett</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Tranzakció aláírása sikertelen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Csatlakozás időkerete milliszekundumban (alapértelmezett: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Rendszerhiba:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Tranzakció összege túl alacsony</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Tranzakció összege pozitív kell legyen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Túl nagy tranzakció</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>UPnP-használat engedélyezése a figyelő port feltérképezésénél (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>UPnP-használat engedélyezése a figyelő port feltérképezésénél (default: 1 when listening)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Felhasználói név JSON-RPC csatlakozásokhoz
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Figyelem</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>verzió</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Jelszó JSON-RPC csatlakozásokhoz
 </translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>JSON-RPC csatlakozások engedélyezése meghatározott IP-címről
 </translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Parancsok küldése &lt;ip&gt; címen működő csomóponthoz (alapértelmezett: 127.0.0.1)
 </translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Parancs, amit akkor hajt végre, amikor a legjobb blokk megváltozik (%s a cmd-ban lecserélődik a blokk hash-re)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>A Tárca frissítése a legfrissebb formátumra</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Kulcskarika mérete &lt;n&gt; (alapértelmezett: 100)
 </translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Blokklánc újraszkennelése hiányzó tárca-tranzakciók után
 </translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>OpenSSL (https) használata JSON-RPC csatalkozásokhoz
 </translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Szervertanúsítvány-fájl (alapértelmezett: server.cert)
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Szerver titkos kulcsa (alapértelmezett: server.pem)
 </translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Ez a súgó-üzenet
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>A %s nem elérhető ezen a gépen (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>DNS-kikeresés engedélyezése az addnode-nál és a connect-nél</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Címek betöltése...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Hiba a wallet.dat betöltése közben: meghibásodott tárca</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Hiba a wallet.dat betöltése közben: ehhez a tárcához újabb verziójú Bitcoin-kliens szükséges</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>A Tárca újraírása szükséges: Indítsa újra a teljesen a Bitcoin-t</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Hiba az wallet.dat betöltése közben</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Érvénytelen -proxy cím: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Ismeretlen hálózat lett megadva -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Ismeretlen -socks proxy kérése: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Csatlakozási cím (-bind address) feloldása nem sikerült: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Külső cím (-externalip address) feloldása nem sikerült: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Étvénytelen -paytxfee=&lt;összeg&gt; összeg: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Étvénytelen összeg</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Nincs elég bitcoinod.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Blokkindex betöltése...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Elérendő csomópont megadása and attempt to keep the connection open</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>A %s nem elérhető ezen a gépen. A Bitcoin valószínűleg fut már.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Tárca betöltése...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Nem sikerült a Tárca visszaállítása a korábbi verzióra</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Nem sikerült az alapértelmezett címet írni.</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Újraszkennelés...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Betöltés befejezve.</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Használd a %s opciót</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Hiba</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_id_ID.ts
+++ b/src/qt/locale/bitcoin_id_ID.ts
@@ -2,161 +2,135 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Mengenai Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
-        <translation type="unfinished"/>
+        <translation>versi &lt;b&gt;Bitcoin Core&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
 Distributed under the MIT/X11 software license, see the accompanying file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/) and cryptographic software written by Eric Young (eay@cryptsoft.com) and UPnP software written by Thomas Bernard.</source>
-        <translation type="unfinished"/>
+        <translation>
+Software ini adalah yang bersifat percobaan.
+
+Dibagikan dengan izin software MIT/X11, bacalah arsip COPYING atau  http://www.opensource.org/licenses/mit-license.php.
+
+Produk ini termasuk software yang dibangun oleh Proyek OpenSSL untuk Toolkit OpenSSL (http://www.openssl.org/) dan software kriptografi dibangun oleh Eric Young (eay@cryptsoft.com) dan software UPnP dibangun oleh Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
-        <translation type="unfinished"/>
+        <translation>Pembangun Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Klik-ganda untuk mengubah alamat atau label</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Buat alamat baru</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Baru</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Salin alamat yang dipilih ke clipboard</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Menyalin</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
-        <translation type="unfinished"/>
+        <translation>T&amp;utup</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Salin Alamat</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
-        <translation type="unfinished"/>
+        <translation>Hapus alamat yang sementara dipilih dari daftar</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished"/>
+        <translation>Ekspor data dalam tab sekarang ke sebuah berkas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Ekspor</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Hapus</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished"/>
+        <translation>Pilihlah alamat kemana koin Anda akan dikirim </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished"/>
+        <translation>Pilihlah alamat dimana Anda akan menerima koin</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
-        <translation type="unfinished"/>
+        <translation>P&amp;ilihlah</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
-        <translation type="unfinished"/>
+        <translation>Alamat-alamat mengirim</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
-        <translation type="unfinished"/>
+        <translation>Alamat-alamat menerima</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished"/>
+        <translation>Alamat-alamat Anda supaya mengirim pembayaran. Periksalah jumlah dan alamat penerima setiap kali Anda mengirim Bitcoin.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
-        <translation type="unfinished"/>
+        <translation>Alamat-alamat Anda supaya menerima pembayaran. Dianjurkan agar Anda menggunakan alamat menerima yang baru untuk setiap transaksi.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Salin &amp;Label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Ubah</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
-        <translation type="unfinished"/>
+        <translation>Ekspor Daftar Alamat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
-        <translation>File CSV (*.csv)</translation>
+        <translation>Berkas CSV (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
-        <translation type="unfinished"/>
+        <translation>Proses Ekspor Gagal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
     </message>
@@ -182,526 +153,413 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Dialog Kata kunci</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Masukkan kata kunci</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Kata kunci baru</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Ulangi kata kunci baru</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Masukkan kata kunci baru ke dompet.&lt;br/&gt;Mohon gunakan kata kunci dengan &lt;b&gt;10 karakter atau lebih dengan acak&lt;/b&gt;, atau &lt;b&gt;delapan kata atau lebih&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Enkripsi dompet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Operasi ini memerlukan kata kunci dompet Anda untuk membuka dompet ini.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Buka dompet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Operasi ini memerlukan kata kunci dompet Anda untuk mendekripsi dompet ini.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dekripsi dompet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Ubah kata kunci</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Masukkan kata kunci lama dan baru ke dompet ini.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Konfirmasi enkripsi dompet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation type="unfinished"/>
+        <translation>Perhatian: Jika anda mengenkripsi dompet anda dan lupa kata kuncinya, anda pasti &lt;b&gt;KEHILANGAN SELURUH BITCOIN ANDA&lt;/B&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
-        <translation type="unfinished"/>
+        <translation>Apakah kamu yakin ingin mengenkripsi dompet anda?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished"/>
+        <translation>Perhatian: tombol Caps Lock sementara aktif!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Dompet terenkripsi</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin akan menutup untuk menyelesaikan proses enkripsi. Ingat bahwa dengan mengenkripsi dompet Anda tidak sepenuhnya melindungi bitcoin Anda dari perangkat lunak berbahaya yang menginfeksi komputer Anda.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Enkripsi dompet gagal</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Enkripsi dompet gagal karena kesalahan internal. Dompet Anda tidak dienkripsi.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Kata kunci yang dimasukkan tidak cocok.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Gagal buka dompet</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Kata kunci yang dimasukkan untuk dekripsi dompet tidak cocok.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Dekripsi dompet gagal</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
-        <translation type="unfinished"/>
+        <translation>Kata kunci untuk dompet berubah berhasil.</translation>
     </message>
 </context>
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Pesan &amp;penanda...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sinkronisasi dengan jaringan...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Kilasan</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
-        <translation type="unfinished"/>
+        <translation>Node</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Tampilkan kilasan umum dari dompet</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transaksi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Jelajah sejarah transaksi</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>K&amp;eluar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Keluar dari aplikasi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Tampilkan informasi mengenai Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Mengenai &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Tampilkan informasi mengenai Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Pilihan...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>%Enkripsi Dompet...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Cadangkan Dompet...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Ubah Kata Kunci...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
-        <translation type="unfinished"/>
+        <translation>Alamat-alamat &amp;Mengirim</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
-        <translation type="unfinished"/>
+        <translation>Alamat-alamat &amp;Menerima</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
-        <translation type="unfinished"/>
+        <translation>Buka &amp;URI</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
-        <translation type="unfinished"/>
+        <translation>Blok-blok sedang di-impor dari disk</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Mengindex ulang block di harddisk...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Kirim koin ke alamat Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Ubah pilihan konfigurasi untuk Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Cadangkan dompet ke lokasi lain</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Ubah kata kunci yang digunakan untuk enkripsi dompet</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Jendela Debug</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Buka konsol debug dan diagnosa</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verifikasi pesan...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Dompet</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Kirim</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Menerima</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Sunjukkan / Menyembungi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
-        <translation type="unfinished"/>
+        <translation>Tampilkan atau sembunyikan jendela utama</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation type="unfinished"/>
+        <translation>Mengenkripsi kunci-kunci pribadi yang dipunyai dompetmu</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished"/>
+        <translation>Tandalah pesanan dengan alamat-alamat Bitcoin Anda supaya membuktikan pesanan itu dikirim oleh Anda</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished"/>
+        <translation>Periksakan pesan-pesan supaya menjaminkan ditandatangani oleh alamat Bitcoin yang terperinci</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Berkas</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Pengaturan</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Bantuan</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Baris tab</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Mengenai Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
-        <translation type="unfinished"/>
+        <translation>Tampilkan daftar alamat dan label yang terkirim</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished"/>
+        <translation>Tampilkan daftar alamat dan label yang diterima</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
-        <translation type="unfinished"/>
+        <translation>Buka URI bitcoin: atau permintaan pembayaran</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished"/>
+        <translation>&amp;pilihan Perintah-baris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished"/>
+        <translation>Tampilkan pesan bantuan Bitcoin Core untuk memberikan daftar pilihan perintah-baris yang memungkinkan dalam aplikasi Bitcoin</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Klien Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n hubungan aktif ke jaringan Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
-        <translation type="unfinished"/>
+        <translation>Sumber blok tidak tersedia...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
-        <translation type="unfinished"/>
+        <translation>%1 blok-blok riwayat transaksi telah diproses</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
-        <translation type="unfinished"><numerusform></numerusform></translation>
+        <translation><numerusform>%n jam</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
-        <translation type="unfinished"><numerusform></numerusform></translation>
+        <translation><numerusform>%n hari</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
-        <translation type="unfinished"><numerusform></numerusform></translation>
+        <translation><numerusform>%n minggu</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
-        <translation type="unfinished"/>
+        <translation>%1 dan %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
-        <translation type="unfinished"><numerusform></numerusform></translation>
+        <translation><numerusform>%n tahun</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
-        <translation type="unfinished"/>
+        <translation>kurang %1</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
-        <translation type="unfinished"/>
+        <translation>Blok terakhir dibuat %1 lalu.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Gagal</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Peringatan</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informasi</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Terbaru</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Menyusul...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transaksi terkirim</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transaksi diterima</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
 Address: %4
 </source>
         <translation>Tanggal: %1
-Jumlah: %2
+Nilai: %2
 Jenis: %3
 Alamat: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Dompet saat ini &lt;b&gt;terenkripsi&lt;/b&gt; dan &lt;b&gt;terbuka&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Dompet saat ini &lt;b&gt;terenkripsi&lt;/b&gt; dan &lt;b&gt;terkunci&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -709,7 +567,6 @@ Alamat: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Notifikasi Jaringan</translation>
     </message>
@@ -717,359 +574,285 @@ Alamat: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
-        <translation type="unfinished"/>
+        <translation>Pilihan alamat pengaturan koin</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
-        <translation type="unfinished"/>
+        <translation>Kuantitas:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
-        <translation type="unfinished"/>
+        <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
-        <translation>Jumlah:</translation>
+        <translation>Nilai:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
-        <translation type="unfinished"/>
+        <translation>Prioritas:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Biaya:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
-        <translation type="unfinished"/>
+        <translation>Jumlah Yang Sedikit:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Dengan Biaya:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
-        <translation type="unfinished"/>
+        <translation>Uang Kembali:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
-        <translation>Jumlah</translation>
+        <translation>Nilai</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished"/>
+        <translation>Konfirmasi-konfirmasi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Terkonfirmasi</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
-        <translation type="unfinished"/>
+        <translation>Prioritas</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Salin alamat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Salin label</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
-        <translation>Salin jumlah</translation>
+        <translation>Salin nilai</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
-        <translation type="unfinished"/>
+        <translation>Menyalinkan ID transaksi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
-        <translation type="unfinished"/>
+        <translation>Salin kuantitas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
-        <translation type="unfinished"/>
+        <translation>Salin biaya</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation type="unfinished"/>
+        <translation>Salin dengan biaya</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
-        <translation type="unfinished"/>
+        <translation>Salin bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
-        <translation type="unfinished"/>
+        <translation>Salin prioritas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
-        <translation type="unfinished"/>
+        <translation>Salin jumlah yang sedikit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
-        <translation type="unfinished"/>
+        <translation>Salin uang kembali</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
-        <translation type="unfinished"/>
+        <translation>terbesar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
-        <translation type="unfinished"/>
+        <translation>lebih besar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
-        <translation type="unfinished"/>
+        <translation>besar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
-        <translation type="unfinished"/>
+        <translation>sedang-sampai-besar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
-        <translation type="unfinished"/>
+        <translation>sedang</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
-        <translation type="unfinished"/>
+        <translation>sedikit-sampai-sedang</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
-        <translation type="unfinished"/>
+        <translation>sedikit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
-        <translation type="unfinished"/>
+        <translation>lebih sedikit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
-        <translation type="unfinished"/>
+        <translation>tersedikit</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
-        <translation type="unfinished"/>
+        <translation>(%1 terkunci)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
-        <translation type="unfinished"/>
+        <translation>tidak satupun</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
-        <translation type="unfinished"/>
+        <translation>Debu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
-        <translation type="unfinished"/>
+        <translation>ya</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
-        <translation type="unfinished"/>
+        <translation>tidak</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation type="unfinished"/>
+        <translation>Label ini akan berubah merah, jika ukuran transaksi lebih besar dari 1000 byte.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
-        <translation type="unfinished"/>
+        <translation>Berarti perlu biaya lebih dari %1 untuk setiap kB.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
-        <translation type="unfinished"/>
+        <translation>Boleh berbeda +/- 1 byte setiap masukan.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
-        <translation type="unfinished"/>
+        <translation>Makin penting transaksinya, makin kemungkinan akan termasuk dalam blok.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
-        <translation type="unfinished"/>
+        <translation>Label ini akan berubah merah, jika prioritas lebih kecil dari &quot;medium&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
-        <translation type="unfinished"/>
+        <translation>Label ini akan berubah merah, jika setiap penerima menerima nilai lebih kecil dari %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
-        <translation type="unfinished"/>
+        <translation>Berarti perlu biaya lebih dari %1.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
-        <translation type="unfinished"/>
+        <translation>Nilai yang kurang dari 0.546 kali biaya pengiriman minimal akan ditampilkan sebagai debu.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
-        <translation type="unfinished"/>
+        <translation>Label ini akan berubah merah, jika perubahan itu lebih kecil dari %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished"/>
+        <translation>uang kembali dari %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished"/>
+        <translation>(uang kembali)</translation>
     </message>
 </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Ubah Alamat</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Label</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
-        <translation type="unfinished"/>
+        <translation>Label yang terkait dengan daftar alamat yang dimasukkan ini</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished"/>
+        <translation>Alamat yang terkait dengan entri buku alamat ini. Hanya dapat diubah untuk alamat pengirim.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Alamat</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Alamat menerima baru</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Alamat mengirim baru</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Ubah alamat menerima</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Ubah alamat mengirim</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Alamat yang dimasukkan &quot;%1&quot; sudah ada di dalam buku alamat.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Alamat yang dimasukkan &quot;%1&quot; bukan alamat Bitcoin yang benar.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Tidak dapat membuka dompet.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Pembuatan kunci baru gagal.</translation>
     </message>
@@ -1077,80 +860,69 @@ Alamat: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
-        <translation type="unfinished"/>
+        <translation>Sebuah data direktori baru telah dibuat.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
-        <translation type="unfinished"/>
+        <translation>nama</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
-        <translation type="unfinished"/>
+        <translation>Direktori masih ada. Tambahlah %1 kalau ingin membuat direktori baru disini.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
-        <translation type="unfinished"/>
+        <translation>Masih ada Path, dan path itu bukan direktori.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
-        <translation type="unfinished"/>
+        <translation>Tidak busa membuat direktori untuk data disini.</translation>
     </message>
 </context>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core - pilihan Perintah-baris</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Penggunaan:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>pilihan perintah-baris</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>pilihan UI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Atur bahasa, sebagai contoh &quot;id_ID&quot; (standar: system locale)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Memulai terminimalisi</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Tampilkan layar pembuka saat nyala (standar: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1158,339 +930,276 @@ Alamat: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
-        <translation type="unfinished"/>
+        <translation>Selamat Datang</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
-        <translation type="unfinished"/>
+        <translation>Selamat Datang ke Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
-        <translation type="unfinished"/>
+        <translation>Menggunakan direktori untuk data yang biasa.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
-        <translation type="unfinished"/>
+        <translation>Menggunakan direktori data yang dipilih Anda:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
-        <translation type="unfinished"/>
+        <translation>Gagal: Direktori untuk data &quot;%1&quot; tidak bisa dibuat.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Gagal</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
-        <translation type="unfinished"/>
+        <translation>GB di hard disk yang masih tersedia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
-        <translation type="unfinished"/>
+        <translation>(dari %1GB yang diperlu)</translation>
     </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
-        <translation type="unfinished"/>
+        <translation>Buka URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
-        <translation type="unfinished"/>
+        <translation>Buka permintaan pembayaran dari URI atau arsip</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
-        <translation type="unfinished"/>
+        <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
-        <translation type="unfinished"/>
+        <translation>Pilihlah arsip permintaan pembayaran</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
-        <translation type="unfinished"/>
+        <translation>Pilihlah arsip permintaan pembayaran yang Anda ingin membuka</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Pilihan</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Utama</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
-        <translation type="unfinished"/>
+        <translation>Biaya transaksi untuk setiap kB yang membantu transaksi Andi diproses cepat (biayanya opsional). Ukuran transaksi biasanya 1kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Bayar &amp;biaya transaksi</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Menyalakan Bitcoin secara otomatis setelah masuk ke dalam sistem.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Menyalakan Bitcoin pada login sistem</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
-        <translation type="unfinished"/>
+        <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
-        <translation type="unfinished"/>
+        <translation>Menghubungkan jaringan Bitcoin lewat proxy SOCKS.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Hubungkan melalui proxy SOCKS (proxy biasa):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished"/>
+        <translation>Alamat IP proxy (cth. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
-        <translation type="unfinished"/>
+        <translation>pilihan perintah-baris aktif menimpa atas pilihan-pilihan: </translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
-        <translation type="unfinished"/>
+        <translation>Reset setiap pilihan untuk pilihan biasa</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Reset Pilihan</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Jaringan</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
-        <translation type="unfinished"/>
+        <translation>D&amp;ompet</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation>Ahli</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>Nyalain cara &amp;pengaturan koin</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished"/>
+        <translation>Jika Anda menonaktifkan perubahan saldo untuk transaksi yang belum dikonfirmasi, perubahan dari transaksi tidak dapat dilakukan sampai transaksi memiliki setidaknya satu konfirmasi. Hal ini juga mempengaruhi bagaimana saldo Anda dihitung.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>&amp;Perubahan saldo untuk transaksi yang belum dikonfirmasi</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Otomatis membuka port client Bitcoin di router. Hanya berjalan apabila router anda mendukung UPnP dan di-enable.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Petakan port dengan &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>IP Proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Port proxy (cth. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>Versi &amp;SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
-        <translation>Versi SOCKS proxy (cth. 5)</translation>
+        <translation>Versi proxy SOCKS (cth. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Jendela</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Hanya tampilkan ikon tray setelah meminilisasi jendela</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Meminilisasi ke tray daripada taskbar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
-        <translation type="unfinished"/>
+        <translation>Meminimalkan tanpa keluar dari aplikasi saat jendela ditutup. Apabila pilihan ini diaktifkan, aplikasi hanya bisa ditutup dengan memilih Keluar di menu Berkas.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;eminilisasi saat tutup</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Tampilan</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Bahasa Antarmuka Pengguna:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
-        <translation type="unfinished"/>
+        <translation>Tampilan bahasa pengguna dapat diatur disini. Pengaturan ini akan berpengaruh setelah memulai kembali aplikasi Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
-        <translation>&amp;Unit untuk menunjukkan jumlah:</translation>
+        <translation>&amp;Unit untuk menunjukkan nilai:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation type="unfinished"/>
+        <translation>Pilihan standar unit yang ingin ditampilkan pada layar aplikasi dan saat mengirim koin.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
-        <translation type="unfinished"/>
+        <translation>Apakah menampilkan alamat-alamat Bitcoin dalam daftar transaksi atau tidak.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Tampilkan alamat dalam daftar transaksi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished"/>
+        <translation>Ingin menunjukkan cara pengaturan koin atau tidak.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;YA</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Batal</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>standar</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
-        <translation type="unfinished"/>
+        <translation>tidak satupun</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
-        <translation type="unfinished"/>
+        <translation>Memastikan reset pilihan</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Alamat proxy yang diisi tidak valid.</translation>
     </message>
@@ -1498,69 +1207,54 @@ Alamat: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulir</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Informasi terlampir mungkin sudah kedaluwarsa. Dompet Anda secara otomatis mensinkronisasi dengan jaringan Bitcoin ketika sebuah hubungan terbentuk, namun proses ini belum selesai.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Dompet</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
-        <translation type="unfinished"/>
+        <translation>Tersedia:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
-        <translation type="unfinished"/>
+        <translation>Jumlah yang Anda bisa keluarkan sekarang</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
-        <translation type="unfinished"/>
+        <translation>Ditunda</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation type="unfinished"/>
+        <translation>Jumlah keseluruhan transaksi yang belum dikonfirmasi, dan belum saatnya dihitung sebagai pengeluaran saldo yang telah dibelanjakan.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
-        <translation type="unfinished"/>
+        <translation>Terlalu Muda:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
-        <translation type="unfinished"/>
+        <translation>Saldo ditambang yang masih terlalu muda</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
-        <translation type="unfinished"/>
+        <translation>Jumlah:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
-        <translation type="unfinished"/>
+        <translation>Jumlah saldo Anda sekarang</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transaksi sebelumnya&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>tidak tersinkron</translation>
     </message>
@@ -1568,117 +1262,93 @@ Alamat: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Penanganan URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation type="unfinished"/>
+        <translation>URI tidak bisa dimengerti! Biasanya oleh karena alamat Bitcoin yang tidak sah atau persoalan tentang parameter-parameter URI.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation type="unfinished"/>
+        <translation>Nilai pembayaran %1 yang diminta oleh Anda terlalu sedikit (dianggap debu).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
-        <translation type="unfinished"/>
+        <translation>Gagalan permintaan pembayaran</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
-        <translation type="unfinished"/>
+        <translation>Proxy Anda tidak mendukung SOCKS5, yang diperlu untuk permintaan pembayaran melalui proxy.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
-        <translation type="unfinished"/>
+        <translation>Pembayaran kembali dari %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
-        <translation type="unfinished"/>
+        <translation>Masalah berkomunikasi dengan %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
-        <translation type="unfinished"/>
+        <translation>Jawaban salah dari server %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
-        <translation type="unfinished"/>
+        <translation>Pembayaran diakui</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
-        <translation type="unfinished"/>
+        <translation>Gagalan permintaan dari jaringan</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
+        <translation>Gagal: Tidak ada direktori untuk data &quot;%1&quot;.</translation>
+    </message>
+    <message>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
-        <translation type="unfinished"/>
+        <translation>Gagal: Gabungan -regtest dan -testnet salah</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Masukkan alamat Bitcoin (cth. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1686,215 +1356,165 @@ Alamat: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Simpan Gambaran...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Salin Gambaran</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Simpan Kode QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
-        <translation type="unfinished"/>
+        <translation>Gambar PNG (*.png)</translation>
     </message>
 </context>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nama Klien</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>T/S</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versi Klien</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informasi</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
-        <translation type="unfinished"/>
+        <translation>Jendela debug</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
-        <translation type="unfinished"/>
+        <translation>Menggunakan versi OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Waktu nyala</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Jaringan</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
-        <translation type="unfinished"/>
+        <translation>Nama</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Jumlah hubungan</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Rantai blok</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Jumlah blok terkini</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
-        <translation>Perkiraan blok total</translation>
+        <translation>Perkiraan jumlah blok</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Waktu blok terakhir</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Buka</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsol</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
-        <translation type="unfinished"/>
+        <translation>Kemacetan &amp;Jaringan </translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
-        <translation type="unfinished"/>
+        <translation>Total</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
-        <translation type="unfinished"/>
+        <translation>Masuk:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
-        <translation type="unfinished"/>
+        <translation>Keluar:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Tanggal pembuatan</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
-        <translation type="unfinished"/>
+        <translation>Berkas catatan debug</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation type="unfinished"/>
+        <translation>Buka berkas catatan debug Bitcoin dari direktori data sekarang. Hal ini dapat memakan waktu beberapa detik untuk berkas catatan yang besar.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Bersihkan konsol</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Selamat datang ke konsol RPC Bitcoin.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Gunakan panah keatas dan kebawah untuk menampilkan sejarah, dan &lt;b&gt;Ctrl-L&lt;/b&gt; untuk bersihkan layar.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Ketik &lt;b&gt;help&lt;/b&gt; untuk menampilkan perintah tersedia.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1902,173 +1522,137 @@ Alamat: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Nilai:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Label:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Pesan:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished"/>
+        <translation>Label opsional untuk mengasosiasikan dengan alamat penerima baru.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished"/>
+        <translation>Gunakan form ini untuk meminta pembayaran. Semua bidang adalah &lt;b&gt;opsional&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished"/>
+        <translation>Nilai permintaan opsional. Biarkan ini kosong atau nol bila tidak meminta nilai tertentu.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished"/>
+        <translation>Hapus informasi dari form.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation>Hapus</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
-        <translation type="unfinished"/>
+        <translation>Riwayat pembayaran yang diminta Anda</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Minta pembayaran</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished"/>
+        <translation>Menunjukkan permintaan yang dipilih (sama dengan tekan pilihan dua kali)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
-        <translation type="unfinished"/>
+        <translation>Menunjukkan</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
-        <translation type="unfinished"/>
+        <translation>Menghapus informasi terpilih dari daftar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
-        <translation type="unfinished"/>
+        <translation>Menghapus</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Salin label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
-        <translation type="unfinished"/>
+        <translation>Salin Pesan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
-        <translation>Salin jumlah</translation>
+        <translation>Salin nilai</translation>
     </message>
 </context>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
-        <translation type="unfinished"/>
+        <translation>Kode QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished"/>
+        <translation>Salin &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished"/>
+        <translation>Salin &amp;Alamat</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Simpan Gambaran...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
-        <translation type="unfinished"/>
+        <translation>Minta pembayaran ke %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
-        <translation type="unfinished"/>
+        <translation>Informasi pembayaran</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
-        <translation type="unfinished"/>
+        <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
-        <translation>Jumlah</translation>
+        <translation>Nilai</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Pesan</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Hasil URI terlalu panjang, coba kurangi label / pesan.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Gagal mengubah URI ke kode QR.</translation>
     </message>
@@ -2076,602 +1660,469 @@ Alamat: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Pesan:</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
-        <translation>Jumlah</translation>
+        <translation>Nilai</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
-        <translation type="unfinished"/>
+        <translation>(tidak ada pesan)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
-        <translation type="unfinished"/>
+        <translation>(tidak ada nilai)</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Kirim Koin</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
-        <translation type="unfinished"/>
+        <translation>Cara Pengaturan Koin</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
-        <translation type="unfinished"/>
+        <translation>Masukan...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
-        <translation type="unfinished"/>
+        <translation>Saldo tidak mencukupi!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
-        <translation type="unfinished"/>
+        <translation>Kuantitas:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
-        <translation type="unfinished"/>
+        <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
-        <translation>Jumlah:</translation>
+        <translation>Nilai:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
-        <translation type="unfinished"/>
+        <translation>Prioritas:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Biaya:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
-        <translation type="unfinished"/>
+        <translation>Jumlah Yang Sedikit:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Dengan Biaya:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
-        <translation type="unfinished"/>
+        <translation>Uang Kembali:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished"/>
+        <translation>Jiki ini dipilih, tetapi alamat pengembalian uang kosong atau salah, uang kembali akan dikirim ke alamat yang baru dibuat.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
-        <translation type="unfinished"/>
+        <translation>Alamat uang kembali yang kustom</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Kirim ke beberapa penerima sekaligus</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
-        <translation type="unfinished"/>
+        <translation>Tambahlah &amp;Penerima</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished"/>
+        <translation>Hapus informasi dari form.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Hapus %Semua</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Konfirmasi aksi pengiriman</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
-        <translation type="unfinished"/>
+        <translation>K&amp;irim</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Konfirmasi pengiriman koin</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 ke %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
-        <translation type="unfinished"/>
+        <translation>Salin kuantitas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
-        <translation>Salin jumlah</translation>
+        <translation>Salin nilai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
-        <translation type="unfinished"/>
+        <translation>Salin biaya</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation type="unfinished"/>
+        <translation>Salin dengan biaya</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
-        <translation type="unfinished"/>
+        <translation>Salin bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
-        <translation type="unfinished"/>
+        <translation>Salin prioritas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
-        <translation type="unfinished"/>
+        <translation>Salin jumlah yang sedikit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
-        <translation type="unfinished"/>
+        <translation>Salin uang kembali</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
-        <translation type="unfinished"/>
+        <translation>Jumlah Nilai %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
-        <translation type="unfinished"/>
+        <translation>atau</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
-        <translation type="unfinished"/>
+        <translation>Alamat penerima tidak sah, silakan periksa sekali lagi.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
-        <translation>Jumlah yang dibayar harus lebih besar dari 0.</translation>
+        <translation>Nilai yang dibayar harus lebih besar dari 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
-        <translation>Jumlah melebihi saldo Anda.</translation>
+        <translation>Nilai melebihi saldo Anda.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation>Kelebihan total saldo Anda ketika biaya transaksi %1 ditambahkan.</translation>
+        <translation>Jumlah melebihi saldo Anda ketika biaya transaksi %1 ditambahkan.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Ditemukan alamat ganda, hanya dapat mengirim ke tiap alamat sekali per operasi pengiriman.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished"/>
+        <translation>Gagal membuat transaksi!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
-        <translation type="unfinished"/>
+        <translation>Gagal: Transaksi ditolak. Ini mungkin terjadi jika beberapa dari koin dalam dompet Anda telah digunakan, seperti ketika Anda menggunakan salinan wallet.dat dan beberapa koin telah dibelanjakan dalam salinan tersebut tetapi disini tidak tertandai sebagai terpakai.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished"/>
+        <translation>Awas: Alamat Bitcoin tidak sah</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(tidak ada label)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
-        <translation type="unfinished"/>
+        <translation>Apakah Anda yakin ingin kirim?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
-        <translation type="unfinished"/>
+        <translation>ditambahkan sebagai biaya transaksi</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
-        <translation type="unfinished"/>
+        <translation>Permintaan pembayaran telah kadaluarsa</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
-        <translation type="unfinished"/>
+        <translation>Alamat pembayaran salah %1</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>J&amp;umlah:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Kirim &amp;Ke:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
-        <translation type="unfinished"/>
+        <translation>Alamat pembayaran (cth. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Masukkan label bagi alamat ini untuk menambahkannya ke buku alamat Anda</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Label:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Pilih alamat yang telah digunakan sebelumnya</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+J</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Tempel alamat dari salinan</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+B</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Pesan:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation type="unfinished"/>
+        <translation>Masukkan label untuk alamat ini untuk dimasukan dalam daftar alamat yang pernah digunakan</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
-        <translation type="unfinished"/>
+        <translation>Kirim Ke:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
-        <translation type="unfinished"/>
+        <translation>Catatan Peringatan:</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core sementara dimatikan...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
-        <translation type="unfinished"/>
+        <translation>Kamu tidak dapat mematikan komputer sebelum jendela ini tertutup sendiri.</translation>
     </message>
 </context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation type="unfinished"/>
+        <translation>Tanda Tangan / Verifikasi sebuah Pesan</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Tandakan Pesan</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
-        <translation type="unfinished"/>
+        <translation>Alamat yang akan ditandai pesan (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Pilih alamat yang telah digunakan sebelumnya</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+J</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Tempel alamat dari salinan</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+B</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
-        <translation type="unfinished"/>
+        <translation>Masukan pesan yang ingin ditandai disini</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
-        <translation type="unfinished"/>
+        <translation>Tanda Tangan</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
-        <translation type="unfinished"/>
+        <translation>Salin tanda tangan terpilih ke sistem klipboard</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
-        <translation type="unfinished"/>
+        <translation>Tandai pesan untuk menyetujui kamu pemiliki alamat Bitcoin ini</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
-        <translation type="unfinished"/>
+        <translation>Tandakan &amp;Pesan</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
-        <translation type="unfinished"/>
+        <translation>Hapus semua bidang penanda pesan</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Hapus %Semua</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Verifikasi Pesan</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
-        <translation type="unfinished"/>
+        <translation>Verifikasi &amp;Pesan</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
-        <translation type="unfinished"/>
+        <translation>Hapus semua bidang verifikasi pesan</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Masukkan alamat Bitcoin (cth. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Alamat yang dimasukkan tidak sesuai.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Silahkan periksa alamat dan coba lagi.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
-        <translation type="unfinished"/>
+        <translation>Alamat itu tidak menghubungkan kunci.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
-        <translation type="unfinished"/>
+        <translation>Membuka kunci dompet dibatalkan.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
-        <translation type="unfinished"/>
+        <translation>Kunci pribadi untuk alamat itu tidak tersedia.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
-        <translation type="unfinished"/>
+        <translation>Menandai pesan gagal.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
-        <translation type="unfinished"/>
+        <translation>Pesan ditandai.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
-        <translation type="unfinished"/>
+        <translation>Tanda tangan tidak bisa diterjemahkan.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
-        <translation type="unfinished"/>
+        <translation>Mohon periksa tanda tangan dan coba kembali</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
-        <translation type="unfinished"/>
+        <translation>Tanda tangan tidak cocok dengan intisari pesan.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
-        <translation type="unfinished"/>
+        <translation>Verifikasi pesan gagal.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
-        <translation type="unfinished"/>
+        <translation>Pesan terverifikasi.</translation>
     </message>
 </context>
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
-        <translation type="unfinished"/>
+        <translation>Pembangun Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2679,7 +2130,6 @@ Alamat: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2687,184 +2137,138 @@ Alamat: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Buka hingga %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
-        <translation type="unfinished"/>
+        <translation>Terkonflik</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
-        <translation type="unfinished"/>
+        <translation>%1/tidak terhubung</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
-        <translation>%1/tidak terkonfirmasi</translation>
+        <translation>%1/belum dikonfirmasi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 konfirmasi</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
-        <translation type="unfinished"><numerusform></numerusform></translation>
+        <translation><numerusform>kirim lewat %n node</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
-        <translation type="unfinished"/>
+        <translation>Sumber</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
-        <translation type="unfinished"/>
+        <translation>Dibuat</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Dari</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Untuk</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
-        <translation type="unfinished"/>
+        <translation>Alamat saya sendiri</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
-        <translation type="unfinished"/>
+        <translation>label</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
-        <translation type="unfinished"/>
+        <translation>Kredit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
-        <translation type="unfinished"><numerusform></numerusform></translation>
+        <translation><numerusform>cukup tua sesudah %n blok lagi</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
-        <translation type="unfinished"/>
+        <translation>tidak diterima</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
-        <translation type="unfinished"/>
+        <translation>Debet</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
-        <translation type="unfinished"/>
+        <translation>Biaya Transaksi</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
-        <translation type="unfinished"/>
+        <translation>Nilai bersih</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Pesan:</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
-        <translation type="unfinished"/>
+        <translation>Komentar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
-        <translation type="unfinished"/>
+        <translation>ID Transaksi</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
-        <translation type="unfinished"/>
+        <translation>Pedagang</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
-        <translation type="unfinished"/>
+        <translation>Informasi debug</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transaksi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
-        <translation type="unfinished"/>
+        <translation>Masukan</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
-        <translation>Jumlah</translation>
+        <translation>Nilai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
-        <translation type="unfinished"/>
+        <translation>benar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
-        <translation type="unfinished"/>
+        <translation>salah</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, belum berhasil disiarkan</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
-        <translation type="unfinished"><numerusform></numerusform></translation>
+        <translation><numerusform>Buka untuk %n blok lagi</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>tidak diketahui</translation>
     </message>
@@ -2872,12 +2276,10 @@ Alamat: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Rincian transaksi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Jendela ini menampilkan deskripsi rinci dari transaksi tersebut</translation>
     </message>
@@ -2885,306 +2287,245 @@ Alamat: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
-        <translation>Jumlah</translation>
+        <translation>Nilai</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished"/>
+        <translation>Terlalu muda (cuma %1 konfirmasi, akan siap sesudah %2) </translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
-        <translation type="unfinished"><numerusform></numerusform></translation>
+        <translation><numerusform>Buka untuk %n blok lagi</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Buka hingga %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Terkonfirmasi (%1 konfirmasi)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Blok ini tidak diterima oleh node lainnya dan kemungkinan tidak akan diterima!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Terbuat tetapi tidak diterima</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
-        <translation type="unfinished"/>
+        <translation>Tidak terhubung</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
-        <translation type="unfinished"/>
+        <translation>Belum dikonfirmasi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation type="unfinished"/>
+        <translation>Sedang dikonfirmasi (%1 dari %2 konfirmasi disarankan)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
-        <translation type="unfinished"/>
+        <translation>Terkonflik</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Diterima dengan</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Diterima dari</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Terkirim ke</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pembayaran ke Anda sendiri</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Tertambang</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(t/s)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status transaksi. Arahkan ke bagian ini untuk menampilkan jumlah konfrimasi.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Tanggal dan waktu transaksi tersebut diterima.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Jenis transaksi.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Alamat tujuan dari transaksi.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
-        <translation>Jumlah terbuang dari atau ditambahkan ke saldo.</translation>
+        <translation>Nilai dihapus dari atau ditambahkan ke saldo.</translation>
     </message>
 </context>
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Semua</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hari ini</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Minggu ini</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Bulan ini</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Bulan kemarin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Tahun ini</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Jarak...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>DIterima dengan</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Terkirim ke</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Ke Anda sendiri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Ditambang</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Lainnya</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Masukkan alamat atau label untuk mencari</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
-        <translation>Jumlah min</translation>
+        <translation>Nilai min</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Salin alamat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Salin label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
-        <translation>Salin jumlah</translation>
+        <translation>Salin Nilai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
-        <translation type="unfinished"/>
+        <translation>Menyalinkan ID transaksi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Ubah label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Tampilkan rincian transaksi</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
-        <translation type="unfinished"/>
+        <translation>Expor Histori Transaksi</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
-        <translation type="unfinished"/>
+        <translation>Proses Ekspor Gagal</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
-        <translation type="unfinished"/>
+        <translation>Proses Ekspor Berhasil</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished"/>
+        <translation>Riwayat transaksi berhasil disimpan di %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Berkas CSV (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Terkonfirmasi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Tanggal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Jenis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
-        <translation>Jumlah</translation>
+        <translation>Nilai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Jarak:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>ke</translation>
     </message>
@@ -3192,15 +2533,13 @@ Alamat: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
-        <translation type="unfinished"/>
+        <translation>Tidak ada dompet yang dibuka</translation>
     </message>
 </context>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Kirim Koin</translation>
     </message>
@@ -3208,150 +2547,121 @@ Alamat: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Ekspor</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
-        <translation type="unfinished"/>
+        <translation>Ekspor data dalam tab sekarang ke sebuah berkas</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
-        <translation type="unfinished"/>
+        <translation>Cadangkan Dompet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
-        <translation type="unfinished"/>
+        <translation>Data Dompet (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
-        <translation type="unfinished"/>
+        <translation>Cadangkgan Gagal</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation type="unfinished"/>
+        <translation>Informasi dalam dompet berhasil disimpan di %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
-        <translation type="unfinished"/>
+        <translation>Cadangkan Berhasil </translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Penggunaan:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Daftar perintah</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Dapatkan bantuan untuk perintah</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Pilihan:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Tentukan berkas konfigurasi (standar: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Tentukan berkas pid (standar: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Tentukan direktori data</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Atur ukuran tembolok dalam megabyte (standar: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Menerima hubungan pada &lt;port&gt; (standar: 8333 atau testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
-        <translation>Mengatur  hubungan paling banyak &lt;n&gt; ke peer (standar: 125)</translation>
+        <translation>Mengatur hubungan paling banyak &lt;n&gt; ke peer (standar: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Hubungkan ke node untuk menerima alamat peer, dan putuskan</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Tentukan alamat publik Anda sendiri</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Batas untuk memutuskan peer buruk (standar: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Jumlah kedua untuk menjaga peer buruk dari hubung-ulang (standar: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Menerima perintah baris perintah dan JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Berjalan dibelakang sebagai daemin dan menerima perintah</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Gunakan jaringan uji</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
-        <translation type="unfinished"/>
+        <translation>Terima hubungan dari luar (standar: 1 kalau -proxy atau -connect tidak dipilih)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3363,725 +2673,686 @@ If the file does not exist, create it with owner-readable-only file permissions.
 It is also recommended to set alertnotify so you are notified of problems;
 for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.com
 </source>
-        <translation type="unfinished"/>
+        <translation>
+</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
-        <translation type="unfinished"/>
+        <translation>Sandi yang diterima (biasanya: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
+        <translation>Gagal: Transaksi ditolak. Ini mungkin terjadi jika beberapa dari koin dalam dompet Anda telah digunakan, seperti ketika Anda menggunakan salinan wallet.dat dan beberapa koin telah dibelanjakan dalam salinan tersebut tetapi disini tidak tertandai sebagai terpakai.</translation>
+    </message>
+    <message>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation>Tidak bisa mengikat dengan %s di computer ini. Kemungkinan Bitcoin Core sudah mulai.</translation>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
-        <translation type="unfinished"/>
+        <translation>Gunakanlah proxy SOCKS5 yang tersendiri supaya menghubungkan peer dengan layanan tersembunyi Tor (biasanya: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
-        <translation type="unfinished"/>
+        <translation>Peringatan: -paytxfee sangat besar! Ini adalah biaya pengiriman yang akan dibayar oleh Anda jika transaksi terkirim.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
-        <translation type="unfinished"/>
+        <translation>Perhatian: Mohon diperiksa pengaturan tanggal dan waktu komputer anda apakah sudah benar! Jika pengaturan waktu salah aplikasi Bitcoin tidak akan berjalan dengan tepat.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
-        <translation type="unfinished"/>
+        <translation>Peringatan: Jaringan tidak semua bersetuju! Beberapa penambang dapat persoalan.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation type="unfinished"/>
+        <translation>Peringatan: Kami tidak bersetujuh dengan peer-peer kami! Kemungkinan Anda harus upgrade, atau node-node lain yang harus diupgrade.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
-        <translation type="unfinished"/>
+        <translation>Awas: wallet.dat tidak bisa dibaca! Berhasil periksakan kunci-kunci dalam arsipnya, tetapi ada kemungkinan informasi tentang transaksi atau isi-isi buku alamat salah atau terhilang.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
-        <translation type="unfinished"/>
+        <translation>Coba memulihkan kunci-kunci pribadi dari wallet.dat yang rusak</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
-        <translation type="unfinished"/>
+        <translation>Daemon Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
-        <translation type="unfinished"/>
+        <translation>Pilihan pembuatan blok:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
-        <translation type="unfinished"/>
+        <translation>Jangan menghubungkan node(-node) selain yang di daftar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
-        <translation type="unfinished"/>
+        <translation>Hubungkan melalui proxy SOCKS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
+        <translation>Menemukan database blok yang rusak </translation>
+    </message>
+    <message>
+        <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
-        <translation type="unfinished"/>
+        <translation>Cari alamat IP Anda sendiri (biasanya: 1 saat mendengarkan dan -externalip tidak terpilih)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
-        <translation type="unfinished"/>
+        <translation>Apakah Anda ingin coba membangun kembali database blok sekarang?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
-        <translation type="unfinished"/>
+        <translation>Gagal memuat database blok</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
-        <translation type="unfinished"/>
+        <translation>Menemukan masalah membukakan database blok</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
-        <translation type="unfinished"/>
+        <translation>Gagal: Hard disk hampir terisi!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
-        <translation type="unfinished"/>
+        <translation>Gagal: Dompet terkunci, transaksi tidak bisa dibuat!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Error: system error:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
-        <translation type="unfinished"/>
+        <translation>Gagal membaca informasi dari blok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
-        <translation type="unfinished"/>
+        <translation>Gagal membaca blok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
-        <translation type="unfinished"/>
+        <translation>Gagal menyamakan daftar isi blok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
-        <translation type="unfinished"/>
+        <translation>Gagal menulis daftar isi blok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
-        <translation type="unfinished"/>
+        <translation>Gagal menulis info blok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
-        <translation type="unfinished"/>
+        <translation>Gagal menulis blok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
-        <translation type="unfinished"/>
+        <translation>Gagal menulis info arsip</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
-        <translation type="unfinished"/>
+        <translation>Gagal menulis daftar isi transaksi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
+        <translation>Biaya untuk setiap kB yang akan ditambahkan ke transaksi yang Anda kirim</translation>
+    </message>
+    <message>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
+        <translation>Cari peer dengan daftar alamat DNS (biasanya: 1 jika -connect tidak terpilih)</translation>
+    </message>
+    <message>
+        <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
-        <translation type="unfinished"/>
+        <translation>Buatlah koin (biasanya: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
-        <translation type="unfinished"/>
+        <translation>Periksakan berapa blok waktu mulai (biasanya: 288, 0 = setiapnya)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation type="unfinished"/>
+        <translation>Tidak bisa cari blok pertama, atau blok pertama salah. Salah direktori untuk jaringan?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
-        <translation type="unfinished"/>
+        <translation>Alamat -onion salah: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
+        <translation>Pililah versi SOCKS untuk -proxy (4 atau 5, biasanya: 5)</translation>
+    </message>
+    <message>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Kirim perintah ke Bitcoin server</translation>
-    </message>
-    <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
-        <translation type="unfinished"/>
+        <translation>Atur ukuran maksimal untuk blok dalam byte (biasanya: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
-        <translation type="unfinished"/>
+        <translation>Tentukan arsip dompet (dalam direktori data)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
-        <translation type="unfinished"/>
+        <translation>Perubahan saldo untuk transaksi yang belum dikonfirmasi setelah transaksi terkirim (default: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Mulai Bitcoin server</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
-        <translation type="unfinished"/>
+        <translation>Blok-blok sedang diverifikasi...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
-        <translation type="unfinished"/>
+        <translation>Dompet sedang diverifikasi...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
-        <translation type="unfinished"/>
+        <translation>Tunggu sampai server RPC dimulai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
-        <translation type="unfinished"/>
+        <translation>Dompet %s ada diluar direktori data %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
-        <translation type="unfinished"/>
+        <translation>Harus membangun ulang database menggunakan -reindex supaya mengubah -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
-        <translation type="unfinished"/>
+        <translation>Impor blok dari eksternal berkas blk000???.dat</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation>Tidak bisa mengunci data directory %s. Kemungkinan Bitcoin Core sudah mulai.</translation>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informasi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
-        <translation type="unfinished"/>
+        <translation>Nilai yang salah untuk -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
+        <translation>Nilai yang salah untuk -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
+    </message>
+    <message>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
-        <translation type="unfinished"/>
+        <translation>Jaga daftar transaksi yang lengkap (biasanya: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
+        <translation>Dilarang menghubungkan node-node selain &lt;net&gt; (IPv4, IPv6 atau Tor)</translation>
+    </message>
+    <message>
+        <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>Pilihan SSL: (petunjuk pengaturan SSL lihat dalam Bitcoin Wiki)</translation>
+    </message>
+    <message>
+        <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
-        <translation>Kirim info lacak/debug ke konsol sebaliknya dari berkas debug.log</translation>
+        <translation>Kirim info jejak/debug ke konsol bukan berkas debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
+        <translation>Atur ukuran minimal untuk blok dalam byte (standar: 0)</translation>
+    </message>
+    <message>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
-        <translation type="unfinished"/>
+        <translation>Mengecilkan berkas debug.log saat klien berjalan  (Standar: 1 jika tidak -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
-        <translation type="unfinished"/>
+        <translation>Tandatangani transaksi tergagal</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
+        <translation>Menetapkan waktu berakhir koneksi di milidetik (biasanya: 5000)</translation>
+    </message>
+    <message>
+        <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
-        <translation type="unfinished"/>
+        <translation>Nilai transaksi terlalu kecil</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
-        <translation type="unfinished"/>
+        <translation>Nilai transaksi harus positif</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
-        <translation type="unfinished"/>
+        <translation>Transaksi terlalu besar</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nama pengguna untuk hubungan JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Peringatan</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
-        <translation type="unfinished"/>
+        <translation>Perhatian: Versi ini sudah lama, perlu ditingkatkan!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
+        <translation>Setiap transaksi dalam dompet sedang di-&apos;Zap&apos;...</translation>
+    </message>
+    <message>
+        <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>versi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
-        <translation type="unfinished"/>
+        <translation>wallet.dat rusak, tidak bisa diperbaiki</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Kata sandi untuk hubungan JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Izinkan hubungan JSON-RPC dari alamat IP yang ditentukan</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Kirim perintah ke node berjalan pada &lt;ip&gt; (standar: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Menjalankan perintah ketika perubahan blok terbaik (%s dalam cmd digantikan oleh hash blok)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Perbarui dompet ke format terbaru</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Kirim ukuran kolam kunci ke &lt;n&gt; (standar: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Pindai ulang rantai-blok untuk transaksi dompet yang hilang</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Gunakan OpenSSL (https) untuk hubungan JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Berkas sertifikat server (standar: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Kunci pribadi server (standar: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Pesan bantuan ini</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Tidak dapat mengikat ke %s dengan komputer ini (ikatan gagal %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Izinkan peninjauan DNS untuk -addnote, -seednode dan -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Memuat alamat...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Gagal memuat wallet.dat: Dompet rusak</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Gagal memuat wallet.dat: Dompet memerlukan versi Bitcoin yang terbaru</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Dompet diperlukan untuk disimpan-ulang: nyala-ulangkan Bitcoin untuk menyelesaikan</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Gagal memuat wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Alamat -proxy salah: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Jaringan tidak diketahui yang ditentukan dalam -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Diminta versi proxy -socks tidak diketahui: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Tidak dapat menyelesaikan alamat -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Tidak dapat menyelesaikan alamat -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
-        <translation>Jumlah salah untuk -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
+        <translation>Nilai salah untuk -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
-        <translation>Jumlah salah</translation>
+        <translation>Nilai salah</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Saldo tidak mencukupi</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Memuat indeks blok...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Tambahkan node untuk dihubungkan dan upaya untuk menjaga hubungan tetap terbuka</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Memuat dompet...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Tidak dapat menurunkan versi dompet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Tidak dapat menyimpan alamat standar</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Memindai ulang...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Memuat selesai</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Gunakan pilihan %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Gagal</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_it.ts
+++ b/src/qt/locale/bitcoin_it.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Info su Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>Versione &lt;b&gt;Bitcoin Core&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,159 +24,128 @@ Distribuito sotto la licenza software MIT/X11, vedi il file COPYING incluso oppu
 Questo prodotto include software sviluppato dal progetto OpenSSL per l&apos;uso del Toolkit OpenSSL (http://www.openssl.org/), software crittografico scritto da Eric Young (eay@cryptsoft.com) e software UPnP scritto da Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Gli sviluppatori del Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation>(%1-bit)</translation>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
-        <translation>Fai doppio click per modificare o cancellare l&apos;etichetta</translation>
+        <translation>Doppio click per modificare l&apos;indirizzo o l&apos;etichetta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crea un nuovo indirizzo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nuovo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Copia l&apos;indirizzo attualmente selezionato nella clipboard</translation>
+        <translation>Copia l&apos;indirizzo attualmente selezionato negli appunti</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copia</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>C&amp;hiudi</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copia l&apos;indirizzo</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Cancella l&apos;indirizzo attualmente selezionato dalla lista</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
-        <translation>Esporta i dati nella tabella corrente su un file</translation>
+        <translation>Esporta su file i dati della tabella corrente </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Esporta</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Cancella</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
-        <translation>Scegli l&apos;indirizzo a cui inviare le monete per</translation>
+        <translation>Scegli l&apos;indirizzo a cui inviare bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
-        <translation>Scegli l&apos;indirizzo in cui ricevere le monete con</translation>
+        <translation>Scegli l&apos;indirizzo con cui ricevere bitcoin</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>Sc&amp;egli</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
-        <translation>Indirizzi invianti</translation>
+        <translation>Indirizzi d&apos;invio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
-        <translation>Indirizzi riceventi</translation>
+        <translation>Indirizzi di ricezione</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation>Questi sono i tuoi indirizzi Bitcoin per inviare pagamenti. Controlla sempre l&apos;importo e l&apos;indirizzo del beneficiario prima di inviare  bitcoin</translation>
+        <translation>Questo è un elenco di indirizzi bitcoin a cui puoi inviare pagamenti. Controlla sempre l&apos;importo e l&apos;indirizzo del beneficiario prima di inviare bitcoin.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
-        <translation>Questi sono i tuoi indirizzi Bitcoin per inviare pagamenti. Controlla sempre l&apos;importo e l&apos;indirizzo del beneficiario prima di inviare  bitcoin</translation>
+        <translation>Questi sono i tuoi indirizzi bitcoin che puoi usare per ricevere pagamenti. Si raccomanda di generare un nuovo indirizzo per ogni transazione.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copia &amp;l&apos;etichetta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Modifica</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Esporta Lista Indirizzi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Testo CSV (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Esportazione Fallita.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
-        <translation>C&apos;è stato un errore tentanto di salvare la lista indirizzi in %1.</translation>
+        <translation>Si è verificato un errore tentando di salvare la lista degli indirizzi in %1.</translation>
     </message>
 </context>
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etichetta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(nessuna etichetta)</translation>
     </message>
@@ -187,140 +153,106 @@ Questo prodotto include software sviluppato dal progetto OpenSSL per l&apos;uso 
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Finestra passphrase</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Inserisci la passphrase</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nuova passphrase</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
-        <translation>Ripeti la passphrase</translation>
+        <translation>Ripeti la nuova passphrase</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>Inserisci la passphrase per il portamonete.&lt;br/&gt;Per piacere usare unapassphrase di &lt;b&gt;10 o più caratteri casuali&lt;/b&gt;, o &lt;b&gt;otto o più parole&lt;/b&gt;.</translation>
+        <translation>Inserisci la nuova passphrase per il portamonete.&lt;br/&gt;Si prega di usare una passphrase di &lt;b&gt;10 o più caratteri casuali&lt;/b&gt;, o di &lt;b&gt;otto o più parole&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Cifra il portamonete</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Quest&apos;operazione necessita della passphrase per sbloccare il portamonete.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Sblocca il portamonete</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Quest&apos;operazione necessita della passphrase per decifrare il portamonete,</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Decifra il portamonete</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Cambia la passphrase</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Inserisci la vecchia e la nuova passphrase per il portamonete.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Conferma la cifratura del portamonete</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation>Attenzione: se si cifra il portamonete e si perde la frase d&apos;ordine, &lt;b&gt;SI PERDERANNO TUTTI I PROPRI BITCOIN&lt;/b&gt;!</translation>
+        <translation>Attenzione: se si cifra il portamonete e si perde la passphrase &lt;b&gt;TUTTI I PROPRI BITCOIN ANDRANNO PERSI&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Si è sicuri di voler cifrare il portamonete?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: qualsiasi backup del portafoglio effettuato precedentemente dovrebbe essere sostituito con il file del portafoglio criptato appena generato. Per ragioni di sicurezza, i backup precedenti del file del portafoglio non criptato diventeranno inservibili non appena si inizi ad usare il nuovo portafoglio criptato.</translation>
+        <translation>IMPORTANTE: qualsiasi backup del file portamonete effettuato in precedenza dovrà essere sostituito con il file del portamonete cifrato appena generato. Per ragioni di sicurezza, i precedenti backup del file del portamonete non cifrato diventeranno inservibili non appena si inizierà ad utilizzare il nuovo portamonete cifrato.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation>Attenzione: tasto Blocco maiuscole attivo.</translation>
+        <translation>Attenzione: il tasto Blocco maiuscole è attivo!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Portamonete cifrato</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation>Bitcoin verrà ora chiuso per finire il processo di crittazione. Ricorda che criptare il tuo portamonete non può fornire una protezione totale contro furti causati da malware che dovessero infettare il tuo computer.</translation>
+        <translation>Bitcoin si chiuderà per portare a termine il processo di cifratura. Ricorda che cifrare il tuo portamonete non può fornire una protezione totale contro i furti causati da infezioni malware.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Cifratura del portamonete fallita</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Cifratura del portamonete fallita a causa di un errore interno. Il portamonete non è stato cifrato.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Le passphrase inserite non corrispondono.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Sblocco del portamonete fallito</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>La passphrase inserita per la decifrazione del portamonete è errata.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Decifrazione del portamonete fallita</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Passphrase del portamonete modificata con successo.</translation>
     </message>
@@ -328,362 +260,286 @@ Questo prodotto include software sviluppato dal progetto OpenSSL per l&apos;uso 
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Firma il &amp;messaggio...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
-        <translation>Sto sincronizzando con la rete...</translation>
+        <translation>Sincronizzazione con la rete in corso...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Sintesi</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation>Nodo</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Mostra lo stato generale del portamonete</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transazioni</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
-        <translation>Cerca nelle transazioni</translation>
+        <translation>Mostra la cronologia delle transazioni</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Esci</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Chiudi applicazione</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Mostra informazioni su Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Informazioni su &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Mostra informazioni su Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opzioni...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Cifra il portamonete...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Backup Portamonete...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Cambia la passphrase...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
-        <translation>&amp;Indirizzi invianti</translation>
+        <translation>&amp;Indirizzi d&apos;invio...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
-        <translation>Indirizzi &amp;riceventi...</translation>
+        <translation>Indirizzi di &amp;ricezione...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Apri &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
-        <translation>Importa blocchi dal disco...</translation>
+        <translation>Importazione blocchi dal disco...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Re-indicizzazione blocchi su disco...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Invia monete ad un indirizzo bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
-        <translation>Modifica configurazione opzioni per bitcoin</translation>
+        <translation>Modifica opzioni di configurazione per bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
-        <translation>Backup portamonete in un&apos;altra locazione</translation>
+        <translation>Effettua il backup del portamonete</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
-        <translation>Cambia la passphrase per la cifratura del portamonete</translation>
+        <translation>Cambia la passphrase utilizzata per la cifratura del portamonete</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Finestra &amp;Debug</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
-        <translation>Apri la console di degugging e diagnostica</translation>
+        <translation>Apri la console di debugging e diagnostica</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verifica messaggio...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Portamonete</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
-        <translation>&amp;Spedisci</translation>
+        <translation>&amp;Invia</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Ricevi</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
-        <translation>&amp;Mostra/Nascondi</translation>
+        <translation>&amp;Mostra / Nascondi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Mostra o nascondi la Finestra principale</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation>Crittografa le chiavi private che appartengono al tuo portafoglio</translation>
+        <translation>Cifra le chiavi private che appartengono al tuo portamonete</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation>Firma i messaggi con il tuo indirizzo Bitcoin per dimostrare di possederli</translation>
+        <translation>Firma i messaggi con il tuo indirizzo bitcoin per dimostrarne il possesso</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation>Verifica i messaggi per accertarsi che siano stati firmati con gli indirizzi Bitcoin specificati</translation>
+        <translation>Verifica i messaggi per accertare che siano stati firmati con gli indirizzi bitcoin specificati</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Impostazioni</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Aiuto</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra degli strumenti &quot;Tabs&quot;</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Richiedi pagamenti (genera codici QR e bitcoin: URI)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
-        <translation>%Info su Bitcoin Core</translation>
+        <translation>Info su Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
-        <translation>Modifica la lista degli indirizzi salvati e delle etichette</translation>
+        <translation>Mostra la lista degli indirizzi di invio utilizzati</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation>Mostra la lista di indirizzi su cui ricevere pagamenti</translation>
+        <translation>Mostra la lista degli indirizzi di ricezione utilizzati</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
-        <translation>Apri un bitcoin: URI o richiesta di pagamento</translation>
+        <translation>Apri un URI o una richiesta di pagamento</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>Opzioni riga di &amp;comando</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Mostra il messaggio di aiuto di Bitcoin Core per avere la lista di tutte le opzioni della riga di comando di Bitcoin.</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin client</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n connessione attiva alla rete Bitcoin</numerusform><numerusform>%n connessioni attive alla rete Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
-        <translation>Nessun blocco di codice sorgente disponibile</translation>
+        <translation>Nessuna fonte di blocchi disponibile</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
-        <translation>Processati %1 di %2 (circa) blocchi della cronologia transazioni.</translation>
+        <translation>Processati %1 di %2 blocchi totali (stimati) della cronologia transazioni.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Processati %1 blocchi della cronologia transazioni.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n ora</numerusform><numerusform>%n ore</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n giorno</numerusform><numerusform>%n giorni</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n settimana</numerusform><numerusform>%n settimane</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 e %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n anno</numerusform><numerusform>%n anni</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>Indietro di %1</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>L&apos;ultimo blocco ricevuto è stato generato %1 fa.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transazioni successive a questa non saranno ancora visibili.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Aggiornato</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>In aggiornamento...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transazione inviata</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transazione ricevuta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,25 +553,21 @@ Indirizzo: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
-        <translation>Il portamonete è &lt;b&gt;cifrato&lt;/b&gt; e attualmente &lt;b&gt;sbloccato&lt;/b&gt;</translation>
+        <translation>Il portamonete è &lt;b&gt;cifrato&lt;/b&gt; ed attualmente &lt;b&gt;sbloccato&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
-        <translation>Il portamonete è &lt;b&gt;cifrato&lt;/b&gt; e attualmente &lt;b&gt;bloccato&lt;/b&gt;</translation>
+        <translation>Il portamonete è &lt;b&gt;cifrato&lt;/b&gt; ed attualmente &lt;b&gt;bloccato&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
-        <translation>Riscontrato un errore irreversibile. Bitcoin non può più continuare in sicurezza e verrà terminato.</translation>
+        <translation>Riscontrato un errore irreversibile. Bitcoin non può più continuare in sicurezza e sarà terminato.</translation>
     </message>
 </context>
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Avviso di rete</translation>
     </message>
@@ -723,291 +575,230 @@ Indirizzo: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Selezione Indirizzo Coin Control</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Quantità:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Byte:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Importo:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Priorità:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Commissione:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Low Output:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Dopo Commissione:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Resto:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(de)seleziona tutto</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Modalità Albero</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Modalità Lista</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Importo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Conferme:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confermato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Priorità</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Copia l&apos;indirizzo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copia l&apos;etichetta</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copia l&apos;importo</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Copia l&apos;ID transazione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Bloccare non spesi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Sbloccare non spesi</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Copia quantità</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Copia commissione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copia dopo commissione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copia byte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copia priorità</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copia low output</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copia resto</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation>massima</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>superiore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>medio-alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>media</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>medio-bassa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>bassa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>minore</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
-        <translation>infima</translation>
+        <translation>minima</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 bloccato)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>nessuno</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Trascurabile</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
-        <translation>si</translation>
+        <translation>sì</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>no</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Questa etichetta diventa rossa, se la dimensione della transazione supera i 1000 bytes</translation>
+        <translation>Questa etichetta diventa rossa se la dimensione della transazione supera i 1000 bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Questo significa che è richiesta una commissione di almeno %1 per ogni kB.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Può variare di +/- 1 byte per input.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
-        <translation>Le transazioni con priorita&apos; piu&apos; alta e&apos; piu&apos; probabile che vengano incluse in un blocco.</translation>
+        <translation>Le transazioni con priorità più alta hanno più probabilità di essere incluse in un blocco.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
-        <translation>Questa etichetta diventa rossa, se la priorità è più piccola di &quot;media&quot;.</translation>
+        <translation>Questa etichetta diventa rossa se la priorità è inferiore a &quot;media&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
-        <translation>Questa etichetta diventa rossa, se qualsiasi destinatario riceve un ammontare inferiore di %1.</translation>
+        <translation>Questa etichetta diventa rossa se uno qualsiasi dei destinatari riceve un ammontare inferiore di %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Questo significa che è richiesta una commissione di almeno %1</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
-        <translation>Importi inferiori a 0.546 volte la commissione minima di trasferimento sono mostrati come trascurabili.</translation>
+        <translation>Importi inferiori a 0,546 volte la commissione minima di trasferimento sono mostrati come trascurabili.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
-        <translation>Questa etichetta diventa rossa, se il resto è più piccolo di %1.</translation>
+        <translation>Questa etichetta diventa rossa se il resto è minore di %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(nessuna etichetta)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>resto da %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(resto)</translation>
     </message>
@@ -1015,67 +806,54 @@ Indirizzo: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Modifica l&apos;indirizzo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etichetta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>L&apos;etichetta associata con questa voce della lista degli indirizzi</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation>L&apos;indirizzo associato a questa voce della rubrica. Si può modificare solo negli indirizzi di spedizione.</translation>
+        <translation>L&apos;indirizzo associato a questa voce della rubrica. Può essere modificato solo per gli indirizzi d&apos;invio.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Indirizzo</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nuovo indirizzo di ricezione</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nuovo indirizzo d&apos;invio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Modifica indirizzo di ricezione</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Modifica indirizzo d&apos;invio</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>L&apos;indirizzo inserito &quot;%1&quot; è già in rubrica.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>L&apos;indirizzo inserito &quot;%1&quot; non è un indirizzo bitcoin valido.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Impossibile sbloccare il portamonete.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Generazione della nuova chiave non riuscita.</translation>
     </message>
@@ -1083,27 +861,22 @@ Indirizzo: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Sarà creata una nuova cartella dati.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>La cartella esiste già. Aggiungi %1 se intendi creare qui una nuova cartella.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
-        <translation>Percorso già esistente, e non è una cartella.</translation>
+        <translation>Il percorso è già esistente e non è una cartella.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Qui non è possibile creare una cartella dati.</translation>
     </message>
@@ -1111,52 +884,46 @@ Indirizzo: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
-        <translation>Bitcoin Core - Opzioni linea di comando</translation>
+        <translation>Bitcoin Core - Opzioni riga di comando</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versione</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Utilizzo:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>opzioni riga di comando</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI opzioni</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Imposta lingua, ad esempio &quot;it_IT&quot; (predefinita: lingua di sistema)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
-        <translation>Parti in icona</translation>
+        <translation>Avvia ridotto a icona</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>Imposta i certificati radice SSL per le richieste di pagamento (predefinito: -system-)</translation>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Mostra finestra di presentazione all&apos;avvio (predefinito: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Scegli una cartella dati all&apos;avvio (predefinito: 0)</translation>
     </message>
@@ -1164,57 +931,46 @@ Indirizzo: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Benvenuto</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Benvenuti su Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
-        <translation>Visto che questa è la prima volta che il programma viene lanciato, puoi scegliere dove Bitcoin-Qt salverà i suoi dati.</translation>
+        <translation>Visto che questa è la prima volta che il programma viene lanciato, puoi scegliere dove Bitcoin Core salverà i propri dati.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
-        <translation>Bitcoin Core scaricherà e salverà una copia del block chain di Bitcoin. Almeno %1GB di dati saranno salvati in questa cartella, e aumenteranno col tempo. Anche il portafoglio sarà salvato in questa cartella.</translation>
+        <translation>Bitcoin Core scaricherà e salverà una copia del block chain di Bitcoin. Almeno %1GB di dati che andranno ad aumentare col tempo saranno salvati in questa cartella. Anche il portamonete sarà salvato in questa cartella.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
-        <translation>Usa la cartella dati predefinita.</translation>
+        <translation>Usa la cartella dati predefinita</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Usa una cartella dati personalizzata:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Errore: La cartella dati &quot;%1&quot; specificata non può essere creata.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB di spazio libero disponibile</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(di %1GB richiesti)</translation>
     </message>
@@ -1222,27 +978,22 @@ Indirizzo: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Apri URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Apri richiesta di pagamento da URI o file</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Seleziona il file di richiesta di pagamento</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Seleziona il file di richiesta di pagamento da aprire</translation>
     </message>
@@ -1250,253 +1001,206 @@ Indirizzo: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Principale</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
-        <translation>Commissione di transazione per kB; è opzionale e contribuisce ad assicurare che le transazioni siano elaborate velocemente. Le transazioni sono per la maggior parte da 1 kB. Commissione raccomandata 0,01.</translation>
+        <translation>Commissione di transazione per kB: è opzionale e contribuisce ad assicurare che le transazioni siano elaborate velocemente. La maggior parte della transazioni ha dimensioni pari a 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Paga la &amp;commissione</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
-        <translation>Avvia automaticamente Bitcoin all&apos;accensione del computer</translation>
+        <translation>Avvia automaticamente Bitcoin una volta effettuato l&apos;accesso al sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
-        <translation>&amp;Fai partire Bitcoin all&apos;avvio del sistema</translation>
+        <translation>&amp;Avvia Bitcoin all&apos;accesso al sistema</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>Dimensione della cache del &amp;database.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
-        <translation>Numero di thread di &amp;verification degli script </translation>
+        <translation>Numero di thread di &amp;verifica degli script </translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Imposta il numero di thread di verifica script (fino a 16, 0 = auto, &lt;0 = lascia il maggior numero di core liberi, predefinito: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation>&amp;Spendere resti non confermati (solo per esperti)</translation>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
-        <translation>Connetti alla rete Bitcoin attraverso un proxy SOCKS.</translation>
+        <translation>Connessione alla rete Bitcoin attraverso un proxy SOCKS.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
-        <translation>&amp;Connetti attraverso proxy SOCKS (proxy predefinito):</translation>
+        <translation>&amp;Connessione attraverso proxy SOCKS (proxy predefinito):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>Indirizzo IP del proxy (es: IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
-        <translation>Attiva le opzioni command-line che ignorano queste opzioni:</translation>
+        <translation>Opzioni command-line attive che sostituiscono i settaggi sopra elencati:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
-        <translation>Ripristina tutte le opzioni del client alle predefinite.</translation>
+        <translation>Reimposta tutte le opzioni del client allo stato predefinito.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Ripristina Opzioni</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>Rete</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation>(0 = automatico, &lt;0 = lascia questo numero di core liberi)</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
-        <translation>Port&amp;afoglio</translation>
+        <translation>Port&amp;amonete</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation>Esperti</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>Abilita le funzionalità di coin &amp;control</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation>Se disabiliti l&apos;uso di resti non confermati, il resto di una transazione non potrà essere usato fintanto che la transazione non avrà almeno una conferma. Questo influisce anche su come è calcolato il saldo.</translation>
+        <translation>Disabilitando l&apos;uso di resti non confermati, il resto di una transazione non potrà essere speso fino a quando la transazione non avrà ottenuto almeno una conferma. Questa impostazione influisce inoltre sul calcolo saldo.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>%Spendere resti non confermati</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>Apri automaticamente la porta del client Bitcoin sul router. Questo funziona solo se il router supporta UPnP ed è abilitato.</translation>
+        <translation>Apri automaticamente la porta del client Bitcoin sul router. Il protocollo UPnP deve essere supportato da parte del router ed attivo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
-        <translation>Mappa le porte tramite l&apos;&amp;UPnP</translation>
+        <translation>Mappa le porte tramite &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP del proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Porta:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Porta del proxy (es. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Version:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Versione SOCKS del proxy (es. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Finestra</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation>Mostra solo un&apos;icona nel tray quando si minimizza la finestra</translation>
+        <translation>Mostra solo nella tray bar quando si riduce ad icona.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation>&amp;Minimizza sul tray invece che sulla barra delle applicazioni</translation>
+        <translation>&amp;Minimizza nella tray bar invece che sulla barra delle applicazioni</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
-        <translation>Riduci ad icona, invece di uscire dall&apos;applicazione quando la finestra viene chiusa. Quando questa opzione è attivata, l&apos;applicazione verrà chiusa solo dopo aver selezionato Esci nel menu.</translation>
+        <translation>Riduci ad icona invece di uscire dall&apos;applicazione quando la finestra viene chiusa. Se l&apos;opzione è attiva, l&apos;applicazione terminerà solo dopo aver selezionato Esci dal menu File.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimizza alla chiusura</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Mostra</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Lingua Interfaccia Utente:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>La lingua dell&apos;interfaccia utente può essere impostata qui. L&apos;impostazione avrà effetto dopo il riavvio di Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
-        <translation>&amp;Unità di misura degli importi in:</translation>
+        <translation>&amp;Unità di misura con cui visualizzare gli importi:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
-        <translation>Scegli l&apos;unità di suddivisione predefinita per l&apos;interfaccia e per l&apos;invio di monete</translation>
+        <translation>Scegli l&apos;unità di suddivisione predefinita da utilizzare per l&apos;interfaccia e per l&apos;invio di monete.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
-        <translation>Se mostrare l&apos;indirizzo Bitcoin nella transazione o meno.</translation>
+        <translation>Specifica se gli indirizzi saranno visualizzati nella lista delle transazioni.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Mostra gli indirizzi nella lista delle transazioni</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
-        <translation>Mostrare/non mostrare le funzionalita&apos; di controllo della moneta.</translation>
+        <translation>Specifica se le funzionalita di coin control saranno visualizzate.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation>Mostrare funzionalità coin &amp;control (solo per esperti)</translation>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancella</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>predefinito</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>nessuno</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Conferma ripristino opzioni</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
-        <translation>Riavvio del client richiesto per attivare cambiamenti.</translation>
+        <translation>È necessario un riavvio del client per rendere attivi i cambiamenti.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
-        <translation>Il client si spegnerà, vuoi procedere?</translation>
+        <translation>Il client sarà arrestato, vuoi procedere?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Questo cambiamento richiede un riavvio del client.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>L&apos;indirizzo proxy che hai fornito è invalido.</translation>
     </message>
@@ -1504,163 +1208,125 @@ Indirizzo: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Modulo</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
-        <translation>Le informazioni visualizzate sono datate. Il tuo partafogli verrà sincronizzato automaticamente con il network Bitcoin dopo che la connessione è stabilita, ma questo processo non può essere completato ora.</translation>
+        <translation>Le informazioni visualizzate potrebbero non essere aggiornate. Il portamonete si sincronizza automaticamente con la rete Bitcoin una volta stabilita una connessione, ma questo processo non è ancora stato completato.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Portamonete</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Disponibile:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Saldo spendibile attuale</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>In attesa:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation>Totale delle transazioni in corso di conferma, che non sono ancora incluse nel saldo spendibile attuale</translation>
+        <translation>Totale delle transazioni in corso di conferma e che non sono ancora conteggiate nel saldo spendibile</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Immaturo:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
-        <translation>Importo scavato che non è ancora maturato</translation>
+        <translation>Importo generato dal mining e non ancora maturato</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Totale:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Saldo totale attuale</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transazioni recenti&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
-        <translation>fuori sincrono</translation>
+        <translation>non sincronizzato</translation>
     </message>
 </context>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Gestione URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation>Impossibile interpretare l&apos;URI! Ciò può essere causato da un indirizzo Bitcoin invalido o da parametri URI non corretti.</translation>
+        <translation>Impossibile interpretare l&apos;URI! Ciò può essere provocato da un indirizzo Bitcoin non valido o da parametri URI non corretti.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation>L&apos;importo di pagamento richiesto di %1 è troppo basso (ed e&apos; quindi trascurabile).</translation>
+        <translation>L&apos;importo di pagamento richiesto di %1 è troppo basso (considerato come trascurabile).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Errore di richiesta di pagamento</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Impossibile avviare bitcoin: gestore click-to-pay</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Avviso Net manager</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
-        <translation>Il tuo proxy attivo non supporta SOCKS5, il quale è necessario per richieste di pagamento via proxy.</translation>
+        <translation>Il proxy attualmente attivo non supporta SOCKS5, il quale è necessario per richieste di pagamento via proxy.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
-        <translation>Richiesta di pagamento per recuperare URL non valida: %1</translation>
+        <translation>URL di recupero della Richiesta di pagamento non valido: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Gestione del file di richiesta del pagamento</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
-        <translation>Il file di richiesta del pagamento non puo&apos; essere letto o elaborato! Il file in questione potrebbe essere danneggiato.</translation>
+        <translation>Il file di richiesta del pagamento non può essere letto o elaborato! Il file in questione potrebbe essere danneggiato.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Le richieste di pagamento non verificate verso script di pagamento personalizzati non sono supportate.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Rimborso da %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Errore di comunicazione con %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
-        <translation>La richiesta di pagamento non può essere analizzata e processata!</translation>
+        <translation>La richiesta di pagamento non può essere analizzata o processata!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
-        <translation>Risposta sbagliata dal server %1</translation>
+        <translation>Risposta errata da parte del server %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Pagamento riconosciuto</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Errore di richiesta di rete</translation>
     </message>
@@ -1668,23 +1334,22 @@ Indirizzo: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Errore: La cartella dati &quot;%1&quot; specificata non esiste.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Errore: impossibile interpretare il file di configurazione: %1. Usare esclusivamente la sintassi chiave=valore.</translation>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Errore: combinazione di -regtest e -testnet non valida.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Inserisci un indirizzo Bitcoin (ad esempio 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1692,22 +1357,18 @@ Indirizzo: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Salva Immagine</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Copia Immagine</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Salva codice QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>Immagine PNG (*.png)</translation>
     </message>
@@ -1715,192 +1376,146 @@ Indirizzo: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nome del client</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/D</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versione client</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
-        <translation>&amp;Informazione</translation>
+        <translation>&amp;Informazioni</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Finestra di debug</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Generale</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Versione OpenSSL in uso</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Tempo di avvio</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Rete</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
-        <translation>Numero connessioni</translation>
+        <translation>Numero di connessioni</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Block chain</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Numero attuale di blocchi</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Numero totale stimato di blocchi</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
-        <translation>Ora dell blocco piu recente</translation>
+        <translation>Ora del blocco più recente</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Apri</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Console</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Traffico di Rete</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Cancella</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totali</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>Entrata:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>Uscita:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Data di creazione</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>File log del Debug</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Apri il file di log del debug di Bitcoin dalla cartella attuale. Può richiedere alcuni secondi per file di log grandi.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
-        <translation>Svuota console</translation>
+        <translation>Cancella console</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Benvenuto nella console RPC di Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
-        <translation>Usa le frecce direzionali per navigare la cronologia, and &lt;b&gt;Ctrl-L&lt;/b&gt; per cancellarla.</translation>
+        <translation>Usa le frecce direzionali per navigare la cronologia, e &lt;b&gt;Ctrl-L&lt;/b&gt; per cancellarla.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Scrivi &lt;b&gt;help&lt;/b&gt; per un riassunto dei comandi disponibili</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1908,105 +1523,82 @@ Indirizzo: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Importo:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etichetta</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Messaggio:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
-        <translation>Riutilizza un indirizzo di ricezione già usato. Riutilizzare indirizza non è sicuro. Non usare senza rigenerare una richiesta di pagamanto.</translation>
+        <translation>Riutilizza uno degli indirizzi di ricezione generati in precedenza. Riutilizzare un indirizzo comporta problemi di sicurezza e privacy. Non utilizzare a meno che non si stia rigenerando una richiesta di pagamento creata in precedenza.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
-        <translation>R&amp;iusa un indirizzo di pagamento (non raccomandato)</translation>
+        <translation>R&amp;iusa un indirizzo di ricezione (non raccomandato)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation>Un messaggio facoltativo da allegare alla richiesta di pagamento, il quale sarà mostrato quando la richiesta è aperta. Nota: Il messaggio non verrà inviato con il pagamento attraverso il network Bitcoin.</translation>
+        <translation>Un messaggio opzionale da allegare alla richiesta di pagamento, il quale sarà mostrato all&apos;apertura della richiesta. Nota: Il messaggio non sarà inviato con il pagamento sulla rete Bitcoin.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation>Un&apos;etichetta facoltativa da associare al nuovo indirizzo ricevente</translation>
+        <translation>Un&apos;etichetta facoltativa da associare al nuovo indirizzo di ricezione</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Usa questo modulo per richiedere pagamenti. Tutti i campi sono &lt;b&gt;opzionali&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation>Un importo facoltativo da richiedere. Lasciare vuoto o a zero per non richiedere un importo specifico.</translation>
+        <translation>Un importo opzionale da associare alla richiesta. Lasciare vuoto o a zero per non richiedere un importo specifico.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Cancellare tutti i campi del modulo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Cronologia pagamenti richiesti</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Richiedi pagamento</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation>Mostra la richiesta selezionata (fa la stessa cosa che il doppio click sul campo)</translation>
+        <translation>Mostra la richiesta selezionata (produce lo stesso effetto di un doppio click su una voce)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Mostra</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation>Rimuovi le voci selezionate dalla lista</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Rimuovi</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Copia l&apos;etichetta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Copia messaggio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copia l&apos;importo</translation>
     </message>
@@ -2014,105 +1606,85 @@ Indirizzo: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Copia &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Copia &amp;Indirizzo</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Salva Immagine</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Richiesta di pagamento a %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Informazioni pagamento</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Importo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etichetta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Messaggio</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
-        <translation>L&apos;URI risulta troppo lungo, prova a ridurre il testo nell&apos;etichetta / messaggio.</translation>
+        <translation>L&apos;URI risultante è troppo lungo, prova a ridurre il testo nell&apos;etichetta / messaggio.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
-        <translation>Errore nella codifica URI nel codice QR</translation>
+        <translation>Errore nella codifica dell&apos;URI nel codice QR</translation>
     </message>
 </context>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etichetta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Messaggio</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Importo</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(nessuna etichetta)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(nessun messaggio)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(nessun importo)</translation>
     </message>
@@ -2120,247 +1692,194 @@ Indirizzo: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
-        <translation>Spedisci Bitcoin</translation>
+        <translation>Invia Bitcoin</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Funzionalità di Coin Control</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Input...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>selezionato automaticamente</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Fondi insufficienti!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Quantità:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Byte:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Importo:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Priorità:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Commissione:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Low Output:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Dopo Commissione:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Resto:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation>Se questo e&apos; abilitato e l&apos;indirizzo per il resto e&apos; vuoto o invalido, il resto verra&apos; inviato a un nuovo indirizzo bitcoin generato per lo scopo.</translation>
+        <translation>Se questo è abilitato e l&apos;indirizzo per il resto è vuoto o invalido, il resto sarà inviato ad un nuovo indirizzo bitcoin generato appositamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Personalizza indirizzo di resto</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
-        <translation>Spedisci a diversi beneficiari in una volta sola</translation>
+        <translation>Invia a diversi beneficiari in una volta sola</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;Aggiungi beneficiario</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Cancellare tutti i campi del modulo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Cancella &amp;tutto</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
-        <translation>Conferma la spedizione</translation>
+        <translation>Conferma l&apos;azione di invio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
-        <translation>&amp;Spedisci</translation>
+        <translation>&amp;Invia</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
-        <translation>Conferma la spedizione di bitcoin</translation>
+        <translation>Conferma l&apos;invio di bitcoin</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 a %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Copia quantità</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copia l&apos;importo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Copia commissione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copia dopo commissione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copia byte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copia priorità</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copia low output</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copia resto</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Importo Totale %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>o</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
-        <translation>L&apos;indirizzo del beneficiario non è valido, per cortesia controlla.</translation>
+        <translation>L&apos;indirizzo del beneficiario non è valido, si prega di ricontrollare.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>L&apos;importo da pagare dev&apos;essere maggiore di 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
-        <translation>L&apos;importo è superiore al saldo attuale</translation>
+        <translation>L&apos;importo è superiore al tuo saldo attuale</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
-        <translation>Il totale è superiore al saldo attuale includendo la commissione %1.</translation>
+        <translation>Il totale è superiore al tuo saldo attuale includendo la commissione di %1.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
-        <translation>Trovato un indirizzo doppio, si può spedire solo una volta a ciascun indirizzo in una singola operazione.</translation>
+        <translation>Rilevato un indirizzo duplicato, è possibile inviare bitcoin una sola volta agli indirizzi durante un&apos;operazione di invio.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Creazione transazione fallita!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
-        <translation>La transazione e&apos; stata rifiutata! Questo puo&apos; accadere se alcune delle monete nel tuo portafoglio sono gia&apos; state spese, per esempio se hai fatto una copia di un file wallet.dat le quali monete eran gia&apos; state spese, ma non marcate come tali nel file.</translation>
+        <translation>La transazione è stata rifiutata! Questo può accadere se alcuni bitcoin nel tuo portamonete sono già stati spesi, ad esempio se hai utilizzato una copia del file wallet.dat per spendere bitcoin e questi non sono stati considerati spesi dal portamonete corrente.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Attenzione: Indirizzo Bitcoin non valido</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(nessuna etichetta)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
-        <translation>Attenzione: Indirizzo di ritorno sconosciuto</translation>
+        <translation>Attenzione: Indirizzo per il resto sconosciuto</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Sei sicuro di voler inviare?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>aggiunto come tassa di transazione</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Richiesta di pagamento scaduta</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Indirizzo di pagamento non valido %1</translation>
     </message>
@@ -2368,98 +1887,74 @@ Indirizzo: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Importo:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Paga &amp;a:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>L&apos;indirizzo del beneficiario a cui inviare il pagamento (ad esempio 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Inserisci un&apos;etichetta per questo indirizzo, per aggiungerlo nella rubrica</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etichetta</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
-        <translation>Scegli indirizzo usato precedentemente</translation>
+        <translation>Scegli un indirizzo usato precedentemente</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Questo è un normale pagamento.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Incollare l&apos;indirizzo dagli appunti</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Rimuovi questa voce</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Messaggio:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Questa è una richiesta di pagamento verificata.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation>Inserisci un&apos;etichetta per questo indirizzo per aggiungerlo nella rubrica</translation>
+        <translation>Inserisci un&apos;etichetta per questo indirizzo per aggiungerlo alla lista degli indirizzi utilizzati</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation>Messaggio che era incluso nel bitcoin URI che sarà memorizzato con la transazione per vostro riferimento. Nota: Questo messaggio non sarà inviato attraverso la rete Bitcoin.</translation>
+        <translation>Messaggio incluso nel bitcoin URI e che sarà memorizzato con la transazione per vostro riferimento. Nota: Questo messaggio non sarà inviato attraverso la rete Bitcoin.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Questa è una richiesta di pagamento non verificata.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Pagare a:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memo:</translation>
     </message>
@@ -2467,199 +1962,153 @@ Indirizzo: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
-        <translation>Bitcoin Core si sta spegnendo...</translation>
+        <translation>Arresto di Bitcoin Core in corso...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
-        <translation>Non spegnere il computer fintanto che non sparisce questa finestra.</translation>
+        <translation>Non spegnere il computer fino a quando questa finestra non si sarà chiusa.</translation>
     </message>
 </context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Firme - Firma / Verifica un messaggio</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Firma il messaggio</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation>Puoi firmare messeggi con i tuoi indirizzi per dimostrare che sono tuoi. Fai attenzione a non firmare niente di vago, visto che gli attacchi di phishing potrebbero cercare di spingerti a mettere la tua firma su di loro. Firma solo dichiarazioni completamente dettagliate con cui sei d&apos;accordo.</translation>
+        <translation>Puoi firmare messaggi con i tuoi indirizzi in modo da dimostrarne il possesso. Presta attenzione a non firmare dichiarazioni vaghe, attacchi di phishing potrebbero cercare di spingerti ad apporre la tua firma su di esse. Firma solo dichiarazioni completamente dettagliate e delle quali condividi in pieno il contenuto.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
-        <translation>Inserisci un indirizzo Bitcoin (ad esempio 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
+        <translation>L&apos;indirizzo con cui firmare il messaggio (ad esempio 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
-        <translation>Scegli indirizzo usato precedentemente</translation>
+        <translation>Scegli un indirizzo usato precedentemente</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
-        <translation>Incollare l&apos;indirizzo dagli appunti</translation>
+        <translation>Incolla l&apos;indirizzo dagli appunti</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Inserisci qui il messaggio che vuoi firmare</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Firma</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copia la firma corrente nella clipboard</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Firma un messaggio per dimostrare di possedere questo indirizzo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Firma &amp;Messaggio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
-        <translation>Reimposta tutti i campi della firma</translation>
+        <translation>Reimposta tutti i campi della firma messaggio</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Cancella &amp;tutto</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verifica Messaggio</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
-        <translation>Inserisci l&apos;indirizzo per la firma, il messaggio (verifica di copiare esattamente anche i ritorni a capo, gli spazi, le tabulazioni, etc) e la firma qui sotto, per verificare il messaggio. Verifica che il contenuto della firma non sia più grande di quello del messaggio per evitare attacchi di tipo man-in-the-middle.</translation>
+        <translation>Inserisci l&apos;indirizzo del firmatario, il messaggio (assicurati di copiare esattamente anche i ritorni a capo, gli spazi, le tabulazioni, etc..) e la firma qui sotto, per verificare il messaggio. Presta attenzione a non vedere nella firma più di quanto non sia riportato nel messaggio stesso, per evitare di cadere vittima di attacchi di tipo man-in-the-middle.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
-        <translation>Inserisci un indirizzo Bitcoin (ad esempio 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
+        <translation>L&apos;indirizzo con cui è stato firmato il messaggio (ad esempio 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
-        <translation>Verifica il messaggio per assicurarsi che sia stato firmato con l&apos;indirizzo Bitcoin specificato</translation>
+        <translation>Verifica il messaggio per accertare che sia stato firmato con l&apos;indirizzo specificato</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verifica &amp;Messaggio</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Reimposta tutti i campi della verifica messaggio</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Inserisci un indirizzo Bitcoin (ad esempio 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Clicca &quot;Firma il messaggio&quot; per ottenere la firma</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>L&apos;indirizzo inserito non è valido.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Per favore controlla l&apos;indirizzo e prova ancora</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>L&apos;indirizzo bitcoin inserito non è associato a nessuna chiave.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
-        <translation>Sblocco del portafoglio annullato.</translation>
+        <translation>Sblocco del portamonete annullato.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>La chiave privata per l&apos;indirizzo inserito non è disponibile.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Firma messaggio fallita.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Messaggio firmato.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Non è stato possibile decodificare la firma.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Per favore controlla la firma e prova ancora.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
-        <translation>La firma non corrisponde al sunto del messaggio.</translation>
+        <translation>La firma non corrisponde al digest del messaggio.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Verifica messaggio fallita.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Messaggio verificato.</translation>
     </message>
@@ -2667,17 +2116,14 @@ Indirizzo: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Gli sviluppatori del Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2685,7 +2131,6 @@ Indirizzo: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2693,184 +2138,138 @@ Indirizzo: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Aperto fino a %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>in conflitto</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/non confermato</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 conferme</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Stato</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, trasmesso attraverso %n nodo</numerusform><numerusform>, trasmesso attraverso %n nodi</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Sorgente</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generato</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Da</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>A</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>proprio indirizzo</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etichetta</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Credito</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
-        <translation><numerusform>matura in %n ulteriore blocco</numerusform><numerusform>matura in altri %n blocchi</numerusform></translation>
+        <translation><numerusform>matura tra %n blocco</numerusform><numerusform>matura tra %n blocchi</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>non accettate</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debito</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Commissione transazione</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Importo netto</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Messaggio</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Commento</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID della transazione</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Mercante</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation>Bisogna attendere %1 blocchi prima di spendere I bitcoin generati. Quando è stato generato questo blocco, è stato trasmesso alla rete per aggiungerlo alla catena di blocchi. Se non riesce a entrare nella catena, verrà modificato in &quot;non accettato&quot; e non sarà spendibile. Questo può accadere a volte, se un altro nodo genera un blocco entro pochi secondi del tuo.</translation>
+        <translation>È necessario attendere %1 blocchi prima che i bitcoin generati possano essere spesi. Quando è stato generato questo blocco, è stato trasmesso alla rete in modo da poter essere aggiunto alla block chain. Se l&apos;inserimento avrà esito negativo il suo stato sarà modificato in &quot;non accettato&quot; e risulterà non spendibile. Questo può occasionalmente accadere se un altro nodo genera un blocco entro pochi secondi dal tuo.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Informazione di debug</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transazione</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Input</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Importo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>vero</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, non è stato ancora trasmesso con successo</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Aperto per %n altro blocco</numerusform><numerusform>Aperto per altri %n blocchi</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>sconosciuto</translation>
     </message>
@@ -2878,12 +2277,10 @@ Indirizzo: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Dettagli sulla transazione</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Questo pannello mostra una descrizione dettagliata della transazione</translation>
     </message>
@@ -2891,127 +2288,102 @@ Indirizzo: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Importo</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>Immaturo (%1 conferme, sarà disponibile fra %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Aperto per %n altro blocco</numerusform><numerusform>Aperto per altri %n blocchi</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Aperto fino a %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confermato (%1 conferme)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
-        <translation>Questo blocco non è stato ricevuto da altri nodi e probabilmente non sarà accettato!</translation>
+        <translation>Questo blocco non è stato ricevuto dagli altri nodi e probabilmente non sarà accettato!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generati, ma non accettati</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Offline</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Non confermato:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>In conferma (%1 di %2 conferme raccomandate)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>In conflitto</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Ricevuto tramite</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Ricevuto da</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
-        <translation>Spedito a</translation>
+        <translation>Inviato a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pagamento a te stesso</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Ottenuto dal mining</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(N / a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
-        <translation>Stato della transazione. Passare con il mouse su questo campo per vedere il numero di conferme.</translation>
+        <translation>Stato della transazione. Passare con il mouse su questo campo per visualizzare il numero di conferme.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Data e ora in cui la transazione è stata ricevuta.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipo di transazione.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Indirizzo di destinazione della transazione.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Importo rimosso o aggiunto al saldo.</translation>
     </message>
@@ -3019,178 +2391,142 @@ Indirizzo: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Tutti</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Oggi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Questa settimana</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Questo mese</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Il mese scorso</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Quest&apos;anno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Intervallo...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Ricevuto tramite</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
-        <translation>Spedito a</translation>
+        <translation>Inviato a</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
-        <translation>A te</translation>
+        <translation>A te stesso</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Ottenuto dal mining</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Altro</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Inserisci un indirizzo o un&apos;etichetta da cercare</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Importo minimo</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copia l&apos;indirizzo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copia l&apos;etichetta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copia l&apos;importo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copia l&apos;ID transazione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Modifica l&apos;etichetta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Mostra i dettagli della transazione</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
-        <translation>Esporta storico delle transazioni</translation>
+        <translation>Esporta lo storico delle transazioni</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Esportazione Fallita.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
-        <translation>C&apos;è stato un errore tentanto di salvare la storia della transazione in %1.</translation>
+        <translation>Si è verificato un errore durante il salvataggio dello storico delle transazioni in %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Esportazione Riuscita</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>Lo storico delle transazioni e&apos; stato salvato con successo in %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Testo CSV (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confermato</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etichetta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Indirizzo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Importo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Intervallo:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>a</translation>
     </message>
@@ -3198,58 +2534,48 @@ Indirizzo: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
-        <translation>Non è stato caricato alcun portafoglio.</translation>
+        <translation>Non è stato caricato alcun portamonete.</translation>
     </message>
 </context>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
-        <translation>Spedisci Bitcoin</translation>
+        <translation>Invia Bitcoin</translation>
     </message>
 </context>
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Esporta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
-        <translation>Esporta i dati nella tabella corrente su un file</translation>
+        <translation>Esporta su file i dati della tabella corrente</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Backup Portamonete</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Dati Portamonete (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Backup Fallito</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation>C&apos;è stato un errore tentanto di salvare i dati del portamonete in %1.</translation>
+        <translation>Si è verificato un errore durante il salvataggio dei dati del portamonete in %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation>Il portafoglio è stato correttamente salvato in %1.</translation>
+        <translation>Il portamonete è stato correttamente salvato in %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Backup eseguito con successo</translation>
     </message>
@@ -3257,114 +2583,86 @@ Indirizzo: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Utilizzo:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
-        <translation>Lista comandi
-</translation>
+        <translation>Elenca comandi</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
-        <translation>Aiuto su un comando
-</translation>
+        <translation>Aiuto su un comando</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
-        <translation>Opzioni:
-</translation>
+        <translation>Opzioni:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Specifica il file di configurazione (predefinito: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Specifica il file pid (predefinito: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
-        <translation>Specifica la cartella dati
-</translation>
+        <translation>Specifica la cartella dati</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Imposta la dimensione cache del database in megabyte (predefinita: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
-        <translation>Ascolta le connessioni JSON-RPC su &lt;porta&gt; (predefinita: 8333 o testnet: 18333)</translation>
+        <translation>Attendi le connessioni su &lt;porta&gt; (predefinita: 8333 o testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Mantieni al massimo &lt;n&gt; connessioni ai peer (predefinite: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
-        <translation>Connessione ad un nodo per ricevere l&apos;indirizzo del peer, e disconnessione</translation>
+        <translation>Connettiti ad un nodo per recuperare gli indirizzi dei peer e scollegati</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Specifica il tuo indirizzo pubblico</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Soglia di disconnessione dei peer di cattiva qualità (predefinita: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
-        <translation>Numero di secondi di sospensione che i peer di cattiva qualità devono trascorrere prima di riconnettersi (predefiniti: 86400)</translation>
+        <translation>Numero di secondi di sospensione che i peer di cattiva qualità devono attendere prima di potersi riconnettere (predefiniti: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Errore riscontrato durante l&apos;impostazione della porta RPC %u per l&apos;ascolto su IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Attendi le connessioni JSON-RPC su &lt;porta&gt; (predefinita: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
-        <translation>Accetta da linea di comando e da comandi JSON-RPC
-</translation>
+        <translation>Accetta comandi da riga di comando e JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation>Versione client RPC di Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
-        <translation>Esegui in background come demone e accetta i comandi
-</translation>
+        <translation>Esegui in background come demone ed accetta i comandi</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
-        <translation>Utilizza la rete di prova
-</translation>
+        <translation>Utilizza la rete di prova</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Accetta connessioni dall&apos;esterno (predefinito: 1 se no -proxy o -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3383,739 +2681,700 @@ rpcuser=bitcoinrpc
 rpcpassword=%s
 (non serve ricordare questa password)
 Il nome utente e la password NON DEVONO essere uguali.
-Se il file non esiste, crealo impostando i permessi di solo scrittura per il proprietario nel file.
+Se il file non esiste, crealo concedendo permessi di lettura al solo proprietario del file.
 Si raccomanda anche di impostare alertnotify così sarai avvisato di eventuali problemi;
-per esempio: alertnotify=echo %%s | mail -s &quot;Allarme Bitcoin&quot; admin@foo.com
+ad esempio: alertnotify=echo %%s | mail -s &quot;Allarme Bitcoin&quot; admin@foo.com
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Cifrature accettabili (predefinito: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Errore riscontrato durante l&apos;impostazione della porta RPC %u per l&apos;ascolto su IPv6, tornando su IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
-        <translation>Collega all&apos;indirizzo indicato e resta sempre in ascolto su questo. Usa la notazione [host]:porta per l&apos;IPv6</translation>
+        <translation>Associa all&apos;indirizzo indicato e resta permanentemente in ascolto su questo. Usa la notazione [host]:porta per l&apos;IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Non è possibile ottenere i dati sulla cartella %s. Probabilmente Bitcoin è già in esecuzione.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation>Limita la quantità di transazioni gratuite ad &lt;n&gt;*1000 byte al minuto (predefinito: 15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Entra in modalità di test di regressione, la quale usa una speciale catena in cui i blocchi sono risolti istantaneamente. Questo è fatto per lo sviluppo di strumenti e applicazioni per test di regressione.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>Entra in modalità di test di regressione, la quale usa una speciale catena in cui i blocchi possono essere risolti istantaneamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
-        <translation>Errore: la transazione è stata rifiutata. Ciò accade se alcuni bitcoin nel portamonete sono stati già spesi, ad esempio se è stata usata una copia del file wallet.dat e i bitcoin sono stati spesi dalla copia ma non segnati come spesi qui.</translation>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation>Errore: l&apos;ascolto per le connessioni in ingresso non è riuscito (errore riportato %d) </translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
+        <translation>Errore: la transazione è stata rifiutata! Questo può accadere se alcuni bitcoin nel tuo portamonete sono già stati spesi, ad esempio se hai utilizzato una copia del file wallet.dat per spendere bitcoin e questi non sono stati considerati spesi dal portamonete corrente.</translation>
+    </message>
+    <message>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Errore: questa transazione necessita di una commissione di almeno %s a causa del suo ammontare, della sua complessità, o dell&apos;uso di fondi recentemente ricevuti!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
-        <translation>Esegui comando quando una transazione del portafoglio cambia (%s in cmd è sostituito da TxID)</translation>
+        <translation>Esegui comando quando una transazione del portamonete cambia (%s in cmd è sostituito da TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation>Le commissioni inferiori a questo valore saranno considerate nulle (per la creazione della transazione) (prefedinito:</translation>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation>Scarica l&apos;attività del database dalla memoria al log su disco ogni &lt;n&gt; megabytes (predefinito: 100)</translation>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation>Determina quanto sarà approfondita la verifica da parte di -checkblocks (0-4, predefinito: 3)</translation>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation>In questa modalità -genproclimit determina quanti blocchi saranno generati immediatamente.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation>Imposta il numero di thread per la verifica degli script (da %u a %d, 0 = automatico, &lt;0 = lascia questo numero di core liberi, predefinito: %d)</translation>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation>Imposta il limite della cpu quando la generazione è abilitata (-1 = non limitato, predefinito: -1)</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Questa versione è una compilazione pre-rilascio - usala a tuo rischio - non utilizzarla per la generazione o per applicazioni di commercio</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation>Impossibile associarsi a %s su questo computer. Probabilmente Bitcoin Core è già in esecuzione.</translation>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Usa un SOCKS5 proxy separato per raggiungere servizi nascosti di Tor (predefinito: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Attenzione: -paytxfee è molto alta. Questa è la commissione che si paga quando si invia una transazione.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
-        <translation>Attenzione: si prega di controllare che la data del computer e l&apos;ora siano corrette. Se il vostro orologio è sbagliato Bitcoin non funziona correttamente.</translation>
+        <translation>Attenzione: si prega di controllare che la data e l&apos;ora del computer siano corrette. Se l&apos;ora di sistema è errata Bitcoin non funzionerà correttamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Attenzione: La rete non sembra essere d&apos;accordo pienamente! Alcuni minatori sembrano riscontrare problemi.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation>Attenzione: Sembra che non siamo in completo accordo con i nostri peer! Potrebbe essere necessario eseguire un aggiornamento, o gli altri nodi potrebbero aver bisogno di aggiornarsi.</translation>
+        <translation>Attenzione: Sembra che non ci sia completo accordo con i nostri peer! Un aggiornamento da parte tua o degli altri nodi potrebbe essere necessario.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
-        <translation>Attenzione: errore di lettura di wallet.dat!  Tutte le chiave lette correttamente, ma i dati delle transazioni o le voci in rubrica potrebbero mancare o non essere corretti.</translation>
+        <translation>Attenzione: errore di lettura di wallet.dat! Tutte le chiavi sono state lette correttamente, ma i dati delle transazioni o le voci in rubrica potrebbero mancare o non essere corretti.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
-        <translation>Attenzione: wallet.dat corrotto, dati salvati! Il wallet.dat originale salvato come wallet.{timestamp}.bak in %s; se il tuo bilancio o le transazioni non sono corrette dovresti ripristinare da un backup.</translation>
+        <translation>Attenzione: wallet.dat corrotto, dati recuperati! Il wallet.dat originale è stato salvato come wallet.{timestamp}.bak in %s; se il tuo saldo o le transazioni non sono corrette dovresti ripristinare da un backup.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation>(predefinito: 1)</translation>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation>(predefinito: wallet.dat)</translation>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; può essere:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Tenta di recuperare le chiavi private da un wallet.dat corrotto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Bitcoin Core Daemon</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Versione Bitcoin RPC client</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Opzioni creazione blocco:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
-        <translation>Elenco chiaro delle transazioni sul portafoglio (strumento di diagnostica; implica -rescan)</translation>
+        <translation>Cancella elenco delle transazioni sul portamonete (strumento di diagnostica; implica -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Connetti solo al nodo specificato</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Connetti attraverso SOCKS proxy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Connetti al JSON-RPC su &lt;port&gt; (predefinita: 8332 o testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>Opzioni di connessione:</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Rilevato database blocchi corrotto</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
-        <translation>Scopri proprio indirizzo IP (predefinito: 1 se in ascolto e no -externalip)</translation>
+        <source>Debugging/Testing options:</source>
+        <translation>Opzioni di Debug/Test:</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation>Disabilita la modalità sicura, escludi effettivamente gli eventi di modalità sicura (predefinito: 0)</translation>
+    </message>
+    <message>
+        <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
+        <translation>Scopre il proprio indirizzo IP (predefinito: 1 se in ascolto e no -externalip)</translation>
+    </message>
+    <message>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Non caricare il portamonete e disabilita le chiamate RPC al portamonete</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Vuoi ricostruire ora il database dei blocchi?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Errore durante l&apos;inizializzazione del database dei blocchi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Errore durante l&apos;inizializzazione dell&apos;ambiente %s del database del portamonete!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Errore caricamento database blocchi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Errore caricamento database blocchi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
-        <translation>Errore: la spazio libero sul disco è poco!</translation>
+        <translation>Errore: la spazio libero sul disco è insufficiente!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
-        <translation>Errore: portafoglio bloccato, impossibile creare la transazione!</translation>
+        <translation>Errore: portamonete bloccato, impossibile creare la transazione!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Errore: errore di sistema:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation>Impossibile mettersi in ascolto su una porta. Usa -listen=0 se vuoi usare questa opzione.</translation>
+        <translation>Nessuna porta disponibile per l&apos;ascolto. Usa -listen=0 se vuoi procedere comunque.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Lettura informazioni blocco fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Lettura blocco fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Sincronizzazione dell&apos;indice del blocco fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Scrittura dell&apos;indice del blocco fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Scrittura informazioni blocco fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Scrittura blocco fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Scrittura informazioni file fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Scrittura nel database dei bitcoin fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Scrittura dell&apos;indice di transazione fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
-        <translation>Scrittura dei dati di ripristino falllita</translation>
+        <translation>Scrittura dei dati di ripristino fallita</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Commissione per kB da aggiungere alle transazioni in uscita</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
-        <translation>Trova peer utilizzando la ricerca DNS (predefinito: 1 finché utilizzato -connect)</translation>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation>Le commissioni inferiori a questo valore saranno considerate nulle (per la trasmissione) (prefedinito:</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
+        <translation>Trova peer utilizzando la ricerca DNS (predefinito: 1 a meno che non si usi -connect)</translation>
+    </message>
+    <message>
+        <source>Force safe mode (default: 0)</source>
+        <translation>Forza modalità provvisoria (predefinito: 0)</translation>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Genera Bitcoin (predefinito: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
-        <translation>Quanti blocchi da controllare all&apos;avvio (predefinito: 288, 0 = tutti)</translation>
+        <translation>Numero di blocchi da controllare all&apos;avvio (predefinito: 288, 0 = tutti)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Quanto è precisa la verifica del blocco (0-4, predefinito: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
-        <translation>Se &lt;category&gt; non e&apos; specificata, mostra tutte le informazioni di debug.</translation>
+        <translation>Se &lt;category&gt; non è specificata, mostra tutte le informazioni di debug.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation>Blocco genesis non corretto o non trovato. Cartella dati sbagliata per network?</translation>
+        <translation>Blocco genesis non corretto o non trovato. Cartella dati errata?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Indirizzo -onion non valido: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Non ci sono abbastanza descrittori di file disponibili.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
-        <translation>Pretendi output di debug con timestamp (predefinito: 1)</translation>
+        <translation>Preponi timestamp all&apos;output di debug (predefinito: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>Opzioni client RPC:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Ricreare l&apos;indice della catena di blocchi dai file blk000??.dat correnti</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Selezionare la versione SOCKS per -proxy (4 o 5, predefinito: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Invia comando al server Bitcoin</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation>Imposta la dimensione cache del database in megabyte (%d a %d, predefinito: %d)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
-        <translation>Impostare la dimensione massima del blocco in byte (predefinita: %d)</translation>
+        <translation>Imposta la dimensione massima del blocco in byte (predefinita: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Specifica il numero massimo di richieste RPC in parallelo (predefinito: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
-        <translation>Specifica il file portafoglio  (nella cartella dati)</translation>
+        <translation>Specifica il file portamonete (all&apos;interno della cartella dati)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
-        <translation>Spendere il resto non confermato con l&apos;invio delle transazioni (predefinito: 1)</translation>
+        <translation>Spendi il resto non confermato quando si inviano transazioni (predefinito: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Avvia server Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
-        <translation>Questo </translation>
+        <translation>Questo è previsto per l&apos;uso con test di regressione e per lo sviluppo di applicazioni.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Usage (deprecato, usare bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verifica blocchi...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
-        <translation>Verifica portafoglio...</translation>
+        <translation>Verifica portamonete...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Attendere l&apos;avvio dell&apos;RPC server</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
-        <translation>Il portafoglio %s si trova fuori dalla cartella dati %s</translation>
+        <translation>Il portamonete %s si trova al di fuori dalla cartella dati %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Opzioni portamonete:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
-        <translation>Attenzione: Argomento deprecato -debugnet ignorato, usa -debug=net</translation>
+        <translation>Attenzione: Argomento deprecato -debugnet ignorato, usare -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
-        <translation>Serve ricostruire il database usando -reindex per cambiare -txindex</translation>
+        <translation>È necessario ricostruire il database usando -reindex per cambiare -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importa blocchi da un file blk000??.dat esterno</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation>Non è possibile ottenere un lock sulla cartella %s. Probabilmente Bitcoin Core è già in esecuzione.</translation>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
-        <translation>Eseguire comando quando un rilevante allarme viene ricevuto o vediamo una fork veramente lunga (%s in cmd è sostituito dal messaggio)</translation>
+        <translation>Esegue un comando quando viene ricevuto un allarme rilevante o quando vediamo un fork veramente lungo (%s in cmd è sostituito dal messaggio)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
-        <translation>Informazione di debug in output (predefinito: 0, fornire &lt;category&gt; è opzionale)</translation>
+        <translation>Emette informazioni di debug in output (predefinito: 0, fornire &lt;category&gt; è opzionale)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
-        <translation>Imposta la dimensione massima delle transazioni di priorità-alta/basse-commissioni in byte (predefinita: %d)</translation>
+        <translation>Imposta la dimensione massima in byte delle transazioni ad alta-priorità/basse-commissioni (predefinita: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Imposta il numero di thread di verifica script (fino a 16, 0 = auto, &lt;0 = lascia il maggior numero di core liberi, predefinito: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informazioni</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Importo non valido per -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Importo non valido per -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation>Limita la dimensione della cache delle firme a &lt;n&gt; voci (predefinito: 50000)</translation>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation>Abilita il log della priorità di transazione e della commissione per kB quando si generano blocchi (default: 0)</translation>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Mantieni un indice di transazione completo (predefinito: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Buffer di ricezione massimo per connessione, &lt;n&gt;*1000 byte (predefinito: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Buffer di invio massimo per connessione, &lt;n&gt;*1000 byte (predefinito: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Accetta solo una catena di blocchi che corrisponde ai checkpoint predefiniti (predefinito: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Connetti solo a nodi nella rete &lt;net&gt; (IPv4, IPv6 o Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation>Stampa il blocco all&apos;avvio, se presente nell&apos;indice dei blocchi</translation>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation>Stampa l&apos;albero dei blocchi all&apos;avvio (default: 0)</translation>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>Opzioni RPC SSL: (consulta la Bitcoin Wiki per le istruzioni relative alla configurazione SSL)</translation>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>Opzioni server RPC:</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation>Scarta casualmente 1 ogni &lt;n&gt; messaggi di rete</translation>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation>Altera casualmente 1 ogni &lt;n&gt; messaggi di rete</translation>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation>Mantieni in esecuzione un thread per scaricare periodicamente il portafoglio (predefinito: 1)</translation>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Opzioni SSL: (vedi il wiki di Bitcoin per le istruzioni di configurazione SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation>Invia comando a Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Invia le informazioni di trace/debug alla console invece che al file debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Imposta dimensione minima del blocco in bytes (predefinita: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation>Imposta il flag DB_PRIVATE nell&apos;ambiente di database del portamonete (predefinito: 1)</translation>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>Mostra tutte le opzioni di debug (utilizzo: --help -help-debug)</translation>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation>Visualizza le informazioni relative al benchmark (predefinito: 0)</translation>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Riduci il file debug.log all&apos;avvio del client (predefinito: 1 se non impostato -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Transazione di firma fallita</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Specifica il timeout di connessione in millisecondi (predefinito: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation>Avvia Bitcoin Core Daemon</translation>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Errore di sistema:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Importo transazione troppo piccolo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>L&apos;importo della transazione deve essere positivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transazione troppo grande</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Usa UPnP per mappare la porta in ascolto (predefinito: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Usa UPnP per mappare la porta in ascolto (predefinito: 1 when listening)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nome utente per connessioni JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Attenzione</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Attenzione: questa versione è obsoleta, aggiornamento necessario!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Cancella e ricompila tutte le transazioni dal wallet...</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>all&apos;avvio</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>versione</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
-        <translation>wallet.dat corrotto, salvataggio fallito</translation>
+        <translation>wallet.dat corrotto, recupero fallito</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Password per connessioni JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Consenti connessioni JSON-RPC dall&apos;indirizzo IP specificato
 </translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Inviare comandi al nodo in esecuzione su &lt;ip&gt; (predefinito: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>Esegui il comando quando il miglior block cambia(%s nel cmd è sostituito dall&apos;hash del blocco)</translation>
+        <translation>Esegui il comando quando il migliore blocco cambia(%s nel cmd è sostituito dall&apos;hash del blocco)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Aggiorna il wallet all&apos;ultimo formato</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
-        <translation>Impostare la quantità di chiavi di riserva a &lt;n&gt; (predefinita: 100)</translation>
+        <translation>Impostare la quantità di chiavi nel key pool a &lt;n&gt; (predefinita: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
-        <translation>Ripeti analisi della catena dei blocchi per cercare le transazioni  mancanti dal portamonete
+        <translation>Ripeti analisi della catena dei blocchi per cercare le transazioni mancanti dal portamonete
 </translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
-        <translation>Utilizzare OpenSSL (https) per le connessioni  JSON-RPC
+        <translation>Utilizzare OpenSSL (https) per le connessioni JSON-RPC
 </translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>File certificato del server (predefinito: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Chiave privata del server (predefinito: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Questo messaggio di aiuto
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
-        <translation>Impossibile collegarsi alla %s su questo computer (bind returned error %d, %s)</translation>
+        <translation>Impossibile associarsi alla %s su questo computer (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
-        <translation>Consenti ricerche DNS per aggiungere nodi e collegare
-</translation>
+        <translation>Consenti ricerche DNS per -addnode, -seednode e -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Caricamento indirizzi...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
-        <translation>Errore caricamento wallet.dat: Wallet corrotto</translation>
+        <translation>Errore caricamento wallet.dat: Portamonete corrotto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
-        <translation>Errore caricamento wallet.dat: il wallet richiede una versione nuova di Bitcoin</translation>
+        <translation>Errore caricamento wallet.dat: il portamonete richiede una versione di Bitcoin più recente</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
-        <translation>Il portamonete deve essere riscritto: riavviare Bitcoin per completare</translation>
+        <translation>Il portamonete necessitava di essere riscritto: riavviare Bitcoin per completare</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Errore caricamento wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Indirizzo -proxy non valido: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Rete sconosciuta specificata in -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Versione -socks proxy sconosciuta richiesta: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Impossibile risolvere -bind address: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Impossibile risolvere indirizzo -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Importo non valido per -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Importo non valido</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Fondi insufficienti</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Caricamento dell&apos;indice del blocco...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
-        <translation>Elérendő csomópont megadása and attempt to keep the connection open</translation>
+        <translation>Aggiunge un nodo a cui connettersi e tenta di tenere aperta la connessione</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Impossibile collegarsi alla %s su questo computer. Probabilmente Bitcoin è già in esecuzione.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Caricamento portamonete...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
-        <translation>Non è possibile retrocedere il wallet</translation>
+        <translation>Non è possibile effettuare il downgrade del portamonete</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Non è possibile scrivere l&apos;indirizzo predefinito</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
-        <translation>Ripetere la scansione...</translation>
+        <translation>Ripetizione scansione...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Caricamento completato</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
-        <translation>Per usare la opzione %s</translation>
+        <translation>Per usare l&apos;opzione %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>
-        <translation>Devi settare rpcpassword=&lt;password&gt; nel file di configurazione: %s Se il file non esiste, crealo con i permessi di amministratore</translation>
+        <translation>Devi settare rpcpassword=&lt;password&gt; nel file di configurazione:
+%s
+Se il file non esiste, crealo assegnando i permessi di lettura solamente al proprietario.</translation>
     </message>
 </context>
 </TS>

--- a/src/qt/locale/bitcoin_ja.ts
+++ b/src/qt/locale/bitcoin_ja.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,18 +24,14 @@ MIT/X11 ソフトウェア ライセンスの下で配布されています。�
 この製品は OpenSSL Toolkit (http://www.openssl.org/) に用いられる  Eric Young (eay@cryptsoft.com)  が開発した暗号化ソフトウェアと Thomas Bernard が開発した UPnP ソフトウェアを含んでいます。</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -46,122 +39,98 @@ MIT/X11 ソフトウェア ライセンスの下で配布されています。�
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>アドレスまたはラベルを編集するにはダブルクリック</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>新規アドレスの作成</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>新規(&amp;N)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>現在選択されているアドレスをシステムのクリップボードにコピーする</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>コピー(&amp;C)</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>閉じる(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>アドレスをコピー (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>選択されたアドレスを一覧から削除する</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>ファイルに現在のタブのデータをエクスポート</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>エクスポート (&amp;E)</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>削除(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>送信先のアドレスを選択</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>支払いを受け取るアドレスを指定する</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>選択(&amp;C)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>アドレス送信中</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>アドレス受信中</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>これらは支払いを送信するためのあなたの Bitcoin アドレスです。コインを送信する前に、常に額と受信アドレスを確認してください。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>ラベルをコピー (&amp;L)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>編集 (&amp;E)</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>アドレス帳をエクスポート</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>CSVファイル (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ MIT/X11 ソフトウェア ライセンスの下で配布されています。�
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>アドレス</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>（ラベル無し）</translation>
     </message>
@@ -187,140 +153,106 @@ MIT/X11 ソフトウェア ライセンスの下で配布されています。�
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>パスフレーズ ダイアログ</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>パスフレーズを入力</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>新しいパスフレーズ</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>新しいパスフレーズをもう一度</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>ウォレットの新しいパスフレーズを入力してください。&lt;br/&gt;&lt;b&gt;8個以上の単語か10個以上のランダムな文字&lt;/b&gt;を使ってください。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>ウォレットを暗号化する</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>この操作はウォレットをアンロックするためにパスフレーズが必要です。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>ウォレットをアンロックする</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>この操作はウォレットの暗号化解除のためにパスフレーズが必要です。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>ウォレットの暗号化を解除する</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>パスフレーズの変更</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>新旧両方のパスフレーズを入力してください。</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>ウォレットの暗号化を確認する</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>警告: もしもあなたのウォレットを暗号化してパスフレーズを失ってしまったなら、&lt;b&gt;あなたの Bitcoin はすべて失われます&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>本当にウォレットを暗号化しますか?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>重要: 過去のウォレット ファイルのバックアップは、暗号化された新しいウォレット ファイルに取り替える必要があります。セキュリティ上の理由により、暗号化された新しいウォレットを使い始めると、暗号化されていないウォレット ファイルのバックアップはすぐに使えなくなります。</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>警告: Caps Lock キーがオンになっています!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>ウォレットは暗号化されました</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin は暗号化プロセスを終了するために今すぐ終了します。あなたのコンピュータがマルウェアに感染してコインを盗まれることもあるので、暗号化してもあなたのウォレットを完全に保護できないことを覚えていてください。</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>ウォレットの暗号化に失敗しました</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>内部エラーによりウォレットの暗号化が失敗しました。ウォレットは暗号化されませんでした。</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>パスフレーズが同じではありません。</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>ウォレットのアンロックに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>ウォレットの暗号化解除のパスフレーズが正しくありません。</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>ウォレットの暗号化解除に失敗しました</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>ウォレットのパスフレーズの変更が成功しました。</translation>
     </message>
@@ -328,363 +260,286 @@ MIT/X11 ソフトウェア ライセンスの下で配布されています。�
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>メッセージの署名... (&amp;m)</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>ネットワークに同期中……</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>概要(&amp;O)</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>ウォレットの概要を見る</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>取引(&amp;T)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>取引履歴を閲覧</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>終了(&amp;E)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>アプリケーションを終了</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Bitcoinに関する情報を見る</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Qt について(&amp;Q)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Qt の情報を表示</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>オプション... (&amp;O)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>ウォレットの暗号化... (&amp;E)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>ウォレットのバックアップ... (&amp;B)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>パスフレーズの変更... (&amp;C)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>ディスクからブロックをインポートしています...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>ディスク上のブロックのインデックスを再作成中...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Bitcoin アドレスにコインを送る</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Bitcoin の設定を変更する</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>ウォレットを他の場所にバックアップ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>ウォレット暗号化用パスフレーズの変更</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>デバッグ ウインドウ (&amp;D)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>デバッグと診断コンソールを開く</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>メッセージの検証... (&amp;V)</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>ウォレット</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>送る (&amp;S)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>受信 (&amp;R)</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>見る/隠す (&amp;S)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>メイン ウインドウを表示または非表示</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>あなたのウォレットの秘密鍵を暗号化します</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>あなたが所有していることを証明するために、あなたの Bitcoin アドレスでメッセージに署名してください</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>指定された Bitcoin アドレスで署名されたことを確認するためにメッセージを検証します</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>ファイル(&amp;F)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>設定(&amp;S)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>ヘルプ(&amp;H)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>タブツールバー</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin のコア</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>支払いを受け取るアドレスとラベルのリストを表示する</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin クライアント</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n の Bitcoin ネットワークへのアクティブな接続</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>利用可能なブロックがありません...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>取引履歴の %2 (推定値) の内 %1 ブロックを処理しました。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>取引履歴の %1 ブロックを処理しました。</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n 時間</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n 日</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n 週間</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 遅延</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>最後に受信されたブロックは %1 前に生成されました。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>この後の取引はまだ表示されません。</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>情報</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>バージョンは最新です</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>追跡中...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>送金取引</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>着金取引</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +551,14 @@ Address: %4
 アドレス: %4</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>ウォレットは&lt;b&gt;暗号化されて、アンロックされています&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>ウォレットは&lt;b&gt;暗号化されて、ロックされています&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>致命的なエラーが発生しました。Bitcoin は安全に継続することができず終了するでしょう。
 </translation>
@@ -715,7 +567,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>ネットワーク警告</translation>
     </message>
@@ -723,291 +574,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>総額:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>総額</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>アドレス</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>検証済み</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>アドレスをコピーする</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>ラベルをコピーする</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>総額のコピー</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>取引 ID をコピー</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>はい</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>（ラベル無し）</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1015,67 +805,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>アドレスの編集</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>ラベル(&amp;L)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>アドレス帳 (&amp;A)</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>新しい受信アドレス</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>新しい送信アドレス</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>受信アドレスを編集</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>送信アドレスを編集</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>入力されたアドレス &quot;%1&quot; は既にアドレス帳にあります。</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>入力されたアドレス &quot;%1&quot; は無効な Bitcoin アドレスです。</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>ウォレットをアンロックできませんでした。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>新しいキーの生成に失敗しました。</translation>
     </message>
@@ -1083,27 +860,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation>新しいデータ ディレクトリが作成されます。</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>name</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>ディレクトリがもうあります。 新しいのディレクトリを作るつもりなら%1を書いてください。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>パスが存在しますがディレクトリではありません。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>ここにデータ ディレクトリを作成することはできません。</translation>
     </message>
@@ -1111,57 +883,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin のコア</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>バージョン</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>使用法:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>コマンドライン オプション</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI オプション</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>言語設定 例: &quot;de_DE&quot; (初期値: システムの言語)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>最小化された状態で起動する</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>起動時にスプラッシュ画面を表示する (初期値: 1)</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>起動時にデータ ディレクトリを選ぶ (初期値: 0)</translation>
     </message>
@@ -1169,57 +930,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>ようこそ</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>初期値のデータ ディレクトリを使用</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>任意のデータ ディレクトリを使用:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>エラー: 指定のデータ ディレクトリ &quot;%1&quot; を作成できません。</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GBの利用可能な空き領域</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(%1GB が必要)</translation>
     </message>
@@ -1227,27 +977,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1255,258 +1000,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>メイン (&amp;M)</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>あたなの取引が早く処理されるように任意で kB 毎の取引手数料を設定します。ほとんどの取引は 1 kB です。</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>支払う取引手数料 (&amp;f)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>システムにログインした時に自動的に Bitcoin を起動します。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>システムにログインした時に Bitcoin を起動 (&amp;S)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>すべてのオプションを初期値に戻します。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>オプションをリセット (&amp;R)</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>ネットワーク (&amp;N)</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>自動的にルーター上の Bitcoin クライアントのポートを開きます。あなたのルーターが UPnP に対応していて、それが有効になっている場合に作動します。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>UPnP を使ってポートを割り当てる (&amp;U)</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>プロキシの IP (&amp;I) :</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>ポート (&amp;P) :</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>プロキシのポート番号 (例 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS バージョン (&amp;V) :</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS プロキシのバージョン (例 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>ウインドウ (&amp;W)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>ウインドウを最小化したあとトレイ アイコンだけを表示する。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>タスクバーの代わりにトレイに最小化 (&amp;M)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>ウインドウが閉じられる時アプリケーションを終了せずに最小化します。このオプションが有効な時にアプリケーションを終了するにはメニューから終了を選択します。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>閉じる時に最小化 (&amp;i)</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>表示 (&amp;D)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>ユーザインターフェースの言語 (&amp;l) :</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>ここでユーザインターフェースの言語を設定できます。設定を反映するには Bitcoin を再起動します。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>額を表示する単位 (&amp;U) :</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>インターフェース上の表示とコインの送信で使用する単位を選択します。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>最近の取引履歴で Bitcoin アドレスを表示するかしないか。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>取引履歴にアドレスを表示 (&amp;D)</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>キャンセル (&amp;C)</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>初期値</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation>オプションのリセットの確認</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>プロキシアドレスが無効です。</translation>
     </message>
@@ -1514,69 +1207,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>フォーム</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>表示された情報は古いかもしれません。接続が確立されると、あなたのウォレットは Bitcoin ネットワークと自動的に同期しますが、このプロセスはまだ完了していません。</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>ウォレット</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>あなたの利用可能残高</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>未検証の取引で利用可能残高に反映されていない数</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>未完成:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>完成していない採掘された残高</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>合計:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>あなたの現在の残高</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;最近の取引&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>同期していない</translation>
     </message>
@@ -1584,94 +1262,71 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI の操作</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI を解析できません! これは無効な Bitcoin アドレスあるいや不正な形式の URI パラメーターによって引き起こされる場合があります。
 </translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>支払いのリクエストのエラーです</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Bitcoin を起動できません: click-to-pay handler</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>%1: %2とコミュニケーション・エラーです</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>サーバーの返事は無効 %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>支払いは確認しました</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>ネットワーク・リクエストのエラーです</translation>
     </message>
@@ -1679,29 +1334,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>エラー: 指定のデータ ディレクトリ &quot;%1&quot; は存在しません。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>エラー：　-regtestと-testnetは一緒にするのは無効です。</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin アドレスを入力します (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1709,22 +1357,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>画像を保存(&amp;S)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>画像をコピー(&amp;C)</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>QR コードの保存</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG画像ファイル(*.png)</translation>
     </message>
@@ -1732,194 +1376,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>クライアント名</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>クライアントのバージョン</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>情報 (&amp;I)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>デバッグ ウインドウ</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>使用中の OpenSSL のバージョン</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>起動した日時</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>ネットワーク</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>接続数</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>ブロック チェーン</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>現在のブロック数</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>推定総ブロック数</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>最終ブロックの日時</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>開く (&amp;O)</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>コンソール (&amp;C)</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>ネットワーク (&amp;N)</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>クリア(&amp;C)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>合計</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>ビルドの日付</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>デバッグ用ログファイル</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>現在のデータ ディレクトリから Bitcoin のデバッグ用ログファイルを開きます。ログファイルが大規模な場合には数秒かかることがあります。</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>コンソールをクリア</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bitcoin RPC コンソールへようこそ。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>上下の矢印で履歴をたどれます。 &lt;b&gt;Ctrl-L&lt;/b&gt; でスクリーンを消去できます。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>使用可能なコマンドを見るには &lt;b&gt;help&lt;/b&gt; と入力します。</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1927,105 +1523,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>総額:(&amp;A)</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>ラベル(&amp;L):</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>クリア</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>表示</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>ラベルをコピーする</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>総額のコピー</translation>
     </message>
@@ -2033,67 +1606,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>画像を保存(&amp;S)</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>支払い情報</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>アドレス</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>総額</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>メッセージ</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI が長くなり過ぎます。ラベルやメッセージのテキストを短くしてください。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>QR コード用の URI エンコードでエラー。</translation>
     </message>
@@ -2101,37 +1661,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>メッセージ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>総額</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>（ラベル無し）</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2139,247 +1692,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>コインを送る</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>総額:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>一度に複数の人に送る</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>受取人を追加 (&amp;R)</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>すべてクリア (&amp;A)</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>残高:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>送る操作を確認する</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>送る (&amp;e)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>コインを送る確認</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>総額のコピー</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>受取人のアドレスが不正です。再確認してください。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>支払額は0より大きくないといけません。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>額が残高を超えています。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>%1 の取引手数料を含めると額が残高を超えています。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>重複しているアドレスが見つかりました。1回の送信で同じアドレスに送ることは出来ません。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>（ラベル無し）</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>送ってよろしいですか？</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>取引手数料として追加された</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>支払いのリクエストは期限切れです</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>支払いのアドレス「%1」は無効です</translation>
     </message>
@@ -2387,98 +1887,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>金額(&amp;A):</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>送り先(&amp;T):</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>支払い送信するアドレス (例 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>アドレス帳に追加するには、このアドレスのラベルを入力します</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>ラベル(&amp;L):</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>前に使用したアドレスを選ぶ</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>クリップボードからアドレスを貼付ける</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>メッセージ:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>メモ：</translation>
     </message>
@@ -2486,12 +1962,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2499,186 +1973,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>署名 - メッセージの署名/検証</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>メッセージの署名 (&amp;S)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>あなた自身を立証するためにあなたのアドレスでメッセージに署名することができます。フィッシング攻撃によってあなたを騙して署名を譲渡させようとするかもしれないので、不明確なものは絶対に署名しないように注意してください。あなたが同意する完全に詳細な声明にだけ署名してください。</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>メッセージの署名に使うアドレス (例 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>前に使用したアドレスを選ぶ</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>クリップボードからアドレスを貼付ける</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>ここにあなたが署名するメッセージを入力します</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>署名</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>現在の署名をシステムのクリップボードにコピーする</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>この Bitcoin アドレスを所有していることを証明するためにメッセージに署名</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>メッセージの署名 (&amp;M)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>入力項目の内容をすべて消去します</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>すべてクリア (&amp;A)</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>メッセージの検証 (&amp;V)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>メッセージを検証するために、署名するアドレスとメッセージ(改行、スペース、タブなどを正確にコピーしてください)、そして署名を入力します。中間者攻撃によってだまされることを避けるために、署名されたメッセージそのものよりも、署名を読み取られないように注意してください。</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>メッセージが署名されたアドレス (例 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>指定された Bitcoin アドレスで署名されたことを保証するメッセージを検証</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>メッセージの検証 (&amp;M)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>入力項目の内容をすべて消去します</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin アドレスを入力します (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>署名を作成するには&quot;メッセージの署名&quot;をクリック</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>不正なアドレスが入力されました。</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>アドレスを確かめてからもう一度試してください。</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>入力されたアドレスに関連するキーがありません。</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>ウォレットのアンロックはキャンセルされました。</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>入力されたアドレスのプライベート キーが無効です。</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>メッセージの署名に失敗しました。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>メッセージに署名しました。</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>署名がデコードできません。</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>署名を確認してからもう一度試してください。</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>署名はメッセージ ダイジェストと一致しませんでした。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>メッセージの検証に失敗しました。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>メッセージは検証されました。</translation>
     </message>
@@ -2686,17 +2116,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin のコア</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2704,7 +2131,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2712,184 +2138,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>ユニット %1 を開く</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/オフライン</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/未検証</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 確認</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>ステータス</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>%n ノードにブロードキャスト</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>ソース</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>生成された</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>送信</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>受信</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>自分のアドレス</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>クレジット</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>%n 以上のブロックが満期</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>承認されなかった</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>引き落とし額</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>取引手数料</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>正味金額</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>メッセージ</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>コメント</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>取引 ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>商人</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>デバッグ情報</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>取引</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>入力</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>総額</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>正しい</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>正しくない</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>まだブロードキャストが成功していません</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>%n 以上のブロックを開く</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>未確認</translation>
     </message>
@@ -2897,12 +2277,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>取引の詳細</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>ここでは取引の詳細を表示しています</translation>
     </message>
@@ -2910,127 +2288,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>タイプ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Helbidea</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>総額</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>%n 以上のブロックを開く</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>ユニット %1 を開く</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>検証されました (%1 検証済み)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>このブロックは他のどのノードによっても受け取られないで、多分受け入れられないでしょう！</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>生成されましたが承認されませんでした</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>受信元</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>送り主</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>送り先</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>自分自身への支払い</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>発掘した</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>取引の状況。このフィールドの上にカーソルを置くと検証の数を表示します。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>取引を受信した日時。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>取引の種類。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>取引の宛先アドレス。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>残高に追加または削除された総額。</translation>
     </message>
@@ -3038,178 +2391,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>すべて</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>今日</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>今週</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>今月</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>先月</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>今年</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>期間...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>送り主</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>送り先</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>自分自身</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>発掘した</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>その他</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>検索するアドレスまたはラベルを入力</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>最小の額</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>アドレスをコピーする</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>ラベルをコピーする</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>総額のコピー</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>取引 ID をコピー</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>ラベルの編集</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>取引の詳細を表示</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>テキスト CSV (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>検証済み</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>日付</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>タイプ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>ラベル</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Helbidea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>総額</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>期間:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>から</translation>
     </message>
@@ -3217,7 +2534,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3225,7 +2541,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>コインを送る</translation>
     </message>
@@ -3233,42 +2548,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation>エクスポート (&amp;E)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>ファイルに現在のタブのデータをエクスポート</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation>ウォレットのバックアップ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>ウォレット データ (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>バックアップに失敗しました</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>バックアップ成功</translation>
     </message>
@@ -3276,107 +2583,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>使用法:</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>コマンド一覧</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>コマンドのヘルプ</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>オプション:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>設定ファイルの指定 (初期値: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>pid ファイルの指定 (初期値: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>データ ディレクトリの指定</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>接続のポート番号 (初期値: 8333、testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>ピアの最大接続数 (初期値: 125)</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>ピア アドレスを取得するためにノードに接続し、そして切断します</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation>あなた自身のパブリックなアドレスを指定</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>不正なピアを切断するためのしきい値 (初期値: 100)</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>不正なピアを再接続するまでの秒数 (初期値: 86400)</translation>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>IPv4 でリスンする RPC ポート %u の設定中にエラーが発生しました: %s</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>&lt;port&gt; で JSON-RPC 接続をリスン (初期値: 8332、testnet は 18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>コマンドラインと JSON-RPC コマンドを許可</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>デーモンとしてバックグランドで実行しコマンドを許可</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>テストのためのネットワークを使用</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>外部からの接続を許可 (初期値:  -proxy または -connect を使用していない場合は1)</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3400,853 +2686,683 @@ rpcpassword=%s
 例えば: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.com</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>IPv6 でリスンする RPC ポート %u の設定中にエラーが発生したので IPv4 に切り替えます: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>指定のアドレスへバインドし、その上で常にリスンします。IPv6 は [ホスト名]:ポート番号 と表記します</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>ブロックを瞬時に解決することができる特別なチェーンを使用して、リグレッションテストモードに入る。これはリグレッションテストツールやアプリケーション開発を対象としています。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>エラー: 取引は拒否されました。wallet.dat のコピーを使い、そしてコピーしたウォレットからコインを使用したことがマークされなかったときなど、ウォレットのいくつかのコインがすでに使用されている場合に、このエラーは起こるかもしれません。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>エラー: この取引は、額、複雑さ、あるいは最近受け取った資金の使用のために、少なくとも %s の手数料が必要です!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>ウォレットの取引を変更する際にコマンドを実行 (cmd の %s は TxID に置換される)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>これはリリース前のテストビルドです - 各自の責任で利用すること - 採掘や商取引に使用しないでください</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>警告: -paytxfee が非常に高く設定されています! これは取引を送信する場合に支払う取引手数料です。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>警告: あなたのコンピュータの日時が正しいことを確認してください! 時計が間違っていると Bitcoin は正常に動作しません。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>警告： ネットワークは完全に同意しないみたいです。マイナーは何かの問題を経験してるみたいなんです。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>警告： ピアーと完全に同意しないみたいです！アップグレードは必要かもしれません、それとも他のノードはアップグレードは必要かもしれません。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>警告: wallet.dat の読み込みエラー! すべてのキーは正しく読み取れますが、取引データやアドレス帳のエントリが失われたか、正しくない可能性があります。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>警告: wallet.dat が壊れたのでデータを復旧しました! オリジナルの wallet.dat は wallet.{timestamp}.bak として %s に保存されました; もしもあなたの残高や取引が正しくないならバックアップから復元してください。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>壊れた wallet.dat から秘密鍵を復旧することを試す</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation>ブロック作成オプション:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>指定したノードだけに接続</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation>破損したブロック データベースが見つかりました
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>自分の IP アドレスを発見 (初期値:  リスン中と -externalip を使用していない場合は1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>ブロック データベースを今すぐ再構築しますか?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>ブロック データベースの初期化中にエラー</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>ウォレットのデータベース環境 %s 初期化エラー!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>ブロック データベースの読み込みエラー</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>ブロック データベースの開始エラー</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>エラー: ディスク容量不足!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>エラー: ウォレットはロックされ、取引を作成できません!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>エラー: システム エラー:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>ポートのリスンに失敗しました。必要であれば -listen=0 を使用してください。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>ブロック情報の読み取りに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>ブロックの読み取りに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>ブロック インデックスの同期に失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>ブロック インデックスの書き込みに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>ブロック情報の書き込みに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>ブロックの書き込みに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>ファイル情報の書き込みに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>コインデータベースへの書き込みに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>取引インデックスの書き込みに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>元へ戻すデータの書き込みに失敗しました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>DNS ルックアップでピアを探す (初期値: -connect を使っていなければ1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation>コインを生成 (初期値: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>起動時に点検するブロック数 (初期値: 288, 0=すべて)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>不正なブロックあるいは、生成されていないブロックが見つかりました。ネットワークの datadir が間違っていませんか?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation>使用可能なファイルディスクリプタが不足しています。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>現在の blk000??.dat ファイルからブロック チェーンのインデックスを再構築</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>RPC サービスのスレッド数を設定 (初期値: 4)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>ウォレットのファイルを指定　(データ・ディレクトリの中に)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>ブロックの検証中...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>ウォレットの検証中...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>財布 %s はデータ・ディレクトリ%sの外にあります</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>-txindex を変更するには -reindex を使用してデータベースを再構築する必要があります</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>外部の blk000??.dat ファイルからブロックをインポート</translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>関連のアラートをもらってもすごく長いのフォークを見てもコマンドを実行 (コマンドの中にあるの%sはメッセージから置き換えさせる)</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>情報</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>不正な額 -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>不正な額 -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>完全な取引インデックスを維持する (初期値: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>接続毎の最大受信バッファ &lt;n&gt;*1000 バイト (初期値: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>接続毎の最大送信バッファ &lt;n&gt;*1000 バイト (初期値: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>内蔵のチェックポイントと一致するブロック チェーンのみを許可 (初期値: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>&lt;net&gt; (IPv4, IPv6, Tor) ネットワーク内のノードだけに接続する</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL オプション: (SSLのセットアップ手順は Bitcoin Wiki をご覧下さい)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>トレース/デバッグ情報を debug.log ファイルの代わりにコンソールへ送る</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>最小ブロックサイズをバイトで設定 (初期値: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>クライアント起動時に debug.log ファイルを縮小 (初期値: -debug オプションを指定しない場合は1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>取引の署名に失敗しました</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>接続のタイムアウトをミリセコンドで指定 (初期値: 5000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>システム エラー:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>取引の額が小さ過ぎます</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>取引の額は0より大きくしてください</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>取引が大き過ぎます</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>リスン ポートの割当に UPnP を使用 (初期値: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>リスン ポートの割当に UPnP を使用 (初期値: リスン中は1)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>JSON-RPC 接続のユーザー名</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>警告: このバージョンは古いのでアップグレードが必要です!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>バージョン</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat が壊れ、復旧に失敗しました</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>JSON-RPC 接続のパスワード</translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>指定した IP アドレスからの JSON-RPC 接続を許可</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>&lt;ip&gt; (初期値: 127.0.0.1) で実行中のノードにコマンドを送信</translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>最良のブロックに変更する際にコマンドを実行 (cmd の %s はブロック ハッシュに置換される)</translation>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>ウォレットを最新のフォーマットにアップグレード</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>key pool のサイズを &lt;n&gt; (初期値: 100) にセット</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>失ったウォレットの取引のブロック チェーンを再スキャン</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>JSON-RPC 接続に OpenSSL (https) を使用</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>サーバ証明書ファイル (初期値: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>サーバの秘密鍵 (初期値: server.pem)</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>このヘルプ メッセージ</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>このコンピュータの %s にバインドすることができません (バインドが返したエラーは %d, %s)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>-addnode, -seednode と -connect で DNS ルックアップを許可する</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>アドレスを読み込んでいます...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>wallet.dat 読み込みエラー: ウォレットが壊れました</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>wallet.dat 読み込みエラー: ウォレットは Bitcoin の最新バージョンを必要とします</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>ウォレットが書き直される必要がありました: 完了するために Bitcoin を再起動します</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>wallet.dat 読み込みエラー</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>無効な -proxy アドレス: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>-onlynet で指定された &apos;%s&apos; は未知のネットワークです</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>-socks で指定された %i は未知のバージョンです</translation>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>-bind のアドレス &apos;%s&apos; を解決できません</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>-externalip のアドレス &apos;%s&apos; を解決できません</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-paytxfee=&lt;amount&gt; の額 &apos;%s&apos; が無効です</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>無効な総額</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>残高不足</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>ブロック インデックスを読み込んでいます...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>接続するノードを追加し接続を持続するように試します</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>ウォレットを読み込んでいます...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation>ウォレットのダウングレードはできません</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>初期値のアドレスを書き込むことができません</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>再スキャン中...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>読み込み完了</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>%s オプションを使うには</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ka.ts
+++ b/src/qt/locale/bitcoin_ka.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Bitcoin Core-ს შესახებ</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;Bitcoin Core&lt;/b&gt;-ს ვერსია</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,18 +24,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 პროდუქტი შეიცავს OpenSSL პროექტის ფარგლებში შემუშავებულ პროგრამულ უზრუნველყოფას OpenSSL Toolkit-ში გამოყენებისათვის (http://www.openssl.org/), კრიპტოგრაფიულ პროგრამას, ავტორი ერიქ იანგი (Eric Young, eay@cryptsoft.com) და UPnP-პროგრამას, ავტორი თომას ბერნარდი (Thomas Bernard).</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>საავტორო უფლებები</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Core-ს ავტორები</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -46,122 +39,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>დააკლიკეთ ორჯერ მისამართის ან ნიშნულის შესაცვლელად</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>ახალი მისამართის შექმნა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>შექმ&amp;ნა</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>მონიშნული მისამართის კოპირება სისტემურ კლიპბორდში</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;კოპირება</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>&amp;დახურვა</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;მისამართის კოპირება</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>მონიშნული მისამართის წაშლა სიიდან</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>ამ ბარათიდან მონაცემების ექსპორტი ფაილში</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;ექსპორტი</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;წაშლა</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>აირჩიეთ მონეტების გაგზავნის მისამართი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>აირჩიეთ მონეტების მიღების მისამართი</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;არჩევა</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>გაგზავნის მისამართი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>მიღების მისამართი</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>ეს არის თქვენი Bitcoin-მისამართები გადახდების შესასრულებლად. მონეტების გაგზავნამდე ყოველთვის შეამოწმეთ თანხა და მიმღების მისამართი.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>ეს არის თქვენი Bitcoin-მისამართები გადახდების მისაღებად. რეკომენდებულია ყოველი ტრანსაქციისათვის ახალი მიღების მისამართის გამოყენება.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>ნიშნუ&amp;ლის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>რ&amp;ედაქტირება</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>მისამართების სიის ექსპორტი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>CSV-ფაილი (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>ექსპორტი ვერ განხორციელდა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>შეცდომა მისამართების სიის %1-ში შენახვის მცდელობისას.</translation>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>ნიშნული</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>მისამართი</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(არ არის ნიშნული)</translation>
     </message>
@@ -187,140 +153,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>ფრაზა-პაროლის დიალოგი</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>შეიყვანეთ ფრაზა-პაროლი</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>ახალი ფრაზა-პაროლი</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>გაიმეორეთ ახალი ფრაზა-პაროლი</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>შეიყვანეთ საფულის ახალი ფრაზა-პაროლი.&lt;br/&gt;ფრაზა-პაროლი შეადგინეთ &lt;b&gt;არანაკლებ 10 შემთხვევითი სიმბოლოსაგან&lt;/b&gt;, ან &lt;b&gt;რვა და მეტი სიტყვისაგან&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>საფულის დაშიფრვა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>ეს ოპერაცია მოითხოვს თქვენი საფულის ფრაზა-პაროლს საფულის განსაბლოკად.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>საფულის განბლოკვა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>ეს ოპერაცია მოითხოვს თქვენი საფულის ფრაზა-პაროლს საფულის გასაშიფრად.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>საფულის გაშიფრვა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>ფრაზა-პაროლის შეცვლა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>შეიყვანეთ საფულის ძველი და ახალი ფრაზა-პაროლი.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>დაადასტურეთ საფულის დაშიფრვა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>ყურადღება: საფულის დაშიფრვის შემდეგ თუ თქვენ დაკარგავთ ფრაზა-პაროლს,  &lt;b&gt;ყველა ბიტქოინი დაგეკარგებათ&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>დარწმუნებული ხართ, რომ გინდათ საფულის დაშიფრვა?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>მნიშვნელოვანია: თქვენი საფულის ყველა ადრინდელი არქივი შეიცვლება ახლადგენერირებული დაშიფრული საფულის ფაილით. უსაფრთხოების მოსაზრებებით დაუშიფრავი საფულის ძველი არქივები ძალას დაკარგავს, როგორც კი დაიწყებთ ახალი, დაშიფრული საფულის გამოყენებას.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>ყურადღება: ჩართულია Caps Lock რეჟიმი!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>საფულე დაშიფრულია</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>ახლა Bitcoin დაიხურება დაშიფრვის პროცესის დასასრულებლად. გაითვალისწინეთ, რომ დაშიფრვა სრულად ვერ დაიცავს თქვენს ბითქოინებს თქვენს კომპიუტერში შემოპარული მავნე პროგრამების საშუალებით დატაცებისაგან.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>ვერ მოხერხდა საფულის დაშიფრვა</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>საფულის დაშიფრვა ვერ მოხერხდა სისტემაში შეცდომის გამო. თქვენი საფულე არ არის დაშფრული.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>ფრაზა-პაროლები არ ემთხვევა ერთმანეთს.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>საფულის განბლოკვა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>საფულის განშიფრვის ფრაზა-პაროლი არაწორია</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>საფულის განშიფრვა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>საფულის ფრაზა-პაროლი შეცვლილია.</translation>
     </message>
@@ -328,363 +260,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>ხელ&amp;მოწერა</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>ქსელთან სინქრონიზება...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>მიმ&amp;ოხილვა</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>კვანძი</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>საფულის ზოგადი მიმოხილვა</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;ტრანსაქციები</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>ტრანსაქციების ისტორიის დათვალიერება</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;გასვლა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>გასვლა</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>ინფორმაცია Bitcoin-ის შესახებ</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>&amp;Qt-ს შესახებ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>ინფორმაცია Qt-ს შესახებ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;ოპციები</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>საფულის &amp;დაშიფრვა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>საფულის &amp;არქივირება</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>ფრაზა-პაროლის შე&amp;ცვლა</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>გაგზავნის მი&amp;სამართი</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>მიღების მისამა&amp;რთი</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>&amp;URI-ის გახსნა...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>ბლოკების იმპორტი დისკიდან...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>დისკზე ბლოკების რეინდექსაცია...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>მონეტების გაგზავნა Bitcoin-მისამართზე</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Bitcoin-ის საკონფიგურაციო პარამეტრების ცვლილება</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>საფულის არქივირება სხვა ადგილზე</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>საფულის დაშიფრვის ფრაზა-პაროლის შეცვლა</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>და&amp;ხვეწის ფანჯარა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>დახვეწისა და გიაგნოსტიკის კონსოლის გაშვება</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;ვერიფიკაცია</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>საფულე</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;გაგზავნა</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;მიღება</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;ჩვენება/დაფარვა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>მთავარი ფანჯრის ჩვენება/დაფარვა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>თქვენი საფულის პირადი გასაღებების დაშიფრვა</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>მესიჯებზე ხელმოწერა თქვენი Bitcoin-მისამართებით იმის დასტურად, რომ ის თქვენია</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>შეამოწმეთ, რომ მესიჯები ხელმოწერილია მითითებული Bitcoin-მისამართით</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;ფაილი</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;პარამეტრები</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;დახმარება</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>ბარათების პანელი</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>გადახდის მოთხოვნა (შეიქმნება QR-კოდები და bitcoin: ბმულები)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>Bitcoin Core-ს შეს&amp;ახებ</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>გამოყენებული გაგზავნის მისამართებისა და ნიშნულების სიის ჩვენება</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>გამოყენებული მიღების მისამართებისა და ნიშნულების სიის ჩვენება</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>bitcoin: URI-ის ან გადახდის მოთხოვნის გახსნა</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>საკომანდო სტრიქონის ოპ&amp;ციები</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Bitcoin Core-ს დახმარების ჩვენება Bitcoin-ის საკომანდო სტრიქონის დასაშვები ოპციების სანახავად</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin-კლიენტი</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>აქტიური მიერთებები ბითქოინის ქსელთან: %n</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>ბლოკების წყარო მიუწვდომელია...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>დამუშავებულია ტრანსაქციების ისტორიის %2-დან (სავარაუდოდ) %1 ბლოკი.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>დამუშავებულია ტრანსაქციების ისტორიის %1 ბლოკი.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n საათი</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n დღე</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n კვირა</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 და %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n წელი</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 გავლილია</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>ბოლო მიღებული ბლოკის გენერირებიდან გასულია %1</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>შემდგომი ტრანსაქციები ნაჩვენები ჯერ არ იქნება.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>შეცდომა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>გაფრთხილება</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>ინფორმაცია</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>განახლებულია</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>ჩართვა...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>გაგზავნილი ტრანსაქციები</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>მიღებული ტრანსაქციები</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +552,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>საფულე &lt;b&gt;დაშიფრულია&lt;/b&gt; და ამჟამად &lt;b&gt;განბლოკილია&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>საფულე &lt;b&gt;დაშიფრულია&lt;/b&gt; და ამჟამად &lt;b&gt;დაბლოკილია&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>ფატალური შეცდომა. Bitcoin ვერ უზრუნველყოფს უსაფრთხო გაგრძელებას, ამიტომ იხურება.</translation>
     </message>
@@ -715,7 +567,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>ქსელური განგაში</translation>
     </message>
@@ -723,291 +574,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>მონეტების კონტროლის მისამართის არჩევა</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>რაოდენობა:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>ბაიტები:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>თანხა:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>პრიორიტეტი:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>საკომისიო:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>ქვედა ზღვარი:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>დამატებითი საკომისიო:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>ხურდა:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>ყველას მონიშვნა/(მოხსნა)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>განტოტვილი</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>სია</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>რაოდენობა</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>მისამართი</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>თარიღი</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>დადასტურება</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>დადასტურებულია</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>პრიორიტეტი</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>მისამართის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>ნიშნულის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>თანხის კოპირება</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>ტრანსაქციის ID-ს კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>დაუხარჯავის დაბლოკვა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>დაუხარჯავის განბლოკვა</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>რაოდენობის კოპირება</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>საკომისიოს კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>დამატებითი საკომისიოს კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>ბაიტების კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>პრიორიტეტის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>ქვედა ზღვრის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>ხურდის კოპირება</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>უმაღლესი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>უფრო მაღალი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>მაღალი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>საშუალოზე მაღალი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>საშუალო</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>საშუალოზე დაბალი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>დაბალი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>უფრო დაბალი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>უდაბლესი</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 დაბლოკილია)</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation>ცარიელი</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>მტვერი</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>კი</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>არა</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>ნიშნული წითლდება, როცა ტრანსაქციის ზომა 1000 ბაიტზე მეტია.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>ეს ნიშნავს, რომ კილობაიტზე საკომისიო იქნება მინიმუმ %1</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>შეიძლება იყოს +/- 1 ბაიტი ყოველ შესავალზე.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>მეტი პრიორიტეტის ტრანსაქციებს მეტი შანსი აქვს მოხვდეს ბლოკში.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>ნიშნული წითლდება, როცა პრიორიტეტი &quot;საშუალო&quot;-ზე დაბალია.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>ნიშნული წითლდება, როცა რომელიმე რეციპიენტი მიიღებს %1-ზე ნაკლებს.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>ეს ნიშნავს, რომ საკომისიო იქნება მინიმუმ %1.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>რეტრანსლაციის მინიმალური საკომისიოს 0.546-ზე ნაკლები თანხები ნაჩვენები იქნება როგორც მტვერი.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>ნიშნული წითლდება, როცა ხურდა ნაკლებია %1-ზე.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(არ არის ნიშნული)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation>ხურდა %1-დან (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(ხურდა)</translation>
     </message>
@@ -1015,67 +805,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>მისამართის შეცვლა</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>ნიშნუ&amp;ლი</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>მისამართების სიის ამ ჩანაწერთან ასოცირებული ნიშნული</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>მისამართების სიის ამ ჩანაწერთან მისამართი ასოცირებული. მისი შეცვლა შეიძლება მხოლოდ გაგზავნის მისამართის შემთხვევაში.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>მის&amp;ამართი</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>ახალი მიღების მისამართი</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>ახალი გაგზავნის მისამართი</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>მიღების მისამართის შეცვლა</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>გაგზავნის მისამართის შეცვლა</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>მისამართი &quot;%1&quot; უკვე არის მისამართების წიგნში.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>შეყვანილი მისამართი &quot;%1&quot; არ არის ვალიდური Bitcoin-მისამართი.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>საფულის განბლოკვა ვერ მოხერხდა.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>ახალი გასაღების გენერირება ვერ მოხერხდა</translation>
     </message>
@@ -1083,27 +860,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation>შეიქმნება ახალი მონაცემთა კატალოგი.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>სახელი</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>კატალოგი უკვე არსებობს. დაამატეთ %1 თუ გინდათ ახალი კატალოგის აქვე შექმნა.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>მისამართი უკვე არსებობს და არ წარმოადგენს კატალოგს.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>კატალოგის აქ შექმნა შეუძლებელია.</translation>
     </message>
@@ -1111,57 +883,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - საკომანდო სტრიქონის ოპციები</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>ვერსია</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>გამოყენება:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>კომანდების ზოლის ოპციები</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>ინტერფეისის პარამეტრები</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>აირჩიეთ ენა, მაგალითად &quot;de_DE&quot; (ნაგულისხმევია სისტემური ლოკალი)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>გაშვება მინიმიზებული ეკრანით</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>მისალმების ეკრანის ჩვენება გაშვებისას (ნაგულისხმევი:1)</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>მონაცემთა კატალოგის მითითება ყოველი გაშვებისას (ნაგულისხმევი: 0)</translation>
     </message>
@@ -1169,57 +930,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>მოგესალმებით</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>მოგესალმებათ Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>ეს პროგრამის პირველი გაშვებაა; შეგიძლიათ მიუთითოთ, სად შეინახოს მონაცემები Bitcoin Core-მ.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core გადმოტვირთავს და შეინახავს Bitcoin-ის ბლოკთა ჯაჭვს. მითითებულ კატალოგში დაგროვდება სულ ცოტა 1 გბ მონაცემები, და მომავალში უფრო გაიზრდება. საფულეც ამავე კატალოგში შეინახება.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>ნაგულისხმევი კატალოგის გამოყენება</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>მითითებული კატალოგის გამოყენება:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>შეცდომა: მითითებული მონაცემთა კატალოგი &quot;%1&quot; ვერ შეიქმნა.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>შეცდომა</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>გიგაბაიტია თავისუფალი</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(საჭიროა  %1GB)</translation>
     </message>
@@ -1227,27 +977,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>URI-ის გახსნა</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>გადახდის მოთხოვნის შექმნა URI-იდან ან ფაილიდან</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>გადახდის მოთხოვნის ფაილის არჩევა</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>გადახდის მოთხოვნის ფაილის არჩევა გასახსნელად</translation>
     </message>
@@ -1255,258 +1000,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>ოპციები</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;მთავარი</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>დამატებითი საკომისიო თითო კილობაიტზე; აჩქარებს ტრანსაქციის შესრულებას. ტრანსაქციების უმეტესობა არის 1 კბ.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>ტრანსაქციის სა&amp;ფასურის გადახდა</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>სისტემაში შესვლის შემდეგ Bitcoin-ის ავტომატური გაშვება.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;სისტემაში შესვლისას გაშვება</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>მონაცემთა ბაზის კეშის სი&amp;დიდე</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>სკრიპტის &amp;ვერიფიცირების ნაკადების რაოდენობა</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Bitcoin-ქსელზე მიერთება SOCKS-პროქსით.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>SO&amp;CKS (ნაგულისხმევი) პროქსი მიერთებისათვის:</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>პროქსის IP-მისამართი (მაგ.: IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation>საკომანდო სტრიქონის აქტიური ოპციები, რომლებიც გადაფარავენ ზემოთნაჩვენებს:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>კლიენტის ყველა პარამეტრის დაბრუნება ნაგულისხმევ მნიშვნელობებზე.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>დაბ&amp;რუნების ოპციები</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;ქსელი</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation>ს&amp;აფულე</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>დაუდასტურებელი ხურდის გამოყენების აკრძალვის შემდეგ მათი გამოყენება შეუძლებელი იქნება, სანამ ტრანსაქციას არ ექნება ერთი დასტური მაინც. ეს აისახება თქვენი ნაშთის დათვლაზეც.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>როუტერში Bitcoin-კლიენტის პორტის ავტომატური გახსნა. მუშაობს, თუ თქვენს როუტერს ჩართული აქვს UPnP.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>პორტის გადამისამართება &amp;UPnP-ით</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>პროქსის &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;პორტი</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>პროქსის პორტი (მაგ.: 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;ვერსია:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>პროქსის SOCKS-ვერსია (მაგ.: 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;ფანჯარა</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>ფანჯრის მინიმიზებისას მხოლოდ იკონა სისტემურ ზონაში</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;მინიმიზება სისტემურ ზონაში პროგრამების პანელის ნაცვლად</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>პროგრამის მინიმიზება ფანჯრის დახურვისას. ოპციის ჩართვის შემდეგ პროგრამის დახურვა შესაძლებელი იქნება მხოლოდ მენიუდან - პუნქტი &quot;გასვლა&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>მ&amp;ინიმიზება დახურვისას</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;ჩვენება</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>სამომხმარებ&amp;ლო ენა:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>აქ შეგიძლიათ აირჩიოთ სამომხმარებლო ენა. ძალაში შევა Bitcoin-ის რესტარტის შემდეგ.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>ერთეუ&amp;ლი:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>აირჩიეთ გასაგზავნი თანხის ნაგულისხმევი ერთეული.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>ტრანსაქციების სიაში იყოს თუ არა ნაჩვენები Bitcoin-მისამართები.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>მისამართების &amp;ჩვენება სიაში</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>ვაჩვენოთ თუ არა მონეტების მართვის პარამეტრები.</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;გაუქმება</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>ნაგულისხმევი</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>ცარიელი</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation>დაადასტურეთ პარამეტრების დაბრუნება ნაგულისხმევზე</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>ცვლილებები ძალაში შევა კლიენტის ხელახალი გაშვების შემდეგ.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>კლიენტი დაიხურება, გავაგრძელოთ?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>ამ ცვლილებების ძალაში შესასვლელად საჭიროა კლიენტის დახურვა და ხელახალი გაშვება.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>პროქსის მისამართი არასწორია.</translation>
     </message>
@@ -1514,69 +1207,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>ფორმა</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>ნაჩვენები ინფორმაცია შეიძლება მოძველებული იყოს. თქვენი საფულე ავტომატურად სინქრონიზდება Bitcoin-ის ქსელთან კავშირის დამყარების შემდეგ, ეს პროცესი ჯერ არ არის დასრულებული.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>საფულე</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>ხელმისაწვდომია:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>თქვენი ხელმისაწვდომი ნაშთი</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>იგზავნება:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>დასადასტურებელი ტრანსაქციების საერთო რაოდენობა, რომლებიც ჯერ არ არის ასახული ბალანსში</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>მოუმზადებელია:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>მოპოვებული თანხა, რომელიც ჯერ არ არის მზადყოფნაში</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>სულ:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>თქვენი სრული მიმდინარე ბალანსი</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;ბოლო ტრანსაქციები&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>არ არის სინქრონიზებული</translation>
     </message>
@@ -1584,93 +1262,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI-ების დამუშავება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI-ის დამუშავება ვერ მოხერხდა. შესაძლოა არასწორია Bitcoin-მისამართი ან  URI-ის პარამეტრები.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>მოთხოვნილი გადახდის %1 მოცულობა ძალიან მცირეა (ითვლება &quot;მტვრად&quot;)</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>გადახდის მოთხოვნის შეცდომა</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>ვერ გაიშვა bitcoin: click-to-pay</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>გაფრთხილება ქსელის მენეჯერისაგან</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>თქვენს აქტიურ პროქსის არა აქვს SOCKS5-ის მხარდაჭერა, რაც საჭიროა გადახდების პროქსით განხორციელებისათვის.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>არასწორია გადახდის მოთხოვნის URL: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>გადახდის მოთხოვნის ფაილის დამუშავება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>ვერ ხერხდება გადახდის მოთხოვნის ფაილის წაკითხვა ან დამუშავება! შესაძლოა დაზიანებულია გადახდის მოთხოვნის ფაილი.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>არავერიფიცირებული გადახდის მოთხოვნები გადახდის სამომხმარებლო სკრიპტებისათვის არ არის მხარდაჭერილი.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>დაბრუნება %1-საგან</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>ვერ გამოდის კავშირზე %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>ვერ ხერხდება გადახდის მოთხოვნის გარჩევა ან დამუშავება!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>ცუდი პასუხი სერვერისაგან %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>გადახდა მიღებულია</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>ქსელური მოთხოვნის შეცდომა</translation>
     </message>
@@ -1678,29 +1333,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>შეცდომა: მითითებული მონაცემთა კატალოგი &quot;%1&quot; არ არსებობს.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>შეცდომა: -regtest-ისა და -testnet-ის დაუშვებელი კომბინაცია.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>შეიყვანეთ ბიტკოინ-მისამართი (მაგ. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1708,22 +1356,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>გამო&amp;სახულების შენახვა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>გამოსახულების &amp;კოპირება</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>QR-კოდის შენახვა</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG სურათი (*.png)</translation>
     </message>
@@ -1731,194 +1375,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>კლიენტი</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>მიუწვდ.</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>კლიენტის ვერსია</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;ინფორმაცია</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>დახვეწის ფანჯარა</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>საერთო</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>OpenSSL-ის ვერსია</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>სტარტის დრო</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>ქსელი</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>სახელი</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>შეერთებების რაოდენობა</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>ბლოკთა ჯაჭვი</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>ბლოკების მიმდინარე რაოდენობა</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>ბლოკების სავარაუდო რაოდენობა</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>ბოლო ბლოკის დრო</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;შექმნა</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;კონსოლი</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;ქსელის ტრაფიკი</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;წაშლა</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>ჯამი</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>შემომავალი:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>გამავალი:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>შექმნის დრო</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>დახვეწის ლოგ-ფაილი</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>გახსენით Bitcoin-ის დახვეწის ლოგ-ფაილი მიმდინარე კატალოგიდან. დიდი ლოგ-ფაილის შემთხვევაში ამას შეიძლება რამდენიმე წამი მოუნდეს.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>კონსოლის გასუფთავება</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>მოგესალმებათ Bitcoin-ის RPC კონსოლი.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>კლავიშები &quot;ზევით&quot; და &quot;ქვევით&quot; - ისტორიაში მოძრაობა, &lt;b&gt;Ctrl-L&lt;/b&gt; - ეკრანის გასუფთავება.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>აკრიფეთ &lt;b&gt;help&lt;/b&gt; ფაშვებული ბრძანებების სანახავად.</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 წთ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 სთ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 სთ %2 წთ</translation>
     </message>
@@ -1926,105 +1522,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>თ&amp;ანხა:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>ნიშნუ&amp;ლი:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;მესიჯი:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>რომელიმე ადრე გამოყენებული მიღების მისამართის გამოყენება. ეს ამცირებს უსაფრთხოებასა და პრივატულობას. ნუ გამოიყენებთ ამ ოპციას, თუ არ ახდენთ ადრე მოთხოვნილი გადახდის ხელახლა გენერირებას.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>ად&amp;რე გამოყენებული მიღების მისამართის გამოყენება (არ არის რეკომენდებული)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>არააუცილებელი მესიჯი, რომელიც ერთვის გადახდის მოთხოვნას და ნაჩვენები იქნება მოთხოვნის გახსნისას. შენიშვნა: მესიჯი არ გაყვება გადახდას ბითქოინის ქსელში.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>არააუცილებელი ნიშნული ახალ მიღების მისამართთან ასოცირებისათვის.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>გამოიყენეთ ეს ფორმა გადახდის მოთხოვნისათვის. ყველა ველი &lt;b&gt;არააუცილებელია&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>მოთხოვნის მოცულობა. არააუცილებელია. ჩაწერეთ 0 ან დატოვეთ ცარიელი, თუ არ მოითხოვება კონკრეტული მოცულობა.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>ფორმის ყველა ველის წაშლა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>წაშლა</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>მოთხოვნილი გადახდების ისტორია</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;გადახდის მოთხოვნა</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>არჩეული მოთხოვნის ჩვენება (იგივეა, რაც ჩანაწერზე ორჯერ ჩხვლეტა)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>ჩვენება</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation>მონიშნული ჩანაწერების წაშლა სიიდან</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>წაშლა</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>ნიშნულის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>მესიჯის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>თანხის კოპირება</translation>
     </message>
@@ -2032,67 +1605,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR-კოდი</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>&amp;URI-ის კოპირება</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>მის&amp;ამართის კოპირება</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>გამო&amp;სახულების შენახვა...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>%1-ის გადაზდის მოთხოვნა</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>ინფორმაცია გადახდის შესახებ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>მისამართი</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>რაოდენობა</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>ნიშნული</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>მესიჯი</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI ძალიან გრძელი გამოდის, შეამოკლეთ ნიშნულის/მესიჯის ტექსტი.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>შედომა URI-ის QR-კოდში გადაყვანისას.</translation>
     </message>
@@ -2100,37 +1660,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>თარიღი</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>ნიშნული</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>მესიჯი</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>რაოდენობა</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(არ არის ნიშნული)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(მესიჯები არ არის)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(თანხა არ არის)</translation>
     </message>
@@ -2138,247 +1691,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>მონეტების გაგზავნა</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>მონეტების კონტროლის პარამეტრები</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>ხარჯები...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>არჩეულია ავტომატურად</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>არ არის საკმარისი თანხა!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>რაოდენობა:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>ბაიტები:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>თანხა:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>პრიორიტეტი:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>საკომისიო:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>ქვედა ზღვარი:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>დამატებითი საკომისიო:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>ხურდა:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>ამის გააქტიურებისას თუ ხურდის მისამართი ცარიელია ან არასწორია, ხურდა გაიგზავნება ახლად გენერირებულ მისამართებზე.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>ხურდის მისამართი</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>გაგზავნა რამდენიმე რეციპიენტთან ერთდროულად</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;რეციპიენტის დამატება</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>ფორმის ყველა ველის წაშლა</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>გ&amp;ასუფთავება</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>ბალანსი:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>გაგზავნის დადასტურება</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>გაგ&amp;ზავნა</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>მონეტების გაგზავნის დადასტურება</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1-დან %2-ში</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>რაოდენობის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>თანხის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>საკომისიოს კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>დამატებითი საკომისიოს კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>ბაიტების კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>პრიორიტეტის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>ქვედა ზღვრის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>ხურდის კოპირება</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>ჯამური თანხა %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>ან</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>მიმღების მისამართი არასწორია, შეამოწმეთ.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>გადახდის მოცულობა 0-ზე მეტი უნდა იყოს</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>თანხა აღემატება თქვენს ბალანსს</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>საკომისიო 1%-ის დამატების შემდეგ თანხა აჭარბებს თქვენს ბალანსს</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>მისამართები დუბლირებულია, დაშვებულია ერთ ჯერზე თითო მისამართზე ერთხელ გაგზავნა.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>შეცდომა ტრანსაქციის შექმნისას!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>ტრანსაქცია უარყოფილია! შესაძლოა მონეტების ნაწილი თქვენი საფულიდან უკვე გამოყენებულია, რაც შეიძლება მოხდეს wallet.dat-ის ასლის გამოყენებისას, როცა მონეტები გაიგზავნა სხვა ასლიდან, აქ კი არ არის გაგზავნილად მონიშნული.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>ყურადღება: არასწორია Bitcoin-მისამართი</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(არ არის ნიშნული)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>ყურადღება: უცნობია ხურდის მისამართი</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>დარწმუნებული ხართ, რომ გინდათ გაგზავნა?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>დამატებულია საკომისიო</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>გადახდის მოთხოვნას ვადა გაუვიდა</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>გადახდის მისამართი არასწორია: %1</translation>
     </message>
@@ -2386,98 +1886,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;რაოდენობა</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>ადრესა&amp;ტი:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>მისამართი, რომლითაც ასრულებთ გადახდას (მაგ.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>შეიყვანეთ ამ მისამართის ნიშნული მისამართების წიგნში დასამატებლად</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>ნიშნუ&amp;ლი:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>აირჩიეთ ადრე გამოყენებული მისამართი</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>ეს არის ჩვეულებრივი გადახდა.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>მისამართის ჩასმა კლიპბორდიდან</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>ჩანაწერის წაშლა</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>მესიჯი:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>ეს არის ვერიფიცირებული გადახდის მოთხოვნა.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>შეიყვანეთ ამ მისამართის ნიშნული გამოყენებული მისამართების სიაში დასამატებლად</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>მესიჯი, რომელიც თან ერთვის მონეტებს:  URI, რომელიც შეინახება ტრანსაქციასთან ერთად თქვენთვის. შენიშვნა: მესიჯი არ გაყვება გადახდას ბითქოინის ქსელში.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>ეს არის არავერიფიცირებული გადახდის მოთხოვნა.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>ადრესატი:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>შენიშვნა:</translation>
     </message>
@@ -2485,12 +1961,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Core იხურება...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>არ გამორთოთ კომპიუტერი ამ ფანჯრის გაქრობამდე.</translation>
     </message>
@@ -2498,186 +1972,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>ხელმოწერები - მესიჯის ხელმოწერა/ვერიფიკაცია</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>მე&amp;სიჯის ხელმოწერა</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>ხელმოწერით თქვენ ადასტურებთ, რომ მესიჯი თქვენია. ფრთხილად - არ მოაწეროთ ხელი რაიმე საეჭვოს: ფიშინგური ხრიკებით შეიძლება ის თქვენს მესიჯად გაასაღონ. მოაწერეთ ხელი მხოლოდ იმას, რასაც ყველა წვრილმანში ეთანხმებით.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>მისამართი, რომლითაც ხელს აწერთ (მაგ.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>აირჩიეთ ადრე გამოყენებული მისამართი</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>მისამართის ჩასმა კლიპბორდიდან</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>აკრიფეთ ხელმოსაწერი მესიჯი</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>ხელმოწერა</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>მიმდინარე ხელმოწერის კოპირება კლიპბორდში</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>მოაწერეთ ხელი იმის დასადასტურებლად, რომ ეს მისამართი თქვენია</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>&amp;მესიჯის ხელმოწერა</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>ხელმოწერის ყველა ველის წაშლა</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>გ&amp;ასუფთავება</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>მესიჯის &amp;ვერიფიკაცია</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>შეიყვანეთ ხელმოწერის მისამართი, მესიჯი (დაუკვირდით, რომ ზუსტად იყოს კოპირებული სტრიქონის გადატანები, ჰარები, ტაბულაციები და სხვ) და ხელმოწერა მესიჯის ვერიფიკაციისათვის. მიაქციეთ ყურადღება, რომ რაიმე ზედმეტი არ გაგყვეთ კოპირებისას, რათა არ გახდეთ &quot;man-in-the-middle&quot; შეტევის ობიექტი.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>მისამართი, რომლითაც ხელმოწერილია მესიჯი (მაგ.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>შეამოწმეთ, რომ მესიჯი ხელმოწერილია მითითებული Bitcoin-მისამართით</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>&amp;მესიჯის ვერიფიკაცია</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>ვერიფიკაციის ყველა ველის წაშლა</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>შეიყვანეთ ბიტკოინ-მისამართი (მაგ. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>ხელმოწერის გენერირებისათვის დააჭირეთ &quot;მესიჯის ხელმოწერა&quot;-ს</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>შეყვანილი მისამართი არასწორია.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>შეამოწმეთ მისამართი და სცადეთ ხელახლა.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>შეყვანილი მისამართი არ არის კავშირში გასაღებთან.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>საფულის განბლოკვა შეწყვეტილია.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>ამ მისამართისათვის პირადი გასაღები მიუწვდომელია.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>ვერ მოხერხდა მესიჯის ხელმოწერა.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>მესიჯი ხელმოწერილია.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>ხელმოწერის დეკოდირება ვერ ხერხდება.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>შეამოწმეთ ხელმოწერა და სცადეთ ხელახლა.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>ხელმოწერა არ შეესაბამება მესიჯის დაიჯესტს.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>მესიჯის ვერიფიკაცია ვერ მოხერხდა.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>მესიჯი ვერიფიცირებულია.</translation>
     </message>
@@ -2685,17 +2115,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Core-ს ავტორები</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2703,7 +2130,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2711,184 +2137,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>ღია იქნება სანამ %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>კონფლიქტშია</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/გათიშულია</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/დაუდასტურებელია</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 დადასტურებულია</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>სტატუსი</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, დაგზავნილია %n კვანძისათვის</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>თარიღი</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>წყარო</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>გენერირებულია</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>გამგზავნი</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>მიმღები</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>საკუთარი მისამართი</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>ნიშნული</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>კრედიტი</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>მზად იქნება %n ბლოკის შემდეგ</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>უარყოფილია</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>დებიტი</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>ტრანსაქციის საფასური - საკომისიო</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>სუფთა თანხა</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>მესიჯი</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>შენიშვნა</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ტრანსაქციის ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>გამყიდველი</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>გენერირებული მონეტები გასაგზავნად მომწიფდება %1 ბლოკის შემდეგ. ეს ბლოკი გენერირების შემდეგ გავრცელებულ იქნა ქსელში ბლოკთა ჯაჭვზე დასამატებლად. თუ ის ვერ ჩაჯდა ჯაჭვში, მიეცემა სტატუსი &quot;უარყოფილია&quot; და ამ მონეტებს ვერ გამოიყენებთ. ასეთი რამ შეიძლება მოხდეს, თუ რომელიმე კვანძმა რამდენიმე წამით დაგასწროთ ბლოკის გენერირება.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>დახვეწის ინფორმაცია</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>ტრანსაქცია</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>ხარჯები</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>თანხა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>ჭეშმარიტი</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>მცდარი</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, დაგზავნა არ არის წარმატებით დასრულებული</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>ღიაა კიდევ %n ბლოკისათვის</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>უცნობია</translation>
     </message>
@@ -2896,12 +2276,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>ტრანსაქციის დეტალები</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>ტრანსაქციის დაწვრილებითი აღწერილობა</translation>
     </message>
@@ -2909,127 +2287,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>თარიღი</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>ტიპი</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>მისამართი</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>რაოდენობა</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>არ არის მომწიფებული (%1 დასტური, საჭიროა სულ %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>ღიაა კიდევ %n ბლოკისათვის</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>ღია იქნება სანამ %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>დადასტურებულია (%1დასტური)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>ეს ბლოკი არ არის მიღებული არცერთი კვანძის მიერ და სავარაუდოდ უარყოფილია!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>გენერირებულია, მაგრამ უარყოფილია</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>ოფლაინშია</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>დაუდასტურებელია</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>დადასტურებულია (%1,  რეკომენდებულია %2)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>კონფლიქტშია</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>მიღებულია</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>გამომგზავნი</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>გაგზავნილია ადრესატთან</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>გადახდილია საკუთარი თავისათვის</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>მოპოვებულია</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(მიუწვდ.)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>ტრანსაქციის სტატუსი. ველზე კურსორის შეყვანისას გამოჩნდება დასტურების რაოდენობა.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>ტრანსაქციის მიღების თარიღი და დრო.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>ტრანსაქციის ტიპი.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>ტრანსაქიის დანიშნულების მისამართი.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>ბალანსიდან მოხსნილი ან დამატებული თანხა.</translation>
     </message>
@@ -3037,178 +2390,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>ყველა</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>დღეს</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>ამ კვირის</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>ამ თვის</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>ბოლო თვის</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>ამ წლის</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>შუალედი...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>შემოსულია</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>გაგზავნილია</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>საკუთარი თავისათვის</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>მოპოვებულია</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>სხვა</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>შეიყვანეთ საძებნი მისამართი ან ნიშნული</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>მინ. თანხა</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>მისამართის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>ნიშნულის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>თანხის კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>ტრანსაქციის ID-ს კოპირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>ნიშნულის რედაქტირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>ტრანსაქციის დეტალების ჩვენება</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>ტრანსაქციების ისტორიის ექსპორტი</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>ექსპორტი ვერ განხორციელდა</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>შეცდომა %1-ში ტრანსაქციების შენახვის მცდელობისას.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>ეხპორტი განხორციელებულია</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>ტრანსაქციების ისტორია შენახულია %1-ში.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>CSV-ფაილი (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>დადასტურებულია</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>თარიღი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>ტიპი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>ნიშნული</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>მისამართი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>თანხა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>შუალედი:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>-</translation>
     </message>
@@ -3216,7 +2533,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>არ არის ჩატვირთული საფულე.</translation>
     </message>
@@ -3224,7 +2540,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>მონეტების გაგზავნა</translation>
     </message>
@@ -3232,42 +2547,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation>&amp;ექსპორტი</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>ამ ბარათიდან მონაცემების ექსპორტი ფაილში</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation>საფულის არქივირება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>საფულის მონაცემები (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>არქივირება ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>შეცდომა %1-ში საფულის მონაცემების შენახვის მცდელობისას.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>საფულის მონაცემები შენახულია %1-ში.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>არქივირება შესრულებულია</translation>
     </message>
@@ -3275,107 +2582,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>გამოყენება:</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>ბრძანებები</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>ბრძანების აღწერილობა</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>ოპციები:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>მიუთითეთ საკონფიგურაციო ფაილი (ნაგულისხმევია: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>მიუთითეთ pid ფაილი (ნაგულისხმევია: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>მიუთითეთ მონაცემთა კატალოგი</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>მიყურადება პორტზე &lt;port&gt; (ნაგულისხმევი: 8333 ან სატესტო ქსელში: 18333)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>არაუმეტეს &lt;n&gt; შეერთებისა პირებზე (ნაგულისხმევი: 125)</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>მიერთება კვანძთან, პირების მისამართების მიღება და გათიშვა</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation>მიუთითეთ თქვენი საჯარო მისამართი</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>არასწორად მოქმედი პირების გათიშვის ზღვარი (ნაგულისხმევი:100)</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>არასწორად მოქმედი პირების ბლოკირების დრო წამებში (ნაგულისხმევი: 86400)</translation>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>შეცდომა %u RPC-პორტის მიყურადების ჩართვისას IPv4 მისამართზე: %s</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation> JSON-RPC-შეერთებების მიყურადება პორტზე &lt;port&gt; (ნაგულისხმევი: 8332 ან სატესტო ქსელში: 18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>საკომანდო სტრიქონისა და JSON-RPC-კომამდების ნებართვა</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>რეზიდენტულად გაშვება და კომანდების მიღება</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>სატესტო ქსელის გამოყენება</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>გარედან შეერთებების დაშვება (ნაგულისხმევი: 1 თუ არ გამოიყენება -proxy ან -connect)</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3400,852 +2686,682 @@ rpcpassword=%s
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>დაშვებული ალგორითმები (ნაგულისხმევი: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>შეცდომა %u RPC-პორტის მიყურადების ჩართვისას IPv6 მისამართზე, ვბრუნდებით IPv4-ზე : %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>მოცემულ მისამართზე მიჯაჭვა მუდმივად მასზე მიყურადებით. გამოიყენეთ [host]:port ფორმა IPv6-სათვის</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>შესვლა რეგრესული ტესტირების რეჟიმში; სპეციალური ჯაჭვის გამოყენებით ბლოკების პოვნა ხდება დაუყოვნებლივ. გამოიყენება რეგრესული ტესტირების ინსტრუმენტებისა და პროგრამების შემუშავებისას.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>გადასვლა რეგრესული ტესტირების რეჟიმში, რომელიც იყენებს სპეციალურ ჯაჭვს ბლოკების დაუყოვნებლივი პოვნის შესაძლებლობით.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>შეცდომა: ტრანსაქცია უარყოფილია! შესაძლოა მონეტების ნაწილი თქვენი საფულიდან უკვე გამოყენებულია, რაც შეიძლება მოხდეს wallet.dat-ის ასლის გამოყენებისას, როცა მონეტები გაიგზავნა სხვა ასლიდან, აქ კი არ არის გაგზავნილად მონიშნული.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>შეცდომა: ტრანსაქცია მოითხოვს საკომისიოს მინიმუმ %s რაოდენობის, სირთულის ან ბოლოს მიღებული თანხების შესაბამისად!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>კომანდის შესრულება საფულის ტრანსაქციის ცვლილებისას (%s კომანდაში ჩანაცვლდება TxID-ით)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>ეს არის წინასწარი სატესტო ვერსია - გამოიყენეთ საკუთარი რისკით - არ გამოიყენოთ მოპოვებისა ან კომერციული მიზნებისათვის</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>ფარული Tor-სერვისებით პირების წვდომისათვის სხვა SOCKS5 პროქსის გამოყენება (ნაგულისხმევია: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>ყურადღება:  ძალიან მაღალია -paytxfee - საკომისო, რომელსაც თქვენ გადაიხდით ამ ტრანსაქციის გაგზავნის საფასურად.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>ყურადღება: შეამოწმეთ თქვენი კომპიუტერის სისტემური თარიღი და დრო! თუ ისინი არასწორია, Bitcoin ვერ იმუშავებს კორექტულად.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>ყურადღება: ქსელში შეუთანხმებლობაა. შესაძლოა ცალკეულ მომპოვებლებს პრობლემები ექმნებათ!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>ყურადღება: ჩვენ არ ვეთანხმებით ყველა პირს. შესაძლოა თქვენ ან სხვა კვანძებს განახლება გჭირდებათ.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>ყურადღება: არ იკითხება wallet.dat! ყველა გასაღები წაკითხულია, მაგრამ გამორჩენილი ან არასწორია ტრანსაქციის თარიღი ან ჩანაწერები მისამართების წიგნში.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>ყურადღება: wallet.dat დაზიანებულია! ორიგინალური wallet.dat შენახულია როგორც wallet.{timestamp}.bak %s-ში; თუ შეამჩნიეთ უზუსტობა ნაშთში ან ტრანსაქციებში, აღადგინეთ არქივიდან.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; შეიძლება იყოს:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>პირადი გასაღებების აღდგენის მცდელობა wallet.dat-იდან</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Bitcoin Core დემონი</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation>ბლოკის შექმნის ოპციები:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>საფულის ტრანსაქციების სიის წაშლა (დიაგნოსტიკის საშუალება; მოიცავს -rescan-ს)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>შეერთება მხოლოდ მითითებულ კვანძ(ებ)თან</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>შეერთება SOCKS-პროქსით</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation> JSON-RPC-შეერთება პორტზე &lt;port&gt; (ნაგულისხმევი: 8332 ან სატესტო ქსელში: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation>შენიშნულია ბლოკთა ბაზის დაზიანება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>საკუთარი IP-მისამართის განსაზღვრა (ნაგულისხმევი: 1 თუ ჩართულია მიყურადება და არ გამოიყენება -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>არ ჩაიტვირთოს საფულე და აიკრძალოს საფულისადმი RPC-მიმართვები</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>გავუშვათ ბლოკთა ბაზის ხელახლა აგება ეხლა?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>ვერ ინიციალიზდება ბლოკების ბაზა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>ვერ ინიციალიზდება საფულის ბაზის გარემო %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>არ იტვირთება ბლოკების ბაზა</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>ბლოკთა ბაზის შექმნა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>შეცდომა: დისზე არ არის ადგილი!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>შეცდომა: საფულე დაბლოკილია, ტრანსაქცია ვერ შეიქმნება!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>შეცდომა: სისტემური შეცდომა:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>ვერ ხერხდება პორტების მიყურადება. თუ გსურთ, გამოიყენეთ -listen=0.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>ბლოკის ინფორმაცია არ იკითხება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>ბლოკი არ იკითხება</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>ბლოკების ინდექსის სინქრონიზება ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>ბლოკების ინდექსის ჩაწერა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>ბლოკის ინფორმაციის ჩაწერა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>ბლოკის ჩაწერა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>ფაილის ინფორმაციის ჩაწერა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>მონეტების ბაზის ჩაწერა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>ტრანსაქციების ინდექსის ჩაწერა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>ცვლილებების გაუქმების მონაცემთა ჩაწერა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>საკომისო კბ-ზე, რომელიც დაემატება გაგზავნილ ტრანსაქციას</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>პირების ძებნა DNS-ით (ნაგულისხმევი: 1 გარდა -connect-ისა)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation>მონეტების გენერირება (ნაგულისხმევი: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>რამდენი ბლოკი შემოწმდეს გაშვებისას (ნაგულისხმევი: 288, 0 - ყველა)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>თუ &lt;category&gt; არ არის მითითებული, ნაჩვენები იქნება სრული დახვეწის ინფორმაცია.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>საწყისი ბლოკი არ არსებობს ან არასწორია. ქსელის მონაცემთა კატალოგი datadir ხომ არის არასწორი?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>არასწორია მისამართი -onion: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation>არ არის საკმარისი ფაილ-დესკრიპტორები.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>დაემატოს დახვეწის ინფორმაციას დროის ჭდეები (ნაგულისხმევი: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation>RPC კლიენტის ოპციები:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>ბლოკთა ჯაჭვის ინდექსის  ხელახლა აგება blk000??.dat ფაილიდან</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation> SOCKS-ვერსიის არჩევა -proxy-სათვის (4 ან 5, ნაგულისხმევი: 5)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>ბლოკის მაქსიმალური ზომის განსაზღვრა ბაიტებში (ნადულისხმევი: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>RPC-ნაკადების რაოდენობა (ნაგულისხმევი: 4)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>მიუთითეთ საფულის ფაილი (კატალოგში)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>დაუდასტურებელი ხურდის გამოყენება ტრანსაქციის გაგზავნისას (ნაგულისხმევი: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>გამოიყენება რეგრესული ტესტირების ინსტრუმენტებისა და პროგრამების შემუშავებისას.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>გამოყენება (მოძველებულია, გამოიყენეთ bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>ბლოკების ვერიფიკაცია...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>საფულის ვერიფიკაცია...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>RPC-სერვერის დალოდება გაშვებისათვის</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>საფულე %s მდებარეობს მონაცემთა კატალოგის %s გარეთ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>სფულის ოპციები:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>ყურადღება: მოძველებული არგუმენტი -debugnet იგნორირდება. გამოიყენეთ -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>საჭიროა ბაზის ხელახალი აგება, გამოიყენეთ -reindex რათა შეცვალოთ -txindex</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>ბლოკების იმპორტი გარე blk000??.dat ფაილიდან</translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>ბრძანების შესრულება შესაბამისი უწყების მიღებისას ან როცა შეინიშნება საგრძნობი გახლეჩა (cmd-ში %s შეიცვლება მესიჯით)</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>დახვეწის ინფორმაციის გამოყვანა (ნაგულისხმევი: 0, &lt;category&gt; - არააუცილებელი არგუმენტია)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>მაღალპრიორიტეტული/დაბალსაკომისიოიანი ტრანსაქციების მაქსიმალური ზომა ბაიტებში (ნაგულისხმევი: %d)</translation>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>ინფორმაცია</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>დაუშვებელი მნიშვნელობა -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>დაუშვებელი მნიშვნელობა -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>ტრანსაქციის სრული ინდექსი (ნაგულისხმევი: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>მიღების ბუფერის მაქსიმალური ზომა შეერთებაზე, &lt;n&gt;*1000 ბაიტი (ნაგულისხმევი: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>გაგზავნის ბუფერის მაქსიმალური ზომა შეერთებაზე, &lt;n&gt;*1000 ბაიტი (ნაგულისხმევი: 5000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>ბლოკთა ჯაჭვი მიიღეთ მხოლოდ მაშინ, თუ ემთხვევა შიდა ჩეკპოინტები (ნაგულისხმევი: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>შეერთება მხოლოდ &lt;net&gt; ქსელის კვანძებთან (IPv4, IPv6 ან Tor)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL ოპციები: (იხილე Bitcoin Wiki-ში  SSL-ს მოწყობის ინსტრუქციები)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>ტრასირების/დახვეწის ინფოს გაგზავნა კონსოლზე debug.log ფაილის ნაცვლად</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>დააყენეთ ბლოკის მინიმალური ზომა ბაიტებში (ნაგულისხმევი: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>debug.log ფაილის შეკუმშვა გაშვებისას (ნაგულისხმევია: 1 როცა არ აყენია -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>ტრანსაქციების ხელმოწერა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>მიუთითეთ შეერთების ტაიმაუტი მილიწამებში (ნაგულისხმევი: 5000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>სისტემური შეცდომა:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>ტრანსაქციების რაოდენობა ძალიან ცოტაა</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>ტრანსაქციების რაოდენობა დადებითი რიცხვი უნდა იყოს</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>ტრანსაქცია ძალიან დიდია</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>გამოიყენეთ UPnP მისაყურადებელი პორტის გადასამისამართებლად (ნაგულისხმევი: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>გამოიყენეთ UPnP მისაყურადებელი პორტის გადასამისამართებლად (ნაგულისხმევი: 1 როცა ჩართულია მიყურადება)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>მომხმარებლის სახელი JSON-RPC-შეერთებისათვის</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>გაფრთხილება</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>ყურადღება: ვერსია მოძველებულია, საჭიროა განახლება!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>ტრანსაქციების ჩახსნა საფულიდან...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>ვერსია</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat დაზიანებულია, აღდგენა ვერ მოხერხდა</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>პაროლი JSON-RPC-შეერთებისათვის</translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>JSON-RPC-შეერთების ნებართვა მითითებული IP მისამართიდან</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>კომანდის გაგზავნა კვანძისათვის, რომელიც გაშვებულია მისამართზე &lt;ip&gt; (ნაგულისხმევი: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>კომანდის შესრულება უკეთესი ბლოკის გამოჩენისას (%s კომანდაში ჩანაცვლდება ბლოკის ჰეშით)</translation>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>საფულის ფორმატის განახლება</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>გასაღების პულის ზომა იქნება &lt;n&gt; (ნაგულისხმევი: 100)</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>ბლოკების ჯაჭვის გადამოწმება საფულეში გამორჩენილ ტრანსაქციებზე</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>OpenSSL-ის (https) გამოყენება JSON-RPC-შეერთებებისათვის</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>სერვერის სერტიფიკატის ფაილი (ნაგულისხმევი: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>სერვერის პირადი გასაღები (ნაგულისხმევი: server.pem)</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>ეს ტექსტი</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>ვერ ხერხდება მიბმა %s-თან ამ კომპიუტერზე (მიღებულია შეცდომა %d, %s)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>DNS-ძებნის დაშვება -addnode, -seednode და -connect-სათვის</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>მისამართების ჩატვირთვა...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>არ იტვირთება wallet.dat: საფულე დაზიანებულია</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>არ იტვირთება wallet.dat: საფულეს სჭირდება Bitcoin-ის ახალი ვერსია</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>საჭიროა საფულის აღდგენა: დაარესტარტეთ Bitcoin </translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>არ იტვირთება wallet.dat</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>არასწორია მისამართი -proxy: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>-onlynet-ში მითითებულია უცნობი ქსელი: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>მოთხოვნილია -socks პროქსის უცნობი ვერსია: %i</translation>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>ვერ ხერხდება -bind მისამართის გარკვევა: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>ვერ ხერხდება -externalip მისამართის გარკვევა: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>დაუშვებელი მნიშვნელობა -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>დაუშვებელი თანხა</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>არ არის საკმარისი თანხა</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>ბლოკების ინდექსის ჩატვირთვა...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>მისაერთებელი კვანძის დამატება და მიერთების შეძლებისდაგვარად შენარჩუნება</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>საფულის ჩატვირთვა...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation>საფულის ძველ ვერსიაზე გადაყვანა შეუძლებელია</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>ვერ ხერხდება ნაგულისხმევი მისამართის ჩაწერა</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>სკანირება...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>ჩატვირთვა დასრულებულია</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>%s ოპციის გამოსაყენებლად</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>შეცდომა</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_kk_KZ.ts
+++ b/src/qt/locale/bitcoin_kk_KZ.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Адресті немесе белгіні өзгерту үшін екі рет шертіңіз</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Жаңа адрес енгізу</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Таңдаған адресті тізімнен жою</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>Жою</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Үтірмен бөлінген текст (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>таңба</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(таңбасыз)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Құпия сөзді енгізу</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Жаңа құпия сөзі</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Жаңа құпия сөзді қайта енгізу</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Әмиянға жаңа қүпия сөзді енгізіңіз.&lt;br/&gt;&lt;b&gt;10 немесе одан әрі кездейсоқ белгілерді&lt;/b&gt;, әлде &lt;b&gt;сегіз немесе одан әрі сөздерді&lt;/b&gt;құпия сөзіңізде пайдалану өтінеміз.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Әмиянді шифрлау</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Бұл операциясы бойынша сіздің әмиянізді қоршаудан шығару үшін әмиянның құпия сөзі керек</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Әмиянізді қоршаудан шығару</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Бұл операциясы бойынша сіздің әмиянізді шифрлап тастау үшін әмиянның құпия сөзі керек</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Әмиянізді шифрлап тастау</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Құпия сөзді өзгерту</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(таңбасыз)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>таңба</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>таңба</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(таңбасыз)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(таңбасыз)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Үтірмен бөлінген файл (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>таңба</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Транзакция өте кішкентай</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Транзакция өте үлкен</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ko_KR.ts
+++ b/src/qt/locale/bitcoin_ko_KR.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>비트코인 코어 소개</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;비트코인 코어&lt;/b&gt; 버젼</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ MIT/X11 프로그램 라이선스에 따라 배포합니다. COPYING 또는 http
 이 프로그램에는 OpenSSL 툴킷(http://www.openssl.org) 사용 목적으로 개발한 OpenSSL 프로젝트를 포함하고 있으며, 암호화 프로그램은 Eric Young(eay@cryptsoft.com)이, UPnP 프로그램은 Thomas Bernard가 작성했습니다.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>비트코인코어 개발자들</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
-        <translation>(%1-비트)</translation>
+        <source>(%1-bit)</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>주소 또는 표를 편집하기 위해 더블클릭 하시오</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>새 주소 만들기</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>현재 선택한 주소를 시스템 클립보드로 복사하기</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>복사</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>계좌 복사(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>현재 목록에 선택한 주소 삭제</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>현재 탭에 있는 데이터를 파일로 내보내기</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;삭제</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>코인을 보내실 주소를 선택하세요</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>코인을 받으실 주소를 선택하세요</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>보내는 주소들</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>받은 주소들</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation type="unfinished"/>
+        <translation>이것이 비트코인 금액을 보내는 주소이다. 항상 코인을 보내기전에 잔고와 받는 주소를 확인하시오</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>표 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>편집&amp;</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>주소 목록 내보내기</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>각각의 파일에 쉼표하기(*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>내보내기 실패</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ MIT/X11 프로그램 라이선스에 따라 배포합니다. COPYING 또는 http
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>표</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>주소</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(표 없음)</translation>
     </message>
@@ -187,140 +153,106 @@ MIT/X11 프로그램 라이선스에 따라 배포합니다. COPYING 또는 http
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>암호문 대화상자</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>암호 입력하기</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>새로운 암호</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>새 암호 반복</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>새로운 암호를 지갑에 입력. 8자보다 많은 단어를 입력하거나 10 자보다 많은 여러 종류를 암호에 사용하세요.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>지갑 암호화</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>이 작업은 지갑을 열기위해 사용자의 지갑의  암호가 필요합니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>지갑 열기</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>이 작업은 지갑을 해독하기 위해 사용자의 지갑 암호가 필요합니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>지갑 해독</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>암호 변경</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>지갑의 예전 암호와 새로운 암호를 입력</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>지갑의 암호화를 확정</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>경고: 만약 당신의 지갑을 암호화 하고 비밀번호를 잃어 버릴 경우, 당신의 모든 비트코인들을 잃어버릴 수 있습니다!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>지갑 암호화를 허용하시겠습니까?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>경고: 캡스록 키가 켜져있습니다!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>지갑 암호화 완료</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>암호화 처리 과정을 끝내기 위해 비트코인을 닫겠습니다. 지갑 암호화는 컴퓨터로의 멀웨어 감염으로 인한 비트코인 도난을 완전히 막아주지 못함을 기억하십시오.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>지갑 암호화 실패</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>지갑 암호화는 내부 에러로 인해 실패했습니다.  당신의 지갑은 암호화 되지 않았습니다.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>지정한 암호가 일치하지 않습니다.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>지갑 열기를 실패하였습니다.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>지갑 해독을 위한 암호가 틀렸습니다.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>지갑 해독에 실패하였습니다.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>지갑 비밀번호가 성공적으로 변경되었습니다</translation>
     </message>
@@ -328,362 +260,286 @@ MIT/X11 프로그램 라이선스에 따라 배포합니다. COPYING 또는 http
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>메시지 서명&amp;...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>네트워크와 동기화중...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;개요</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation>노드</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>지갑의 일반적 개요를 보여 줍니다.</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;거래</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>거래내역을 검색합니다.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>나가기(&amp;X)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>적용 중단</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>비트코인에 대한 정보를 보여줍니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Qt 정보(&amp;Q)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Qt 정보를 표시합니다</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;옵션</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>지갑 암호화&amp;...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>지갑 백업&amp;...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>암호문 변경&amp;...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;주소 보내는 중</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp; 주소 받는 중</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>URI&amp;열기</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>디스크에서 블록 가져오는 중...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>디스크에서 블록 다시 색인중...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>비트코인 주소로 코인 전송</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>비트코인 설정 옵션 수정</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>지갑을 다른장소에 백업</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>지갑 암호화에 사용되는 암호를 변경합니다</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>디버그 창&amp;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>디버깅 및 진단 콘솔을 엽니다</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>메시지 확인&amp;...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>비트코인</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>지갑</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>보내기(&amp;S)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>받기(&amp;R)</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>보이기/숨기기(&amp;S)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>주 창 보이기 또는 숨기기</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>소유 지갑 개인키 암호화</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;파일</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;설정</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;도움말</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>툴바 색인표</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[테스트넷]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>비트코인코어</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>지불 요청하기 (QR코드와 비트코인이 생성됩니다: URIs)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;비트코인 코어 소개</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>비트코인: URI 또는 지불요청 열기</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>명령어-라인 옵션</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>비트코인 고객</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>비트코인 네트워크와 %n 개의 활성연결</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>사용 가능한 블락 소스가 없습니다...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>송금 기록 %1/%2개 블록 (추산) 처리됨.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>%1 블락의 거래 기록들이 처리됨.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>시간</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>일</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>주</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 그리고 %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n 년</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
-        <translation type="unfinished"/>
+        <translation>%1 뒤에</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>최근에 받은 블록은 %1 전에 생성되었습니다.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>이것 후의 거래들은 아직 보이지 않을 것입니다.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>경고</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>정보</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>현재까지</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>따라잡기...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>거래 보내기</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>거래 들어오는 중</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +552,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>지갑이 암호화 되었고 현재 차단해제 되었습니다</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>지갑이 암호화 되었고 현재 잠겨져 있습니다</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>치명적인 오류가 있습니다. 비트코인을 더이상 안전하게 진행할 수 없어 빠져나갑니다.</translation>
     </message>
@@ -714,7 +567,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>네트워크 경고</translation>
     </message>
@@ -722,291 +574,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>코인컨트롤 주소 선택</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>수량:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>거래량</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>우선도:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>수수료:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>수수료 이후:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>트리 모드</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>리스트 모드</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>거래량</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>주소</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>확인</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>확인됨</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>우선도</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>주소 복사하기</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>라벨 복사하기</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>거래액 복사</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>송금 ID 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>수량 복사</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>수수료 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>수수료 이후 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>bytes를 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>우선도 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation>최상</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>상</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>중상</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>중</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>중하</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>하</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 잠금)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>없음</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>예</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>아니요</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
-        <translation type="unfinished"/>
+        <translation>이 의미는 수수료가 최소한 %1 per 키로바이트 필요합니다</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(표 없슴)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>~로부터 변경 %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1014,67 +805,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>주소 편집</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;표</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;주소</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>새로 받는 주소</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>새로 보내는 주소</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>받는 주소 편집</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>보내는 주소 편집</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>입력된 주소는&quot;%1&quot; 이미 주소록에 있습니다.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>입력한 &quot;%1&quot; 주소는 올바른 비트코인 주소가 아닙니다.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>지갑을 열 수 없습니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>새로운 키 생성이 실패하였습니다</translation>
     </message>
@@ -1082,27 +860,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>새로운 데이터 폴더가 생성됩니다.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>경로가 이미 존재합니다. 그리고 그것은 폴더가 아닙니다.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>데이터 폴더를 여기 생성할 수 없습니다.</translation>
     </message>
@@ -1110,52 +883,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>비트코인 코어 - 명령어-라인 옵션</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>비트코인코어</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>사용법:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>명령줄 옵션</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI 옵션</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>&quot;de_DE&quot;와 같이 언어를 설정하십시오 (기본값: 시스템 로캘)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>최소화 상태에서 시작</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>시작시 시작 화면 표시 (기본값: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>파일목록을 선택하여 시작하시오(기본값: 0)</translation>
     </message>
@@ -1163,57 +930,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>환영합니다</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>비트코인 코어에 오신것을 환영합니.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>기본 데이터 폴더를 사용하기</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>커스텀 데이터 폴더 사용:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>비트코인</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB가 사용가능</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(%1GB가 필요)</translation>
     </message>
@@ -1221,27 +977,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>URI 열기</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>지급 요청 URI 또는 파일 열기</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>지불 요청 파일을 선택하세요</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>지불 요청 파일을 열기 위해서 선택하세요</translation>
     </message>
@@ -1249,253 +1000,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>선택들</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>메인(&amp;M)</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>당신의 거래가 더욱 빠르게 처리될 수 있도록 선택적으로 kBd당 거래 수수료를 지정합니다. 참고로 대부분의 거래들은 1kB입니다.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>송금 수수료(&amp;F)</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>시스템 로그인후에 비트코인을 자동으로 시작합니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>시스템 로그인시 비트코인 시작(&amp;S)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>데이터베이스 캐시 크기</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>메가바이트</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
-        <translation type="unfinished"/>
+        <translation>SOCKS 프록시를 통해 비트코인 네트워크 연결</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>SOCKS 프록시를 거쳐 연결합니다 (기본값 프록시):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>프록시 아이피 주소(예. IPv4:127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>모든 클라이언트 옵션을 기본값으로 재설정</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>옵션 재설정(&amp;R)</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>네트워크(&amp;N)</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation>지갑</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>라우터의 비트코인 클라이언트 포트를 자동으로 엽니다. 라우터에서 UPnP를 지원하고 활성화 했을 경우에만 동작합니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>사용중인 UPnP 포트 매핑(&amp;U)</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>프록시 IP(&amp;I):</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>포트(&amp;P):</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>프록시의 포트번호입니다(예: 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS 버전(&amp;V):</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>프록시의 SOCKS 버전입니다(예: 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>창(&amp;W)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>창을 최소화 하면 트레이에 아이콘만 표시합니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>작업 표시줄 대신 트레이로 최소화(&amp;M)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>창을 닫으면 프로그램에서 나가지 않고 최소화합니다. 이 옵션을 활성화하면, 프로그램은 메뉴에서 나가기를 선택한 후에만 닫힙니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>닫을때 최소화(&amp;I)</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>표시(&amp;D)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>사용자 인터페이스 언어(&amp;L):</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>사용자 인터페이스 언어를 여기서 설정할 수 있습니다. 이 설정은 비트코인을 다시 시작할때 적용됩니다.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>거래액을 표시할 단위(&amp;U):</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>인터페이스에 표시하고 코인을 보낼때 사용할 기본 최소화 단위를 선택하십시오.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>송금 목록에 비트코인 주소를 표시할지의 여부입니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>송금 목록에 주소 표시(&amp;D)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>확인(&amp;O)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>취소(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>기본값</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>없음</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>옵션 초기화를 확인</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>클라이언트가 종료됩니다, 계속 진행하시겠습니까?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>지정한 프록시 주소가 잘못되었습니다.</translation>
     </message>
@@ -1503,69 +1207,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>유형</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>표시한 정보가 오래된 것 같습니다. 비트코인 네트워크에 연결하고 난 다음에 지갑을 자동으로 동기화 하지만, 아직 과정이 끝나지는 않았습니다.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>지갑</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>유용한</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>당신의 현재 사용 가능한 잔액</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>미정</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>전체 거래들은 아직 확인되지 않았고, 그리고 현재 잔액에 아직 반영되지 않았습니다.</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>아직 사용 불가능:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>아직 사용 가능하지 않은 채굴된 잔액</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>총액:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>당신의 현재 총액</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;최근 거래내역&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>오래됨</translation>
     </message>
@@ -1573,93 +1262,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
-        <translation type="unfinished"/>
+        <translation>URI 조작중</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>지불 요청 애러</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>비트코인을 시작할 수 없습니다: 지급제어기를 클릭하시오</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>네트워크 관리인 경고</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>%1 으로부터의 환불</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>%1과 소통하는데 애러: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>서버로 부터 반응이 없습니다 %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>지불이 승인됨</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>네트워크 요청 애러</translation>
     </message>
@@ -1667,23 +1333,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>비트코인</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>애러: 지정한 데이터 폴더 &quot;%1&quot;은 존재하지 않습니다.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>비트코인 주소를 입력하기 (예 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1691,22 +1356,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>이미지 저장(&amp;S)...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>이미지 복사(&amp;C)</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>QR코드 저장</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG 이미지(*.png)</translation>
     </message>
@@ -1714,192 +1375,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>클라이언트 이름</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>없음</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>클라이언트 버전</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>정보&amp;</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>디버그 창</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>일반</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>오픈SSL 버전을 사용합니다</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>시작 시간</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>네트워크</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>이름</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>연결 수</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>블럭 체인</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>현재 블럭 수</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>예상 전체 블럭</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>최종 블럭 시각</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>열기(&amp;O)</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>콘솔(&amp;C)</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;네트워크 트래픽</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>총액</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>빌드 날짜</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>로그 파일 디버그</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>비트코인 디버그 로그파일을 현재 데이터 폴더에서 여십시요. 용량이 큰 로그 파일들은 몇 초가 걸릴 수 있습니다.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>콘솔 초기화</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>비트코인 RPC 콘솔에 오신걸 환영합니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>기록을 찾아보려면 위 아래 화살표 키를, 화면을 지우려면 &lt;b&gt;Ctrl-L&lt;/b&gt;키를 사용하십시오.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>사용할 수 있는 명령을 둘러보려면 &lt;b&gt;help&lt;/b&gt;를 입력하십시오.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>% 1 바이트</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>% 1 킬로바이트</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>% 1 메가바이트</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>% 1 기가바이트</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>% 1 분</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>% 1 시간</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>% 1시 %2 분</translation>
     </message>
@@ -1907,105 +1522,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;거래량:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>표:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;메시지:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>양식의 모든 필드를 지웁니다</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>지우기</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>지출기록 확인</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>지불 요청(&amp;R)</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>보기</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation>목록에서 삭제할 항목을 선택하시오</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>삭제</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>표 복사하기</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>메시지 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>거래량 복사</translation>
     </message>
@@ -2013,67 +1605,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>URI 복사(&amp;U)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>주소 복사(&amp;A)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>이미지 저장(&amp;S)...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>%1에 지불을 요청했습니다</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>지불 정보</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>주소</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>거래량</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>표</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>메시지</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI 결과가 너무 길음, 표/메세지의 글을 줄이도록 하세요.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>QR코드 인코딩 오류</translation>
     </message>
@@ -2081,37 +1660,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>표</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>메시지</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>거래량</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(표 없슴)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(메세지가 없습니다)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(거래량 없음)</translation>
     </message>
@@ -2119,247 +1691,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>코인들 보내기</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>코인 컨트롤 기능들</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>자동 선택</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>자금이 부족합니다!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>수량:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>거래량:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>우선도:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>수수료:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>수수료 이후:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>주소변경</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>다수의 수령인들에게 한번에 보내기</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>수령인 추가하기</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>양식의 모든 필드를 지웁니다</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>모두 지우기(&amp;A)</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>잔액:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>전송 기능 확인</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>보내기(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>코인 전송을 확인</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1을(를) %2(으)로</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>수량 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>거래액 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>수수료 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>수수료 이후 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>bytes 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>우선도 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>총 액수 %1(=%2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>또는</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>수령인 주소가 정확하지 않습니다. 재확인 바랍니다</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>지불하는 금액은 0 보다 커야 합니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>잔고를 초과하였습니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>%1 의 거래수수료를 포함하면 잔고를 초과합니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>두개 이상의 주소입니다. 한번에 하나의 주소에만 작업할 수 있습니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>거래를 생성하는 것을 실패하였습니다</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>경고: 잘못된 비트코인주소입니다</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(표 없슴)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>경고: 알려지지 않은 주소변경입니다</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>정말로 보내시겠습니까?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>거래 수수료로 추가됨</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>지불 요청 만료</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>잘못된 지불 주소입니다 %1</translation>
     </message>
@@ -2367,98 +1886,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>금액:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>지급&amp;수신:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>당신의 주소록에 이 주소를 추가하기 위하여 표를 입역하세요 </translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>표:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>이전에 사용한 주소를 선택하십시오</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>평균지급입니다</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>클립보드로 부터 주소를 붙이세요</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>항목을 지우시오</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>메시지:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>지급 확인요청입니다.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>지급요청 미확인입니다</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>메모:</translation>
     </message>
@@ -2466,12 +1961,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>비트코인코어가 닫아지고 있습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>창이 사라지기 전까지 컴퓨터를 끄지마시오.</translation>
     </message>
@@ -2479,186 +1972,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>서명 - 싸인 / 메시지 확인</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>메시지 서명(&amp;S)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>여러분 자신을 증명하기 위해 주소를 첨가하고 섬여할 수 있습니다. 피싱 공격으로 말미암아 여러분의 서명을 통해 속아 넘어가게 할 수 있으므로, 서명하지 않은 어떤 모호한 요소든 주의하십시오. 동의하는 완전 무결한 조항에만 서명하십시오.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>메시지를 서명할 주소 (예: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>이전에 사용한 주소를 선택하십시오</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>클립보드로 부터 주소를 붙이세요</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>여기에 서명하려는 메시지를 입력하십시오</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>서명</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>현재 서명을 시스템 클립보드에 복사</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>여러분의 비트코인 주소를 증명하려면 메시지 서명하십시오</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>메시지에 서명(&amp;M)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>메시지 필드의 모든 서명 재설정</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>모두 지우기(&amp;A)</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>메시지 검증(&amp;V)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>서명한 메시지의 주소입니다 (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>정확한 비트코인주소가 입력됬는지 메시지를 확인하시오</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>메시지 검증(&amp;M)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>모든 검증 메시지 필드 재설정</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>비트코인 주소를 입력하기 (예 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>서명을 만들려면 &quot;메시지 서명&quot;을 누르십시오</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>입력한 주소가 잘못되었습니다.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>주소를 확인하고 다시 시도하십시오.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>입력한 주소는 키에서 참조하지 않습니다.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>지갑 잠금 해제를 취소했습니다.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>입력한 주소에 대한 개인키가 없습니다.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>메시지 서명에 실패했습니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>메시지를 서명했습니다.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>서명을 해독할 수 없습니다.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>서명을 확인하고 다시 시도하십시오.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>메시지 다이제스트와 서명이 일치하지 않습니다.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>메시지 검증에 실패했습니다.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>메시지를 검증했습니다.</translation>
     </message>
@@ -2666,17 +2115,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>비트코인코어</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>비트코인코어 개발자들</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[테스트넷]</translation>
     </message>
@@ -2684,7 +2130,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2692,184 +2137,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>%1 까지 열림</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>충돌</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/오프라인</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/미확인</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 확인됨</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>상태</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>소스</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>생성하다</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>으로부터</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>에게</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>자신의 주소</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>라벨</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>예금</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>허용되지 않는다</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>차변</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>송금 수수료</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>총액</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>메시지</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>설명</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>송금 ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>상인</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>디버깅 정보</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>송금</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>입력</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>거래량</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>참</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>거짓</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>. 아직 성공적으로 통보하지 않음</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>알수없음</translation>
     </message>
@@ -2877,12 +2276,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>거래 세부 내역</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>이 창은 거래의 세부내역을 보여줍니다</translation>
     </message>
@@ -2890,127 +2287,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>형식</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>주소</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>수량</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>%1 까지 열림</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>확인됨(%1 확인됨)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>이 블럭은 다른 노드로부터 받지 않아 허용되지 않을 것임.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>생성되었으나 거절됨</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>오프라인</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>미확인</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>충돌</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>다음과 함께 받음 : </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>보낸 주소</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>다음에게 보냄 :</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>자신에게 지불</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>채굴됨</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(없음)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>거래상황. 마우스를 올리면 승인횟수가 표시됩니다.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>거래가 이루어진 날짜와 시각.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>거래의 종류.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>거래가 도달할 주소</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>변경된 잔고.</translation>
     </message>
@@ -3018,178 +2390,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>전체</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>오늘</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>이번주</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>이번 달</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>지난 달</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>올 해</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>범위...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>보낸 주소</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>받는 주소</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>자기거래</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>채굴</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>기타</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>검색하기 위한 주소 또는 표 입력</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>최소 거래량</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>주소 복사하기</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>표 복사하기</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>거래액 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>송금 ID 복사</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>표 수정하기</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>거래 내역 확인</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation>거래 기록 내보내기</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>내보내기 실패</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>%1으로 거래 기록을 저장하는데 애러가 있었습니다.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>내보내기 성공</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>거래 기록이 성공적으로 %1에 저장되었습니다.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>각각의 파일에 쉼표하기(*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>확인됨</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>날짜</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>종류</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>표</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>주소</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>거래량</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>아이디</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>범위:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>상대방</translation>
     </message>
@@ -3197,7 +2533,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>지갑 불러오기가 안됩니다</translation>
     </message>
@@ -3205,7 +2540,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>코인들 보내기</translation>
     </message>
@@ -3213,42 +2547,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>현재 탭에 있는 데이터를 파일로 내보내기</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>지갑 백업</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>지갑 데이터(*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>백업 실패</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>지갑 정보가 %1에 성공적으로 저장되었습니다</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>백업 성공</translation>
     </message>
@@ -3256,107 +2582,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>사용법:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>커맨드 목록</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>커맨드 도움말</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>옵션:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>설정파일 지정 (기본값: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>pid 파일 지정 (기본값: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>데이터 폴더 지정</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>데이터베이스 캐시 크기를 메가바이트로 지정(기본값:25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>&lt;port&gt;로 연결을 허용한다 (기본값: 8333 또는 테스트넷: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>가장 잘 연결되는 사용자를 유지합니다(기본값: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>피어 주소를 받기 위해 노드에 연결하고, 받은 후에 연결을 끊습니다</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>공인 주소를 지정하십시오</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>이상행동 네트워크 참여자의 연결을 차단시키기 위한 한계치 (기본값: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>이상행동을 하는 네트워크 참여자들을 다시 연결시키는데 걸리는 시간 (기본값: 86400초)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>IPv4 감청을 위한 RPC 포트 %u번을 설정중 오류가 발생했습니다: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>명령줄과 JSON-RPC 명령 수락</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>데몬으로 백그라운드에서 실행하고 명령을 허용</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>테스트 네트워크 사용</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>외부 접속을 승인합니다</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3371,722 +2676,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
-        <translation type="unfinished"/>
+        <translation>암호 허용(기본값: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Tor 서비스를 이용하여 네트워크에 참여하기 위해서 SOCKS5 프록시를 따로 사용함 (기본값: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>경고: -paytxfee값이 너무 큽니다! 이 값은 송금할때 지불할 송금 수수료입니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>경고: 컴퓨터의 날짜와 시간이 올바른지 확인하십시오! 시간이 잘못되면 비트코인은 제대로 동작하지 않습니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>경고: 현재 비트코인 버전이 다른 네트워크 참여자들과 동일하지 않는 것 같습니다. 당신 또는 다른 참여자들이 동일한 비트코인 버전으로 업그레이드 할 필요가 있습니다.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>손상된 wallet.dat에서 개인키 복원을 시도합니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>비트코인 코어 데몬</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>비트코인 RPC 클라이언트 버전</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>블록 생성 옵션:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>거래내역 삭제(진단도구; 재스캔 포함)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>지정된 노드에만 연결하기</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>SOCKS 프록시를 통해 연결</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
+        <translation>JSON-RPC에 연결 &lt;포트&gt;(기본값:8332 또는 테스트넷: 18332)</translation>
+    </message>
+    <message>
+        <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Corrupted block database detected</source>
         <translation>손상된 블록 데이터베이스가 감지되었습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
+        <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
+        <translation>자신의 아이피 주소를 발견합니다 (기본값: 1 반응이 없거나 외부 아이피가 없을 때)</translation>
+    </message>
+    <message>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>블락 데이터베이스를 다시 생성하시겠습니까?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>블록 데이터베이스를 초기화하는데 오류</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>블록 데이터베이스를 불러오는데 오류</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>블록 데이터베이스를 여는데 오류</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>오류: 디스크 공간이 부족합니다!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>오류: 지갑이 잠금상태여서 거래를 생성할 수 없습니다!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>오류: 시스템 오류:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation type="unfinished"/>
+        <translation>어떤 포트도 반응하지 않습니다. 사용자 반응=0 만약 원한다면</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>블록 정보를 읽는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>블록을 읽는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>블록 인덱스를 동기화하는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>블록 인덱스를 기록하는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>블록 정보를 기록하는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>블록을 기록하는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>파일 정보를 기록하는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>코인 데이터베이스에 기록하는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>송금 인덱스에 기록하는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>데이터 실행 취소를 기록하는데 실패했습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>DNS 찾기를 이용하여 사용자를 찾으시오(기본값: 1 연결 되면)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>코인 생성(기본값: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>시작할때 검사할 블록 갯수입니다(기본값: 288, 0 = 모두)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>잘못된 -onion 주소입니다: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>RPC 클라이언트 옵션</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>-proxy를 위한 SOCKS 버전을 선택하세요 (4 또는 5, 기본: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>비트코인 서버로 명령 보내기</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation>데이터베이스 케시 크기를 메가바이트로 설정(%d 부터 %d, 기본값: %d)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>최대 블락 크기를 Bytes로 지정하세요 (기본: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>데이터 폴더 안에 지갑 파일을 선택하세요.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>비트코인 서버 시작</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>사용법 (오래되었습니다. bitcoin-cli를 사용하십시오):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>블록 검증중...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>지갑 검증중...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>RPC서버가 시작되길 기다리십시요</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>지갑 옵션:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>외부 blk000??.dat 파일에서 블록 가져오기</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>정보</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>전체 거래 지수를 유지합니다(기본값: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>내부 중단점에 일치하는 블록 체인만 수용(기본값: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL 옵션: (SSL 설정 절차를 보혀면 비트코인 위키를 참조하십시오)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>추적오류 정보를 degug.log 자료로 보내는 대신 콘솔로 보내기</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>바이트 단위의 최소 블록 크기 설정(기본값: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>클라이언트 시작시 debug.log 파일 비우기(기본값: 디버그 안할때 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>거래를 서명하는것을 실패하였습니다.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>밀리초 단위로 연결 제한시간을 설정하십시오(기본값: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>시스템 오류:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>거래량이 너무 적습니다</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>거래량은 반드시 정수여야합니다.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>너무 큰 거래</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
-        <translation type="unfinished"/>
+        <translation>UPnP사용하여 지도에서 포트 반응기다리는 중  (기본값: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
-        <translation type="unfinished"/>
+        <translation>UPnP사용하여 지도에서 포트 반응기다리는 중  (기본값: 1 반응이 생기면)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>JSON-RPC 연결에 사용할 사용자 이름</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>경고</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>경고: 이 버전이 오래되어 업그레이드가 필요합니다!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>지갑의 모든거래내역 건너뛰기...</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>버전</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat 파일이 손상되었고 복구가 실패하였습니다.</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>JSON-RPC 연결에 사용할 암호</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>지정한 IP 주소의 JSON-RPC 연결 허용</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>실행 중인 노드로 명령 전송 &lt;ip&gt; (기본값: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>최고의 블럭이 변하면 명령을 실행(cmd 에 있는 %s 는 블럭 해시에 의해 대체되어 짐)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>지갑을 최근 형식으로 개선하시오</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>키 풀 크기 설정 &lt;n&gt;(기본값: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>누락된 지갑 송금에 대한 블록 체인 다시 검색</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>JSON-RPC 연결에 OpenSSL(https) 사용</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>서버 인증 파일 (기본값: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>서버 개인 키(기본값: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>도움말 메시지입니다</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>이 컴퓨터의 %s에 바인딩할 수 없습니다 (바인딩 과정에 %d 오류 발생, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>-addnode, -seednode, -connect 옵션에 대해 DNS 탐색 허용</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>주소를 불러오는 중...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>wallet.dat 불러오기 에러: 지갑 오류</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>wallet.dat 불러오기 에러:  지갑은 새버전의 비트코인이 필요합니다.</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>지갑을 새로 써야 합니다.:  완성하기 위하여 비트코인을 다시 시작하십시오.</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>wallet.dat 불러오기 에러</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>잘못된 -proxy 주소입니다: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>-onlynet에 지정한 네트워크를 알 수 없습니다: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>요청한 -socks 프록히 버전을 알 수 없습니다: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>-bind 주소를 확인할 수 없습니다: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>-externalip 주소를 확인할 수 없습니다: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-paytxfee=&lt;amount&gt;에 대한 양이 잘못되었습니다: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>효력없는 금액</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>자금 부족</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>블럭 인덱스를 불러오는 중...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
-        <translation type="unfinished"/>
+        <translation>노드를 추가하여 연결하고 연결상태를 계속 유지하려고 시도합니다.</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>이 컴퓨터의 %s에 바인딩 할 수 없습니다. 아마도 비트코인이 실행중인 것 같습니다.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>지갑을 불러오는 중...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>지갑을 다운그레이드 할 수 없습니다</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>기본 계좌에 기록할 수 없습니다</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>재검색 중...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>로딩 완료</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>%s 옵션을 사용하려면</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>오류</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ky.ts
+++ b/src/qt/locale/bitcoin_ky.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,18 +19,14 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -41,122 +34,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Жаң даректи жасоо</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>Ө&amp;чүрүү</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Дарек</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(аты жок)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,363 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Транзакциялар</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>Билдирүүнү &amp;текшерүү...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Капчык</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Жардам</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Ката</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Эскертүү</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Маалымат</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Жаңыланган</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -688,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -706,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -714,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Дарек</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation>жок</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(аты жок)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1006,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Дарек</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1074,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1102,57 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>версия</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1160,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>Ката</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1218,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1246,258 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>МБ</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Тармак</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Порт:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Терезе</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;Жарайт</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Жокко чыгаруу</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>жарыяланбаган</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>жок</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1505,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Капчык</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>синхрондоштурулган эмес</translation>
     </message>
@@ -1575,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1669,29 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1699,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1722,194 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Жалпы</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Аты</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Ачуу</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Консоль</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Консолду тазалоо</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1917,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2023,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Дарек</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Билдирүү</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2091,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Билдирүү</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(аты жок)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2129,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Бардыгын тазалоо</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Жөнөтүү</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(аты жок)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2377,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Даректи алмашуу буферинен коюу</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Билдирүү:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2476,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2489,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Даректи алмашуу буферинен коюу</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Бардыгын тазалоо</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2676,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2694,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2702,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/тармакта эмес</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Билдирүү</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2887,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2900,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Дарек</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3028,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Дарек</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3207,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3215,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3223,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3266,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,852 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>Маалымат</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Эскертүү</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>версия</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>Ката</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_la.ts
+++ b/src/qt/locale/bitcoin_la.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -26,141 +23,113 @@ Distributum sub MIT/X11 licentia programmatum, vide comitantem plicam COPYING ve
 Hoc productum continet programmata composita ab OpenSSL Project pro utendo in OpenSSL Toolkit (http://www.openssl.org/) et programmata cifrarum scripta ab Eric Young (eay@cryptsoft.com) et UPnP programmata scripta ab Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dupliciter-clicca ut inscriptionem vel titulum mutes</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Crea novam inscriptionem</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copia inscriptionem iam selectam in latibulum systematis</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copia Inscriptionem</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Dele active selectam inscriptionem ex enumeratione</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exporta data in hac tabella in plicam</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exporta</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Dele</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Hae sunt inscriptiones mittendi pensitationes.  Semper inspice quantitatem et inscriptionem accipiendi antequam nummos mittis.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copia &amp;Titulum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Muta</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Comma Separata Plica (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -168,17 +137,14 @@ Hoc productum continet programmata composita ab OpenSSL Project pro utendo in Op
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Titulus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Inscriptio</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(nullus titulus)</translation>
     </message>
@@ -186,140 +152,106 @@ Hoc productum continet programmata composita ab OpenSSL Project pro utendo in Op
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Dialogus Tesserae</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Insere tesseram</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nova tessera</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Itera novam tesseram</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Insero novam tesseram cassidili.&lt;br/&gt;Sodes tessera &lt;b&gt;10 pluriumve fortuitarum litterarum&lt;/b&gt; utere aut &lt;b&gt;octo pluriumve verborum&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Cifra cassidile</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Huic operationi necesse est tessera cassidili tuo ut cassidile reseret.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Resera cassidile</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Huic operationi necesse est tessera cassidili tuo ut cassidile decifret.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Decifra cassidile</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Muta tesseram</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Insero veterem novamque tesseram cassidili.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirma cifrationem cassidilis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Monitio: Si cassidile tuum cifras et tesseram amittis, tu &lt;b&gt;AMITTES OMNES TUOS NUMMOS BITOS&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Certusne es te velle tuum cassidile cifrare?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>GRAVE: Oportet ulla prioria conservata quae fecisti de plica tui cassidilis reponi a nove generata cifrata plica cassidilis.  Propter securitatem, prioria conservata de plica non cifrata cassidilis inutilia fiet simul atque incipis uti novo cifrato cassidili.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Monitio: Litterae ut capitales seratae sunt!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Cassidile cifratum</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin iam desinet ut finiat actionem cifrandi.  Memento cassidile cifrare non posse cuncte curare ne tui nummi clepantur ab malis programatibus in tuo computatro.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Cassidile cifrare abortum est</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Cassidile cifrare abortum est propter internum errorem.  Tuum cassidile cifratum non est.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Tesserae datae non eaedem sunt.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Cassidile reserare abortum est.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Tessera inserta pro cassidilis decifrando prava erat.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Cassidile decifrare abortum est.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Tessera cassidilis successa est in mutando.</translation>
     </message>
@@ -327,362 +259,286 @@ Hoc productum continet programmata composita ab OpenSSL Project pro utendo in Op
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Signa &amp;nuntium...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synchronizans cum rete...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Summarium</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Monstra generale summarium cassidilis</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transactiones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Inspicio historiam transactionum</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>E&amp;xi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Exi applicatione</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Monstra informationem de Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Informatio de &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Monstra informationem de Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Optiones</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Cifra Cassidile...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Conserva Cassidile...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Muta tesseram...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importans frusta ab disco...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Recreans indicem frustorum in disco...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Mitte nummos ad inscriptionem Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Muta configurationis optiones pro Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Conserva cassidile in locum alium</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Muta tesseram utam pro cassidilis cifrando</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Fenestra &amp;Debug</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Aperi terminalem debug et diagnosticalem</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verifica nuntium...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Cassidile</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Mitte</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Accipe</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Monstra/Occulta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Monstra vel occulta Fenestram principem</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Cifra claves privatas quae cassidili tui sunt</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Signa nuntios cum tuis inscriptionibus Bitcoin ut demonstres te eas possidere</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verifica nuntios ut certus sis eos signatos esse cum specificatis inscriptionibus Bitcoin</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Plica</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configuratio</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Auxilium</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Tabella instrumentorum &quot;Tabs&quot;</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Nucleus</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin cliens</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n activa conexio ad rete Bitcoin</numerusform><numerusform>%n activae conexiones ad rete Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Nulla fons frustorum absens...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Perfecta %1 de %2 (aestimato) frusta historiae transactionum.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Processae %1 frusta historiae transactionum.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hora</numerusform><numerusform>%n horae</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n dies</numerusform><numerusform>%n dies</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n hebdomas</numerusform><numerusform>%n hebdomades</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 post</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Postremum acceptum frustum generatum est %1 abhinc.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transactiones post hoc nondum visibiles erunt.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Monitio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informatio</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Recentissimo</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Persequens...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transactio missa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transactio incipiens</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -695,17 +551,14 @@ Inscriptio: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Cassidile &lt;b&gt;cifratum&lt;/b&gt; est et iam nunc &lt;b&gt;reseratum&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Cassidile &lt;b&gt;cifratum&lt;/b&gt; est et iam nunc &lt;b&gt;seratum&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Error fatalis accidit.  Bitcoin nondum pergere tute potest, et exibit.</translation>
     </message>
@@ -713,7 +566,6 @@ Inscriptio: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Monitio Retis</translation>
     </message>
@@ -721,291 +573,230 @@ Inscriptio: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Quantitas:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Quantitas</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Inscriptio</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Dies</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmatum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Copia inscriptionem</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copia titulum</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copia quantitatem</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Copia transactionis ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(nullus titulus)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1013,67 +804,54 @@ Inscriptio: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Muta Inscriptionem</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Titulus</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Inscriptio</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nova inscriptio accipiendi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nova inscriptio mittendi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Muta inscriptionem accipiendi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Muta inscriptionem mittendi</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Inserta inscriptio &quot;%1&quot; iam in libro inscriptionum est.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Inscriptio inserta &quot;%1&quot; non valida inscriptio Bitcoin est.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Non potuisse cassidile reserare</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Generare novam clavem abortum est.</translation>
     </message>
@@ -1081,27 +859,22 @@ Inscriptio: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1109,52 +882,46 @@ Inscriptio: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Nucleus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versio</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Usus:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>Optiones mandati intiantis</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI optiones</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Constitue linguam, exempli gratia &quot;de_DE&quot; (praedefinitum: lingua systematis)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Incipe minifactum ut icon</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Monstra principem imaginem ad initium (praedefinitum: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1162,57 +929,46 @@ Inscriptio: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1220,27 +976,22 @@ Inscriptio: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1248,253 +999,206 @@ Inscriptio: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Optiones</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Princeps</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Optionalis merces transactionum singulis kB quae adiuvat curare tuas transactiones processas esse celeriter.  Plurimi transactiones 1kB sunt.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Solve &amp;mercedem transactionis</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Pelle Bitcoin per se postquam in systema inire.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Pelle Bitcoin cum inire systema</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Constitue numerum filorum verificationis scriptorum (Maximum 16, 0 = auto, &lt;0 = tot corda libera erunt, praedefinitum: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Reconstitue omnes optiones clientis ad praedefinita.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Reconstitue Optiones</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Rete</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Aperi per se portam clientis Bitcoin in itineratore.  Hoc tantum effectivum est si itineratrum tuum supportat UPnP et id activum est.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Designa portam utendo &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP vicarii:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Porta:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Porta vicarii (e.g. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Versio:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS versio vicarii (e.g. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Fenestra</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Monstra tantum iconem in tabella systematis postquam fenestram minifactam est.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minifac in tabellam systematis potius quam applicationum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minifac potius quam exire applicatione quando fenestra clausa sit.  Si haec optio activa est, applicatio clausa erit tantum postquam selegeris Exi in menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inifac ad claudendum</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;UI</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Lingua monstranda utenti:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Lingua monstranda utenti hic constitui potest.  Haec configuratio effectiva erit postquam Bitcoin iterum initiatum erit.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unita qua quantitates monstrare:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Selige praedefinitam unitam subdivisionis monstrare in interfacie et quando nummos mittere</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Num monstrare inscriptiones Bitcoin in enumeratione transactionum.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Monstra inscriptiones in enumeratione transactionum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancella</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>praedefinitum</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Confirma optionum reconstituere</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Inscriptio vicarii tradita non valida est.</translation>
     </message>
@@ -1502,69 +1206,54 @@ Inscriptio: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Schema</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Monstrata informatio fortasse non recentissima est.  Tuum cassidile per se synchronizat cum rete Bitcoin postquam conexio constabilita est, sed hoc actio nondum perfecta est.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Cassidile</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Immatura:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Fossum pendendum quod nondum maturum est</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Recentes transactiones&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>non synchronizato</translation>
     </message>
@@ -1572,93 +1261,70 @@ Inscriptio: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Tractatio URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI intellegi non posse!  Huius causa possit inscriptionem Bitcoin non validam aut URI parametra maleformata.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Bitcoin incipere non potest: cliccare-ad-pensandum handler</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1666,23 +1332,22 @@ Inscriptio: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Insere inscriptionem Bitcoin (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1690,22 +1355,18 @@ Inscriptio: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Salva codicem QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1713,192 +1374,146 @@ Inscriptio: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nomen clientis</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versio clientis</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informatio</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Utens OpenSSL versione</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Tempus initiandi</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Rete</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Numerus conexionum</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Catena frustorum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Numerus frustorum iam nunc</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Aestimatus totalis numerus frustorum</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Hora postremi frusti</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Aperi</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Terminale</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Dies aedificandi</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Debug catalogi plica</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Aperi plicam catalogi de Bitcoin debug ex activo indice datorum.  Hoc possit pauca secunda pro plicis magnis catalogi.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Vacuefac terminale</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bene ventio in terminale RPC de Bitcoin.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Utere sagittis sursum deorsumque ut per historiam naviges, et &lt;b&gt;Ctrl+L&lt;/b&gt; ut scrinium vacuefacias.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Scribe &lt;b&gt;help&lt;/b&gt; pro summario possibilium mandatorum.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1906,105 +1521,82 @@ Inscriptio: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Titulus:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Copia titulum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copia quantitatem</translation>
     </message>
@@ -2012,67 +1604,54 @@ Inscriptio: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Inscriptio</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Quantitas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Titulus</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Nuntius</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Resultato URI nimis longo, conare minuere verba pro titulo / nuntio.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Error codificandi URI in codicem QR.</translation>
     </message>
@@ -2080,37 +1659,30 @@ Inscriptio: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Dies</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Titulus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Nuntius</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Quantitas</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(nullus titulus)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2118,247 +1690,194 @@ Inscriptio: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Mitte Nummos</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Quantitas:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Mitte pluribus accipientibus simul</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Adde &amp;Accipientem</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Vacuefac &amp;Omnia</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Pendendum:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Confirma actionem mittendi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Mitte</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirma mittendum nummorum</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copia quantitatem</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Inscriptio accipientis non est valida, sodes reproba.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Oportet quantitatem ad pensandum maiorem quam 0 esse.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Quantitas est ultra quod habes.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Quantitas est ultra quod habes cum merces transactionis %1 includitur.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Geminata inscriptio inventa, tantum posse mittere ad quamque inscriptionem semel singulare operatione.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(nullus titulus)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2366,98 +1885,74 @@ Inscriptio: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Quantitas:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Pensa &amp;Ad:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Inscriptio cui mittere pensitationem (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Insero titulum huic inscriptioni ut eam in tuum librum inscriptionum addas.</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Titulus:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Conglutina inscriptionem ex latibulo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Nuntius:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2465,12 +1960,10 @@ Inscriptio: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2478,186 +1971,142 @@ Inscriptio: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Signationes - Signa / Verifica nuntium</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Signa Nuntium</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Potes nuntios signare inscriptionibus tuis ut demonstres te eas possidere.  Cautus es non amibiguum signare, quia impetus phiscatorum conentur te fallere ut signes identitatem tuam ad eos.  Solas signa sententias cuncte descriptas quibus convenis.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Inscriptio qua signare nuntium (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Glutina inscriptionem ex latibulo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Insere hic nuntium quod vis signare</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Signatio</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copia signationem in latibulum systematis</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Signa nuntium ut demonstres hanc inscriptionem Bitcoin a te possessa esse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Signa &amp;Nuntium</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Reconstitue omnes campos signandi nuntii</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Vacuefac &amp;Omnia</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verifica Nuntium</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Insere inscriptionem signantem, nuntium (cura ut copias intermissiones linearum, spatia, tabs, et cetera exacte) et signationem infra ut nuntium verifices.  Cautus esto ne magis legas in signationem quam in nuntio signato ipso est, ut vites falli ab impetu homo-in-medio.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Inscriptio qua nuntius signatus est (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verifica nuntium ut cures signatum esse cum specifica inscriptione Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verifica &amp;Nuntium</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Reconstitue omnes campos verificandi nuntii</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Insere inscriptionem Bitcoin (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Clicca &quot;Signa Nuntium&quot; ut signatio generetur</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Inscriptio inserta non valida est.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Sodes inscriptionem proba et rursus conare.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Inserta inscriptio clavem non refert.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Cassidilis reserare cancellatum est.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Clavis privata absens est pro inserta inscriptione.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Nuntium signare abortum est.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Nuntius signatus.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Signatio decodificari non potuit.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Sodes signationem proba et rursus conare.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Signatio non convenit digesto nuntii</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Nuntium verificare abortum est.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Nuntius verificatus.</translation>
     </message>
@@ -2665,17 +2114,14 @@ Inscriptio: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Nucleus</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2683,7 +2129,6 @@ Inscriptio: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2691,184 +2136,138 @@ Inscriptio: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Apertum donec %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/non conecto</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/non confirmata</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmationes</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, disseminatum per %n nodo</numerusform><numerusform>, disseminata per %n nodis</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Dies</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Fons</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generatum</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Ab</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Ad</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>inscriptio propria</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>titulus</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Creditum</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>maturum erit in %n plure frusto</numerusform><numerusform>maturum erit in %n pluribus frustis</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>non acceptum</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debitum</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Transactionis merces</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Cuncta quantitas</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Nuntius</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Annotatio</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID transactionis</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Informatio de debug</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transactio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Lectenda</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Quantitas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>verum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falsum</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, nondum prospere disseminatum est</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform>Aperi pro %n pluribus frustis</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>ignotum</translation>
     </message>
@@ -2876,12 +2275,10 @@ Inscriptio: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Particularia transactionis</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Haec tabula monstrat descriptionem verbosam transactionis</translation>
     </message>
@@ -2889,127 +2286,102 @@ Inscriptio: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Dies</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Typus</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Inscriptio</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Quantitas</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Aperi pro %n plure frusto</numerusform><numerusform>Aperi pro %n pluribus frustis</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Apertum donec %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmatum (%1 confirmationes)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Hoc frustum non acceptum est ab ulla alia nodis et probabiliter non acceptum erit!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generatum sed non acceptum</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Acceptum cum</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Acceptum ab</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Missum ad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pensitatio ad te ipsum</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Fossa</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status transactionis.  Supervola cum mure ut monstretur numerus confirmationum.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Dies et tempus quando transactio accepta est.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Typus transactionis.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Inscriptio destinationis transactionis.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Quantitas remota ex pendendo aut addita ei.</translation>
     </message>
@@ -3017,178 +2389,142 @@ Inscriptio: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Omne</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hodie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Hac hebdomade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Hoc mense</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Postremo mense</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Hoc anno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Intervallum...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Acceptum cum</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Missum ad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Ad te ipsum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Fossa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Alia</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Insere inscriptionem vel titulum ut quaeras</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Quantitas minima</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copia inscriptionem</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copia titulum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copia quantitatem</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copia transactionis ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Muta titulum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Monstra particularia transactionis</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Comma Separata Plica (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmatum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Dies</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Typus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Titulus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Inscriptio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Quantitas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Intervallum:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>ad</translation>
     </message>
@@ -3196,7 +2532,6 @@ Inscriptio: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,7 +2539,6 @@ Inscriptio: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Mitte Nummos</translation>
     </message>
@@ -3212,42 +2546,34 @@ Inscriptio: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Exporta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exporta data in hac tabella in plicam</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Conserva cassidile</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Data cassidilis (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Conservare abortum est.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Successum in conservando</translation>
     </message>
@@ -3255,107 +2581,86 @@ Inscriptio: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Usus:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Enumera mandata</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Accipe auxilium pro mandato</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Optiones:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Specifica configurationis plicam (praedefinitum: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Specifica pid plicam (praedefinitum: bitcoin.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Specifica indicem datorum</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Constitue magnitudinem databasis cache in megabytes (praedefinitum: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Ausculta pro conexionibus in &lt;porta&gt; (praedefinitum: 8333 vel testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Manutene non plures quam &lt;n&gt; conexiones ad paria (praedefinitum: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Conecta ad nodum acceptare inscriptiones parium, et disconecte</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Specifica tuam propriam publicam inscriptionem</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Limen pro disconectendo paria improba (praedefinitum: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Numerum secundorum prohibere ne paria improba reconectant (praedefinitum: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Error erat dum initians portam RPC %u pro auscultando in IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Ausculta pro conexionibus JSON-RPC in &lt;porta&gt; (praedefinitum: 8332 vel testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Accipe terminalis et JSON-RPC mandata.</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Operare infere sicut daemon et mandata accipe</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Utere rete experimentale</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Accipe conexiones externas (praedefinitum: 1 nisi -proxy neque -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3380,722 +2685,682 @@ exempli gratia: alertnotify=echo %%s | mail -s &quot;Bitcoin Notificatio&quot; a
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Error erat dum initians portam RPC %u pro auscultando in IPv6, labens retrorsum ad IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Conglutina ad inscriptionem datam et semper in eam ausculta.  Utere [moderatrum]:porta notationem pro IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Non posse serare datorum indicem %s.  Bitcoin probabiliter iam operatur.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Error: Transactio eiecta est! Hoc possit accidere si alii nummorum in cassidili tuo iam soluti sint, ut si usus es exemplar de wallet.dat et nummi soluti sunt in exemplari sed non hic notati ut soluti.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Error: Huic transactioni necesse est merces saltem %s propter eius magnitudinem, complexitatem, vel usum recentum acceptorum nummorum!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Facere mandatum quotiescumque cassidilis transactio mutet (%s in mandato sbstituitur ab TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Hoc est prae-dimittum experimentala aedes - utere eo periculo tuo proprio - nolite utere fodendo vel applicationibus mercatoriis</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Monitio: -paytxfee constitutum valde magnum!  Hoc est merces transactionis solves si mittis transactionem.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Monitio: Sodes cura ut dies tempusque computatri tui recti sunt!  Si horologium tuum pravum est, Bitcoin non proprie fungetur.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Monitio: error legendo wallet.dat!  Omnes claves recte lectae, sed data transactionum vel libri inscriptionum fortasse desint vel prava sint.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Monitio: wallet.data corrupta, data salvata!  Originalis wallet.dat salvata ut wallet.{timestamp}.bak in %s; si pendendum tuum vel transactiones pravae sunt, oportet ab conservato restituere.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Conare recipere claves privatas de corrupto wallet.dat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Optiones creandi frustorum:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Conecte sole ad nodos specificatos (vel nodum specificatum)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Corruptum databasum frustorum invenitur</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Discooperi propriam inscriptionem IP (praedefinitum: 1 quando auscultans et nullum -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Visne reficere databasum frustorum iam?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Error initiando databasem frustorum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Error initiando systematem databasi cassidilis %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Error legendo frustorum databasem</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Error aperiendo databasum frustorum</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Error: Inopia spatii disci!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Error: Cassidile seratum, non posse transactionem creare!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Error: systematis error:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Non potuisse auscultare in ulla porta.  Utere -listen=0 si hoc vis.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Non potuisse informationem frusti legere </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Non potuisse frustum legere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Synchronizare indicem frustorum abortum est</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Scribere indicem frustorum abortum est</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Scribere informationem abortum est</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Scribere frustum abortum est</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Scribere informationem plicae abortum est</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Scribere databasem nummorum abortum est</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Scribere indicem transactionum abortum est</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Scribere data pro cancellando mutationes abortum est</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Inveni paria utendo DNS quaerendo (praedefinitum: 1 nisi -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Genera nummos (praedefinitum: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Quot frusta proba ad initium (praedefinitum: 288, 0 = omnia)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Quam perfecta frustorum verificatio est (0-4, praedefinitum: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Inopia descriptorum plicarum.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Restituere indicem catenae frustorum ex activis plicis blk000??.dat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Constitue numerum filorum ad tractandum RPC postulationes (praedefinitum: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verificante frusta...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Verificante cassidilem...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importat frusta ab externa plica blk000??.dat</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Constitue numerum filorum verificationis scriptorum (Maximum 16, 0 = auto, &lt;0 = tot corda libera erunt, praedefinitum: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informatio</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantitas non valida pro -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantitas non valida pro -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Manutene completam indicem transactionum (praedefinitum: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maxima magnitudo memoriae pro datis accipendis singulis conexionibus, &lt;n&gt;*1000 octetis/bytes (praedefinitum: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maxima magnitudo memoriae pro datis mittendis singulis conexionibus, &lt;n&gt;*1000 octetis/bytes (praedefinitum: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Tantum accipe catenam frustorum convenientem internis lapidibus (praedefinitum: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Tantum conecte ad nodos in rete &lt;net&gt; (IPv4, IPv6 aut Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Optiones SSL: (vide vici de Bitcoin pro instructionibus SSL configurationis)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Mitte informationem vestigii/debug ad terminale potius quam plicam debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Constitue minimam magnitudinem frusti in octetis/bytes (praedefinitum: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Diminue plicam debug.log ad initium clientis (praedefinitum: 1 nisi -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Signandum transactionis abortum est</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Specifica tempumfati conexionis in millisecundis (praedefinitum: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Systematis error:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Magnitudo transactionis nimis parva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Necesse est magnitudines transactionum positivas esse.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transactio nimis magna</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Utere UPnP designare portam auscultandi (praedefinitum: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Utere UPnP designare portam auscultandi (praedefinitum: 1 quando auscultans)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nomen utentis pro conexionibus JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Monitio</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Monitio: Haec versio obsoleta est, progressio postulata!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>versio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corrupta, salvare abortum est</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Tessera pro conexionibus JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permitte conexionibus JSON-RPC ex inscriptione specificata</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Mitte mandata nodo operanti in &lt;ip&gt; (praedefinitum: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Pelle mandatum quando optissimum frustum mutat (%s in mandato substituitur ab hash frusti)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Progredere cassidile ad formam recentissimam</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Constitue magnitudinem stagni clavium ad &lt;n&gt; (praedefinitum: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Iterum perlege catenam frustorum propter absentes cassidilis transactiones</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Utere OpenSSL (https) pro conexionibus JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Plica certificationis daemonis moderantis (praedefinitum: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Clavis privata daemonis moderans (praedefinitum: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Hic nuntius auxilii</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Non posse conglutinare ad %s in hoc computatro (conglutinare redidit errorem %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permitte quaerenda DNS pro -addnode, -seednode, et -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Legens inscriptiones...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Error legendi wallet.dat: Cassidile corruptum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Error legendi wallet.dat: Cassidili necesse est recentior versio Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Cassidili necesse erat rescribi: Repelle Bitcoin ut compleas</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Error legendi wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Inscriptio -proxy non valida: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Ignotum rete specificatum in -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Ignota -socks vicarii versio postulata: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Non posse resolvere -bind inscriptonem: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Non posse resolvere -externalip inscriptionem: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantitas non valida pro -paytxfee=&lt;quantitas&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Quantitas non valida</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Inopia nummorum</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Legens indicem frustorum...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Adice nodum cui conectere et conare sustinere conexionem apertam</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Non posse conglutinare ad %s in hoc cumputatro.  Bitcoin probabiliter iam operatur.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Legens cassidile...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Non posse cassidile regredi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Non posse scribere praedefinitam inscriptionem</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Iterum perlegens...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Completo lengendi</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Ut utaris optione %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_lt.ts
+++ b/src/qt/locale/bitcoin_lt.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -26,141 +23,113 @@ Platinama pagal MIT/X11 licenciją, kurią rasite faile COPYING arba http://www.
 Šiame produkte yra OpenSSL projekto kuriamas OpenSSL Toolkit (http://www.openssl.org/), Eric Young parašyta kriptografinė programinė įranga bei Thomas Bernard sukurta UPnP programinė įranga.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Spragtelėkite, kad pakeistumėte adresą arba žymę</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Sukurti naują adresą</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Naujas</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopijuoti esamą adresą į mainų atmintį</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopijuoti</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>&amp;Užverti</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopijuoti adresą</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Eksportuoti</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Trinti</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopijuoti ž&amp;ymę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Keisti</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kableliais išskirtas failas (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -168,17 +137,14 @@ Platinama pagal MIT/X11 licenciją, kurią rasite faile COPYING arba http://www.
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Žymė</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresas</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(nėra žymės)</translation>
     </message>
@@ -186,140 +152,106 @@ Platinama pagal MIT/X11 licenciją, kurią rasite faile COPYING arba http://www.
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Slaptafrazės dialogas</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Įvesti slaptafrazę</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nauja slaptafrazė</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Pakartokite naują slaptafrazę</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Įveskite naują piniginės slaptafrazę.&lt;br/&gt;Prašome naudoti slaptafrazę iš &lt;b&gt; 10 ar daugiau atsitiktinių simbolių&lt;/b&gt; arba &lt;b&gt;aštuonių ar daugiau žodžių&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Užšifruoti piniginę</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Ši operacija reikalauja jūsų piniginės slaptafrazės jai atrakinti.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Atrakinti piniginę</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Ši operacija reikalauja jūsų piniginės slaptafrazės jai iššifruoti.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Iššifruoti piniginę</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Pakeisti slaptafrazę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Įveskite seną ir naują piniginės slaptafrazes.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Patvirtinkite piniginės užšifravimą</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Dėmesio: jei užšifruosite savo piniginę ir pamesite slaptafrazę, jūs&lt;b&gt;PRARASITE VISUS SAVO BITCOINUS&lt;/b&gt;! </translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Ar tikrai norite šifruoti savo piniginę?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Įspėjimas: įjungtas Caps Lock klavišas!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Piniginė užšifruota</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin dabar užsidarys šifravimo proceso pabaigai. Atminkite, kad piniginės šifravimas negali pilnai apsaugoti bitcoinų vagysčių kai tinkle esančios kenkėjiškos programos patenka į jūsų kompiuterį.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Nepavyko užšifruoti piniginę</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Dėl vidinės klaidos nepavyko užšifruoti piniginę.Piniginė neužšifruota.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Įvestos slaptafrazės nesutampa.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Nepavyko atrakinti piniginę</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Neteisingai įvestas slaptažodis piniginės iššifravimui.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Nepavyko iššifruoti piniginės</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Piniginės slaptažodis sėkmingai pakeistas.</translation>
     </message>
@@ -327,362 +259,286 @@ Platinama pagal MIT/X11 licenciją, kurią rasite faile COPYING arba http://www.
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Pasirašyti ži&amp;nutę...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sinchronizavimas su tinklu ...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Apžvalga</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Rodyti piniginės bendrą apžvalgą</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Sandoriai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Apžvelgti sandorių istoriją</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Išeiti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Išjungti programą</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Rodyti informaciją apie Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Apie &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Rodyti informaciją apie Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Parinktys...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Užšifruoti piniginę...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Backup piniginę...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Keisti slaptafrazę...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Blokai importuojami iš disko...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Blokai iš naujo indeksuojami...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Siųsti monetas Bitcoin adresui</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Keisti bitcoin konfigūracijos galimybes</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Daryti piniginės atsarginę kopiją</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Pakeisti slaptafrazę naudojamą piniginės užšifravimui</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Derinimo langas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Atverti derinimo ir diagnostikos konsolę</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Tikrinti žinutę...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Piniginė</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Siųsti</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Gauti</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Rodyti / Slėpti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Rodyti arba slėpti pagrindinį langą</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Failas</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Nustatymai</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Pagalba</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Kortelių įrankinė</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testavimotinklas]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin branduolys</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin klientas</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n Bitcoin tinklo aktyvus ryšys</numerusform><numerusform>%n Bitcoin tinklo aktyvūs ryšiai</numerusform><numerusform>%n Bitcoin tinklo aktyvūs ryšiai</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n valanda</numerusform><numerusform>%n valandos</numerusform><numerusform>%n valandų</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n diena</numerusform><numerusform>%n dienos</numerusform><numerusform>%n dienų</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n savaitė</numerusform><numerusform>%n savaitės</numerusform><numerusform>%n savaičių</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Klaida</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informacija</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Atnaujinta</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Vejamasi...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Sandoris nusiųstas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Ateinantis sandoris</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -694,17 +550,14 @@ Tipas: %3
 Adresas: %4</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Piniginė &lt;b&gt;užšifruota&lt;/b&gt; ir šiuo metu &lt;b&gt;atrakinta&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Piniginė &lt;b&gt;užšifruota&lt;/b&gt; ir šiuo metu &lt;b&gt;užrakinta&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -712,7 +565,6 @@ Adresas: %4</translation>
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Tinklo įspėjimas</translation>
     </message>
@@ -720,291 +572,230 @@ Adresas: %4</translation>
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Suma:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Patvirtintas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopijuoti adresą</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopijuoti žymę</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopijuoti sumą</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(nėra žymės)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1012,67 +803,54 @@ Adresas: %4</translation>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Keisti adresą</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>Ž&amp;ymė</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adresas</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Naujas gavimo adresas</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Naujas siuntimo adresas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Keisti gavimo adresą</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Keisti siuntimo adresą</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Įvestas adresas „%1“ jau yra adresų knygelėje.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Įvestas adresas „%1“ nėra galiojantis Bitcoin adresas.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Nepavyko atrakinti piniginės.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Naujo rakto generavimas nepavyko.</translation>
     </message>
@@ -1080,27 +858,22 @@ Adresas: %4</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1108,52 +881,46 @@ Adresas: %4</translation>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin branduolys</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versija</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Naudojimas:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>komandinės eilutės parametrai</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Naudotoji sąsajos parametrai</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Nustatyti kalbą, pavyzdžiui &quot;lt_LT&quot; (numatyta: sistemos kalba)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Paleisti sumažintą</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1161,57 +928,46 @@ Adresas: %4</translation>
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Sveiki</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Klaida</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1219,27 +975,22 @@ Adresas: %4</translation>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1247,253 +998,206 @@ Adresas: %4</translation>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Parinktys</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Pagrindinės</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>&amp;Mokėti sandorio mokestį</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Automatiškai paleisti Bitkoin programą įjungus sistemą.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Paleisti Bitcoin programą su window sistemos paleidimu</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Tinklas</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Automatiškai atidaryti Bitcoin kliento prievadą maršrutizatoriuje. Tai veikia tik tada, kai jūsų maršrutizatorius palaiko UPnP ir ji įjungta.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Persiųsti prievadą naudojant &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Tarpinio serverio &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Prievadas:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Tarpinio serverio preivadas (pvz, 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;versija:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Tarpinio serverio SOCKS versija (pvz., 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Langas</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Po programos lango sumažinimo rodyti tik programos ikoną.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;M sumažinti langą bet ne užduočių juostą</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Uždarant langą neuždaryti programos. Kai ši parinktis įjungta, programa bus uždaryta tik pasirinkus  meniu komandą Baigti.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>&amp;Sumažinti uždarant</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Rodymas</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Naudotojo sąsajos &amp;kalba:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Čia gali būti nustatyta naudotojo sąsajos kalba. Šis nustatymas įsigalios iš naujo paleidus Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Vienetai, kuriais rodyti sumas:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Rodomų ir siunčiamų monetų kiekio matavimo vienetai</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Rodyti adresus sandorių sąraše</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;Gerai</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Atšaukti</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>numatyta</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Nurodytas tarpinio serverio adresas negalioja.</translation>
     </message>
@@ -1501,69 +1205,54 @@ Adresas: %4</translation>
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Forma</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Piniginė</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Nepribrendę:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Viso:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Jūsų balansas</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Naujausi sandoriai&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>nesinchronizuota</translation>
     </message>
@@ -1571,93 +1260,70 @@ Adresas: %4</translation>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI apdorojimas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Tinklo užklausos klaida</translation>
     </message>
@@ -1665,23 +1331,22 @@ Adresas: %4</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Įveskite bitkoinų adresą (pvz. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1689,22 +1354,18 @@ Adresas: %4</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Įrašyti QR kodą</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1712,192 +1373,146 @@ Adresas: %4</translation>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Kliento pavadinimas</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>nėra</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Kliento versija</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informacija</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Naudojama OpenSSL versija</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Paleidimo laikas</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Tinklas</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Prisijungimų kiekis</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Blokų grandinė</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Dabartinis blokų skaičius</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Paskutinio bloko laikas</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Atverti</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsolė</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Kompiliavimo data</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Derinimo žurnalo failas</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Išvalyti konsolę</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1905,105 +1520,82 @@ Adresas: %4</translation>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>Ž&amp;ymė:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopijuoti žymę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopijuoti sumą</translation>
     </message>
@@ -2011,67 +1603,54 @@ Adresas: %4</translation>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR kodas</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Mokėjimo informacija</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Žymė</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Žinutė</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Klaida, koduojant URI į QR kodą.</translation>
     </message>
@@ -2079,37 +1658,30 @@ Adresas: %4</translation>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Žymė</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Žinutė</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(nėra žymės)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2117,247 +1689,194 @@ Adresas: %4</translation>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Siųsti monetas</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Suma:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Siųsti keliems gavėjams vienu metu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;A Pridėti gavėją</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Išvalyti &amp;viską</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Balansas:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Patvirtinti siuntimo veiksmą</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Siųsti</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Patvirtinti monetų siuntimą</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopijuoti sumą</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Negaliojantis gavėjo adresas. Patikrinkite.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Apmokėjimo suma turi būti didesnė nei 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Suma viršija jūsų balansą.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Jei pridedame sandorio mokestį %1 bendra suma viršija jūsų balansą.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Rastas adreso dublikatas.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(nėra žymės)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2365,98 +1884,74 @@ Adresas: %4</translation>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Su&amp;ma:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Mokėti &amp;gavėjui:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Įveskite žymę šiam adresui kad galėtumėte įtraukti ją į adresų knygelę</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>Ž&amp;ymė:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Įvesti adresą iš mainų atminties</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Žinutė:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2464,12 +1959,10 @@ Adresas: %4</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2477,186 +1970,142 @@ Adresas: %4</translation>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Pasirašyti žinutę</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Įveskite bitkoinų adresą (pvz. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Įvesti adresą iš mainų atminties</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Įveskite pranešimą, kurį norite pasirašyti čia</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Registruotis žinute įrodymuii, kad turite šį adresą</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Išvalyti &amp;viską</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Patikrinti žinutę</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Įveskite bitkoinų adresą (pvz. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Patikrinkite žinutę, jog įsitikintumėte, kad ją pasirašė nurodytas Bitcoin adresas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Įveskite bitkoinų adresą (pvz. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Spragtelėkite &quot;Registruotis žinutę&quot; tam, kad gauti parašą</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Įvestas adresas negalioja.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Prašom patikrinti adresą ir bandyti iš naujo.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Piniginės atrakinimas atšauktas.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Žinutės pasirašymas nepavyko.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Žinutė pasirašyta.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Nepavyko iškoduoti parašo.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Prašom patikrinti parašą ir bandyti iš naujo.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Parašas neatitinka žinutės.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Žinutės tikrinimas nepavyko.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Žinutė patikrinta.</translation>
     </message>
@@ -2664,17 +2113,14 @@ Adresas: %4</translation>
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin branduolys</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testavimotinklas]</translation>
     </message>
@@ -2682,7 +2128,6 @@ Adresas: %4</translation>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2690,184 +2135,138 @@ Adresas: %4</translation>
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Atidaryta iki %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/neprisijungęs</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepatvirtintas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 patvirtinimų</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Būsena</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Šaltinis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Sugeneruotas</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Nuo</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Kam</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>savo adresas</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>žymė</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Kreditas</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>nepriimta</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debitas</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Sandorio mokestis</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Neto suma</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Žinutė</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Komentaras</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Sandorio ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Derinimo informacija</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Sandoris</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>tiesa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>netiesa</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, transliavimas dar nebuvo sėkmingas</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>nežinomas</translation>
     </message>
@@ -2875,12 +2274,10 @@ Adresas: %4</translation>
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Sandorio detelės</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Šis langas sandorio detalų aprašymą</translation>
     </message>
@@ -2888,127 +2285,102 @@ Adresas: %4</translation>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresas</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Atidaryta iki %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Patvirtinta (%1 patvirtinimai)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Šis blokas negautas nė vienu iš mazgų ir matomai nepriimtas</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Išgauta bet nepriimta</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Gauta su</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Gauta iš</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Siųsta </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Mokėjimas sau</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Išgauta</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>nepasiekiama</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Sandorio būklė. Užvedus pelės žymeklį ant šios srities matysite patvirtinimų skaičių.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Sandorio gavimo data ir laikas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Sandorio tipas.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Sandorio paskirties adresas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Suma pridėta ar išskaičiuota iš balanso</translation>
     </message>
@@ -3016,178 +2388,142 @@ Adresas: %4</translation>
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Visi</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Šiandien</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Šią savaitę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Šį mėnesį</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Paskutinį mėnesį</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Šiais metais</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Intervalas...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Gauta su</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Išsiųsta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Skirta sau</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Išgauta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Kita</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Įveskite adresą ar žymę į paiešką</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimali suma</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopijuoti adresą</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopijuoti žymę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopijuoti sumą</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Taisyti žymę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Rodyti sandėrio detales</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kableliais atskirtų duomenų failas (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Patvirtintas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Žymė</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Grupė:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>skirta</translation>
     </message>
@@ -3195,7 +2531,6 @@ Adresas: %4</translation>
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3203,7 +2538,6 @@ Adresas: %4</translation>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Siųsti monetas</translation>
     </message>
@@ -3211,42 +2545,34 @@ Adresas: %4</translation>
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Eksportuoti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Atsarginė kopija sėkmingai padaryta</translation>
     </message>
@@ -3254,107 +2580,86 @@ Adresas: %4</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Naudojimas:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Komandų sąrašas</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Suteikti pagalba komandai</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Parinktys:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Nurodyti konfigūracijos failą (pagal nutylėjimąt: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Nurodyti pid failą (pagal nutylėjimą: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Nustatyti duomenų aplanką</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Sujungimo klausymas prijungčiai  &lt;port&gt; (pagal nutylėjimą: 8333 arba testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Palaikyti ne daugiau &lt;n&gt; jungčių kolegoms (pagal nutylėjimą: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Atjungimo dėl netinkamo kolegų elgesio riba  (pagal nutylėjimą: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Sekundžių kiekis eikiamas palaikyti ryšį dėl lygiarangių nestabilumo (pagal nutylėjimą: 86.400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Klausymas JSON-RPC sujungimui prijungčiai &lt;port&gt; (pagal nutylėjimą: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Priimti komandinę eilutę ir JSON-RPC komandas</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Dirbti fone kaip šešėlyje ir priimti komandas</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Naudoti testavimo tinklą</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3369,722 +2674,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Įspėjimas: -paytxfee yra nustatytas per didelis. Tai sandorio mokestis, kurį turėsite mokėti, jei siųsite sandorį.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Įspėjimas: Patikrinkite, kad kompiuterio data ir laikas yra teisingi.Jei Jūsų laikrodis neteisingai nustatytas Bitcoin, veiks netinkamai.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Prisijungti tik prie nurodyto mazgo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Klaida atveriant blokų duombazę</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Klaida: sistemos klaida:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Nepavyko nuskaityti bloko informacijos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Nepavyko nuskaityti bloko</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Nepavyko įrašyti bloko</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Nepavyko įrašyti failo informacijos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation> Įtraukti mokestį už kB siunčiamiems sandoriams</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generuoti monetas (numatyta: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Siųsti komandą Bitcoin serveriui</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Paleisti Bitcoin serverį</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Tikrinami blokai...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Tikrinama piniginė...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informacija</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maksimalus buferis priėmimo sujungimui &lt;n&gt;*1000 bitų (pagal nutylėjimą: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maksimalus buferis siuntimo sujungimui &lt;n&gt;*1000 bitų (pagal nutylėjimą: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL opcijos (žr.e Bitcoin Wiki for SSL setup instructions)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Siųsti atsekimo/derinimo info į konsolę vietoj debug.log failo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Nustatyti sujungimo trukmę milisekundėmis (pagal nutylėjimą: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Sistemos klaida:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Bandymas naudoti UPnP struktūra klausymosi prievadui (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Bandymas naudoti UPnP struktūra klausymosi prievadui (default: 1 when listening)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Vartotojo vardas JSON-RPC jungimuisi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>versija</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Slaptažodis JSON-RPC sujungimams</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Leisti JSON-RPC tik iš nurodytų IP adresų</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Siųsti komandą mazgui dirbančiam &lt;ip&gt; (pagal nutylėjimą: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Atnaujinti piniginę į naujausią formatą</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Nustatyti rakto apimties dydį &lt;n&gt; (pagal nutylėjimą: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Ieškoti  prarastų piniginės sandorių blokų grandinėje</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Naudoti OpenSSL (https) jungimuisi JSON-RPC </translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Serverio sertifikato failas (pagal nutylėjimą: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Serverio privatus raktas (pagal nutylėjimą: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Pagelbos žinutė</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Nepavyko susieti šiame kompiuteryje prievado %s (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Leisti DNS paiešką sujungimui ir mazgo pridėjimui</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Užkraunami adresai...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation> wallet.dat pakrovimo klaida,  wallet.dat sugadintas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation> wallet.dat pakrovimo klaida,  wallet.dat reikalauja naujasnės Bitcoin versijos</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Piniginė turi būti prrašyta: įvykdymui perkraukite Bitcoin</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation> wallet.dat pakrovimo klaida</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Neteisingas proxy adresas: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Neteisinga suma -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Neteisinga suma</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Nepakanka lėšų</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Įkeliamas blokų indeksas...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Pridėti mazgą prie sujungti su and attempt to keep the connection open</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Nepavyko susieti šiame kompiuteryje prievado %s. Bitcoin tikriausiai jau veikia.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Užkraunama piniginė...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Peržiūra</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Įkėlimas baigtas</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Klaida</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_lv_LV.ts
+++ b/src/qt/locale/bitcoin_lv_LV.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Par Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
-        <translation type="unfinished"/>
+        <translation>&lt;b&gt;Bitcoin Core&lt;/b&gt; versija</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
-        <translation type="unfinished"/>
+        <translation>Autortiesības</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core izstrādātāji</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Adresi vai nosaukumu rediģē ar dubultklikšķi</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Izveidot jaunu adresi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Jauns</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopēt iezīmēto adresi uz starpliktuvi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Kopēt</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Aizvērt</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopēt adresi</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Eksportēt</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Dzēst</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Izvēlēties</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
-        <translation type="unfinished"/>
+        <translation>Sūtīšanas adreses</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
-        <translation type="unfinished"/>
+        <translation>Saņemšanas adreses</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopēt &amp;Nosaukumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Rediģēt</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
-        <translation type="unfinished"/>
+        <translation>Eksportēt Adrešu Sarakstu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Fails ar komatu kā atdalītāju (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
-        <translation type="unfinished"/>
+        <translation>Eksportēšana Neizdevās</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Nosaukums</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adrese</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(bez nosaukuma)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Paroles dialogs</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Ierakstiet paroli</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Jauna parole</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Jaunā parole vēlreiz</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Ierakstiet maciņa jauno paroli.&lt;br/&gt;Lūdzu izmantojiet &lt;b&gt;10 vai vairāk nejauši izvēlētas zīmes&lt;/b&gt;, vai &lt;b&gt;astoņus un vairāk vārdus&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Šifrēt maciņu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Lai veikto šo darbību, maciņš jāatslēdz ar paroli.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Atslēgt maciņu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Šai darbībai maciņš jāatšifrē ar maciņa paroli.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Atšifrēt maciņu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Mainīt paroli</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Ierakstiet maciņa veco un jauno paroli.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Apstiprināt maciņa šifrēšanu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation type="unfinished"/>
+        <translation>Brīdinājums: Caps Lock ir ieslēgts!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Maciņš nošifrēts</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin aizvērsies, lai pabeigtu šifrēšanu. Atcerieties, ka maciņa šifrēšana nevar pilnībā novērst bitkoinu zādzību, ko veic datorā ieviesušās kaitīgas programmas.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Maciņa šifrēšana neizdevās</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Maciņa šifrēšana neizdevās programmas kļūdas dēļ. Jūsu maciņš netika šifrēts.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Ievadītās paroles nav vienādas.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Maciņu atšifrēt neizdevās</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Maciņa atšifrēšanai ievadītā parole nav pareiza.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Maciņu neizdevās atšifrēt</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Parakstīt &amp;ziņojumu...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sinhronizācija ar tīklu...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Pārskats</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Rādīt vispārēju maciņa pārskatu</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transakcijas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Skatīt transakciju vēsturi</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Iziet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Aizvērt programmu</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Parādīt informāciju par Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Par &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Parādīt informāciju par Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Iespējas</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>Š&amp;ifrēt maciņu...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Izveidot maciņa rezerves kopiju</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Mainīt paroli</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Adrešu sūtīšana...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
-        <translation type="unfinished"/>
+        <translation>Adrešu &amp;saņemšana...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
-        <translation type="unfinished"/>
+        <translation>Atvērt &amp;URI</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
-        <translation type="unfinished"/>
+        <translation>Importē blokus no diska...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
-        <translation type="unfinished"/>
+        <translation>Bloku reindeksēšana no diska...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Nosūtīt bitkoinus uz Bitcoin adresi</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Mainīt Bitcoin konfigurācijas uzstādījumus</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Izveidot maciņa rezerves kopiju citur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Mainīt maciņa šifrēšanas paroli</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Debug logs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Atvērt atkļūdošanas un diagnostikas konsoli</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Pārbaudīt ziņojumu...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Maciņš</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Sūtīt</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
-        <translation type="unfinished"/>
+        <translation>Saņe&amp;mt</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Rādīt / Paslēpt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation type="unfinished"/>
+        <translation>Šifrēt privātās atslēgas kuras pieder tavam maciņam</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
-        <translation type="unfinished"/>
+        <translation>Parakstīt ziņojumus ar savām Bitcoin adresēm lai pierādītu ka tās pieder tev</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
-        <translation type="unfinished"/>
+        <translation>Pārbaudīt ziņojumus lai pārliecinātos, ka tie tika parakstīti ar norādītajām Bitcoin adresēm</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Fails</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Uzstādījumi</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Palīdzība</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Ciļņu rīkjosla</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Par &amp;Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
-        <translation type="unfinished"/>
+        <translation>Atvērt bitcoin URI vai maksājuma pieprasījumu</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Komandrindas iespējas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin klients</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktīvu savienojumu ar Bitcoin tīklu</numerusform><numerusform>%n aktīvs savienojums ar Bitcoin tīklu</numerusform><numerusform>%n aktīvu savienojumu as Bitcoin tīklu</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
-        <translation type="unfinished"/>
+        <translation>Nav pieejams neviens bloku avots...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
-        <translation type="unfinished"/>
+        <translation>Apstrādāti %1 bloki no transakciju vēstures.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>%n stundas</numerusform><numerusform>%n stunda</numerusform><numerusform>%n stundas</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>%n dienas</numerusform><numerusform>%n diena</numerusform><numerusform>%n dienas</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>%n nedēļas</numerusform><numerusform>%n nedēļa</numerusform><numerusform>%n nedēļas</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
-        <translation type="unfinished"/>
+        <translation>%1 un %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>%n gadi</numerusform><numerusform>%n gads</numerusform><numerusform>%n gadi</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
-        <translation type="unfinished"/>
+        <translation>Transakcijas pēc šī vel nebūs redzamas</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Brīdinājums</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
-        <translation type="unfinished"/>
+        <translation>Informācija</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Sinhronizēts</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Sinhronizējos...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transakcija nosūtīta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Ienākoša transakcija</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -691,17 +547,14 @@ Adrese: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Maciņš ir &lt;b&gt;šifrēts&lt;/b&gt; un pašlaik &lt;b&gt;atslēgts&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Maciņš ir &lt;b&gt;šifrēts&lt;/b&gt; un pašlaik &lt;b&gt;slēgts&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -709,7 +562,6 @@ Adrese: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Tīkla brīdinājums</translation>
     </message>
@@ -717,359 +569,285 @@ Adrese: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Kontroles Adrešu Atlase</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
-        <translation type="unfinished"/>
+        <translation>Daudzums:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
-        <translation type="unfinished"/>
+        <translation>Baiti:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Daudzums:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
-        <translation type="unfinished"/>
+        <translation>Prioritāte:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Maksa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Pēc Maksas:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
-        <translation type="unfinished"/>
+        <translation>Atlikums:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
-        <translation type="unfinished"/>
+        <translation>Koka režīms</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
-        <translation type="unfinished"/>
+        <translation>Saraksta režīms</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Daudzums</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adrese</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Datums</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished"/>
+        <translation>Apstiprinājumi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Apstiprināts</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
-        <translation type="unfinished"/>
+        <translation>Prioritāte</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopēt adresi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopēt nosaukumu</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopēt daudzumu</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt transakcijas ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt daudzumu</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt maksu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt pēc maksas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt baitus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt prioritāti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt atlikumu</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
-        <translation type="unfinished"/>
+        <translation>augstākais</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
-        <translation type="unfinished"/>
+        <translation>augstāks</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
-        <translation type="unfinished"/>
+        <translation>augsts</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
-        <translation type="unfinished"/>
+        <translation>vidēji-augsts</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
-        <translation type="unfinished"/>
+        <translation>vidējs</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
-        <translation type="unfinished"/>
+        <translation>zemi-vidējs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
-        <translation type="unfinished"/>
+        <translation>zems</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
-        <translation type="unfinished"/>
+        <translation>zemāks</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
-        <translation type="unfinished"/>
+        <translation>zemākais</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
-        <translation type="unfinished"/>
+        <translation>neviens</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
-        <translation type="unfinished"/>
+        <translation>jā</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
-        <translation type="unfinished"/>
+        <translation>nē</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(bez nosaukuma)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished"/>
+        <translation>atlikums no %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished"/>
+        <translation>(atlikums)</translation>
     </message>
 </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Mainīt adrese</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Nosaukums</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adrese</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Jauna saņemšanas adrese</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Jauna nosūtīšanas adrese</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Mainīt saņemšanas adresi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Mainīt nosūtīšanas adresi</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Nupat ierakstītā adrese &quot;%1&quot; jau atrodas adrešu grāmatā.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Ierakstītā adrese &quot;%1&quot; nav derīga Bitcoin adrese.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Nav iespējams atslēgt maciņu.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Neizdevās ģenerēt jaunu atslēgu.</translation>
     </message>
@@ -1077,27 +855,22 @@ Adrese: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
-        <translation type="unfinished"/>
+        <translation>vārds</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1105,52 +878,46 @@ Adrese: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core - Komandrindas iespējas</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versija</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Lietojums:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>komandrindas izvēles</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Lietotāja interfeisa izvēlnes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Uzstādiet valodu, piemēram &quot;de_DE&quot; (pēc noklusēšanas: sistēmas lokāle)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Sākt minimizētu</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Uzsākot, parādīt programmas informācijas logu (pēc noklusēšanas: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1158,339 +925,276 @@ Adrese: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
-        <translation type="unfinished"/>
+        <translation>Sveiciens</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
-        <translation type="unfinished"/>
+        <translation>Sveicināts Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
-        <translation type="unfinished"/>
+        <translation>Kļūda</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
-        <translation type="unfinished"/>
+        <translation>GB ar brīvo vietu pieejams</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
-        <translation type="unfinished"/>
+        <translation>(no %1GB nepieciešams)</translation>
     </message>
 </context>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
-        <translation type="unfinished"/>
+        <translation>Atvērt URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
-        <translation type="unfinished"/>
+        <translation>Atvērt maksājuma pieprasījumu no URI vai datnes</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
-        <translation type="unfinished"/>
+        <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
-        <translation type="unfinished"/>
+        <translation>Izvēlies maksājuma pieprasījuma datni</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
-        <translation type="unfinished"/>
+        <translation>Izvēlies maksājuma pieprasījuma datni lai atvēru</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Iespējas</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Galvenais</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>&amp;Maksāt par transakciju</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Automātiski sākt Bitcoin pēc pieteikšanās sistēmā.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Sākt Bitcoin reizē ar sistēmu</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
-        <translation type="unfinished"/>
+        <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Tīkls</translation>
     </message>
     <message>
-        <location line="-86"/>
-        <source>W&amp;allet</source>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>W&amp;allet</source>
+        <translation>&amp;Maciņš</translation>
+    </message>
+    <message>
+        <source>Expert</source>
+        <translation>Eksperts</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>Ieslēgt bitcoin &amp;kontroles funkcijas</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>&amp;Tērēt neapstiprinātu atlikumu</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Uz rūtera automātiski atvērt Bitcoin klienta portu. Tas strādā tikai tad, ja rūteris atbalsta UPnP un tas ir ieslēgts.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Kartēt portu, izmantojot &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Ports:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Proxy ports (piem. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Versija:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>proxy SOCKS versija (piem. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Logs</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Pēc loga minimizācijas rādīt tikai ikonu sistēmas teknē.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimizēt uz sistēmas tekni, nevis rīkjoslu</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Logu aizverot, minimizēt, nevis beigt darbu. Kad šī izvēlne iespējota, programma aizvērsies tikai pēc Beigt komandas izvēlnē.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimizēt aizverot</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Izskats</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Lietotāja interfeiss un &amp;valoda:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Šeit var iestatīt lietotāja valodu. Iestatījums aktivizēsies pēc Bitcoin pārstartēšanas.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Vienības, kurās attēlot daudzumus:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Izvēlēties dalījuma vienību pēc noklusēšanas, ko izmantot interfeisā un nosūtot bitkoinus.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Rādīt vai nē Bitcoin adreses transakciju sarakstā.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Attēlot adreses transakciju sarakstā</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished"/>
+        <translation>Vai rādīt Bitcoin kontroles funkcijas vai nē.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Atcelt</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>pēc noklusēšanas</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
-        <translation type="unfinished"/>
+        <translation>neviens</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Norādītā proxy adrese nav derīga.</translation>
     </message>
@@ -1498,69 +1202,54 @@ Adrese: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Forma</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Attēlotā informācija var būt novecojusi. Jūsu maciņš pēc savienojuma izveides automātiski sinhronizējas ar Bitcoin tīklu, taču šis process vēl nav beidzies.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Maciņš</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
-        <translation type="unfinished"/>
+        <translation>Pieejams:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
-        <translation type="unfinished"/>
+        <translation>Tava pašreizējā tērējamā bilance</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Nenobriedušu:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
-        <translation type="unfinished"/>
+        <translation>Kopā:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
-        <translation type="unfinished"/>
+        <translation>Jūsu kopējā tekošā bilance</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Pēdējās transakcijas&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>nav sinhronizēts</translation>
     </message>
@@ -1568,93 +1257,70 @@ Adrese: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1662,23 +1328,22 @@ Adrese: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ierakstiet Bitcoin adresi (piem. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1686,321 +1351,248 @@ Adrese: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Saglabāt Attēlu...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Kopēt Attēlu</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Saglabāt QR kodu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
-        <translation type="unfinished"/>
+        <translation>PNG Attēls (*.png)</translation>
     </message>
 </context>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Klienta vārds</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Klienta versija</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informācija</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
-        <translation type="unfinished"/>
+        <translation>Izmantotā OpenSSL versija</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Sākuma laiks</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Tīkls</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
-        <translation type="unfinished"/>
+        <translation>Vārds</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Savienojumu skaits</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Bloku virkne</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Pašreizējais bloku skaits</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Bloku skaita novērtējums</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Pēdējā bloka laiks</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Atvērt</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsole</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Tīkla Satiksme</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Notīrīt</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
-        <translation type="unfinished"/>
+        <translation>Kopsummas</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Kompilācijas datums</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Notīrīt konsoli</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Laipni lūgti Bitcoin RPC konsolē.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Izmantojiet bultiņas uz augšu un leju, lai pārvietotos pa vēsturi, un &lt;b&gt;Ctrl-L&lt;/b&gt; ekrāna notīrīšanai.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Ierakstiet &lt;b&gt;help&lt;/b&gt; lai iegūtu pieejamo komandu sarakstu.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
-        <translation type="unfinished"/>
+        <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
-        <translation type="unfinished"/>
+        <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
-        <translation type="unfinished"/>
+        <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
-        <translation type="unfinished"/>
+        <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
-        <translation type="unfinished"/>
+        <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
-        <translation type="unfinished"/>
+        <translation>%1 st</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
-        <translation type="unfinished"/>
+        <translation>%1 st %2 m</translation>
     </message>
 </context>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Daudzums:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Nosaukums:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Ziņojums:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished"/>
+        <translation>Notīrīt visus laukus formā.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation>Notīrīt</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
-        <translation type="unfinished"/>
+        <translation>Pieprasīto maksājumu vēsture</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Pieprasīt maksājumu</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
-        <translation type="unfinished"/>
+        <translation>Rādīt</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
-        <translation type="unfinished"/>
+        <translation>Noņemt</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopēt nosaukumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt ziņojumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopēt daudzumu</translation>
     </message>
@@ -2008,67 +1600,54 @@ Adrese: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
-        <translation type="unfinished"/>
+        <translation>QR Kods</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt &amp;Adresi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Saglabāt Attēlu</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
-        <translation type="unfinished"/>
+        <translation>Pieprasīt maksājumu uz %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
-        <translation type="unfinished"/>
+        <translation>Maksājuma informācija</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
-        <translation type="unfinished"/>
+        <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adrese</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Daudzums</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Nosaukums</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
-        <translation type="unfinished"/>
+        <translation>Ziņojums</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Rezultāta URI pārāk garš, mēģiniet saīsināt nosaukumu vai ziņojumu. </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Kļūda kodējot URI QR kodā.</translation>
     </message>
@@ -2076,285 +1655,225 @@ Adrese: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Datums</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Nosaukums</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
-        <translation type="unfinished"/>
+        <translation>Ziņojums</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Daudzums</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(bez nosaukuma)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
-        <translation type="unfinished"/>
+        <translation>(nav ziņojuma)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
-        <translation type="unfinished"/>
+        <translation>(nav summas)</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Sūtīt bitkoinus</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Kontroles Funkcijas</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
-        <translation type="unfinished"/>
+        <translation>Daudzums:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
-        <translation type="unfinished"/>
+        <translation>Baiti:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Daudzums:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
-        <translation type="unfinished"/>
+        <translation>Prioritāte:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Maksa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Pēc Maksas:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
-        <translation type="unfinished"/>
+        <translation>Atlikums:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
-        <translation type="unfinished"/>
+        <translation>Pielāgota atlikuma adrese</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Sūtīt vairākiem saņēmējiem uzreiz</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Pievienot Saņēmēju</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished"/>
+        <translation>Notīrīt visus laukus formā.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Notīrīt visu</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Bilance:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Apstiprināt nosūtīšanu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Sūtīt</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Apstiprināt bitkoinu sūtīšanu</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
-        <translation type="unfinished"/>
+        <translation>%1 līdz %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt daudzumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopēt daudzumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt maksu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt pēc maksas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt baitus</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt prioritāti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt atlikumu</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
-        <translation type="unfinished"/>
+        <translation>Kopējā Summa %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
-        <translation type="unfinished"/>
+        <translation>vai</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Nosūtāmajai summai jābūt lielākai par 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Daudzums pārsniedz pieejamo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Kopsumma pārsniedz pieejamo, ja pieskaitīta %1 transakcijas maksa.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Atrastas divas vienādas adreses, vienā nosūtīšanas reizē uz katru adresi var sūtīt tikai vienreiz.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished"/>
+        <translation>Transakcijas izveidošana neizdevās!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(bez nosaukuma)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
-        <translation type="unfinished"/>
+        <translation>pievienots kā transakcijas maksa</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
-        <translation type="unfinished"/>
+        <translation>Maksājuma pieprasījums ir novecojis</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2362,98 +1881,74 @@ Adrese: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Apjo&amp;ms</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Saņēmējs:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
-        <translation type="unfinished"/>
+        <translation>Adrese lai sūtītu maksājumu uz (piem. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Lai pievienotu adresi adrešu grāmatai, tai jādod nosaukums</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Nosaukums:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
-        <translation type="unfinished"/>
+        <translation>Šis ir parasts maksājums.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>ielīmēt adresi no starpliktuves</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
-        <translation type="unfinished"/>
+        <translation>Noņem šo ierakstu</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Ziņojums:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
-        <translation type="unfinished"/>
+        <translation>Šis ir pārbaudīts maksājuma pieprasījums.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
-        <translation type="unfinished"/>
+        <translation>Šis ir nepārbaudīts maksājuma pieprasījums.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
-        <translation type="unfinished"/>
+        <translation>Maksāt:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2461,12 +1956,10 @@ Adrese: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core tiek izslēgta...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2474,397 +1967,303 @@ Adrese: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
-        <translation type="unfinished"/>
+        <translation>Paraksti - Parakstīt / Pabaudīt Ziņojumu</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
-        <translation type="unfinished"/>
+        <translation>Parakstīt &amp;Ziņojumu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>ielīmēt adresi no starpliktuves</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
-        <translation type="unfinished"/>
+        <translation>Paraksts</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
-        <translation type="unfinished"/>
+        <translation>Parakstīt &amp;Ziņojumu</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Notīrīt visu</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Pārbaudīt Ziņojumu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Pārbaudīt Ziņojumu</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ierakstiet Bitcoin adresi (piem. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
-        <translation type="unfinished"/>
+        <translation>Nospied &quot;Parakstīt Ziņojumu&quot; lai ģenerētu parakstu</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
-        <translation type="unfinished"/>
+        <translation>Neizdevās parakstīt ziņojumu.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
-        <translation type="unfinished"/>
+        <translation>Ziņojums parakstīts.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
-        <translation type="unfinished"/>
+        <translation>Paraksts nevarēja tikt dekodēts.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
-        <translation type="unfinished"/>
+        <translation>Ziņojumu neizdevās pārbaudīt.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
-        <translation type="unfinished"/>
+        <translation>Ziņojums pārbaudīts.</translation>
     </message>
 </context>
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core izstrādātāji</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
-        <translation type="unfinished"/>
+        <translation>[testnets]</translation>
     </message>
 </context>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
-        <translation type="unfinished"/>
+        <translation>KB/s</translation>
     </message>
 </context>
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Atvērts līdz %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
-        <translation type="unfinished"/>
+        <translation>%1/bezsaistē</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/neapstiprinātas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 apstiprinājumu</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
-        <translation type="unfinished"/>
+        <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Datums</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
-        <translation type="unfinished"/>
+        <translation>Avots</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
-        <translation type="unfinished"/>
+        <translation>No</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
-        <translation type="unfinished"/>
+        <translation>Uz</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
-        <translation type="unfinished"/>
+        <translation>Transakcijas maksa</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
-        <translation type="unfinished"/>
+        <translation>Neto summa</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
-        <translation type="unfinished"/>
+        <translation>Ziņojums</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
-        <translation type="unfinished"/>
+        <translation>Komentārs</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
-        <translation type="unfinished"/>
+        <translation>Transakcijas ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
-        <translation type="unfinished"/>
+        <translation>Transakcija</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Daudzums</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
-        <translation type="unfinished"/>
+        <translation>patiess</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
-        <translation type="unfinished"/>
+        <translation>nepatiess</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, vēl nav veiksmīgi izziņots</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>nav zināms</translation>
     </message>
@@ -2872,12 +2271,10 @@ Adrese: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Transakcijas detaļas</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Šis panelis parāda transakcijas detaļas</translation>
     </message>
@@ -2885,127 +2282,102 @@ Adrese: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Datums</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tips</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adrese</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Daudzums</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Atvērts līdz %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Apstiprināts (%1 apstiprinājumu)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Neviens cits mezgls šo bloku nav saņēmis un droši vien netiks akceptēts!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Ģenerēts, taču nav akceptēts</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
-        <translation type="unfinished"/>
+        <translation>Bezsaitē</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
-        <translation type="unfinished"/>
+        <translation>Neapstiprināts</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Saņemts ar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Saņemts no</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Nosūtīts</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Maksājums sev</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Atrasts</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(nav pieejams)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transakcijas statuss. Turiet peli virs šī lauka, lai redzētu apstiprinājumu skaitu.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Transakcijas saņemšanas datums un laiks.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Transakcijas tips.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Transakcijas mērķa adrese.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Bilancei pievienotais vai atņemtais daudzums.</translation>
     </message>
@@ -3013,178 +2385,142 @@ Adrese: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Visi</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Šodien</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Šonedēļ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Šomēnes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Pēdējais mēnesis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Šogad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Diapazons...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Saņemts ar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Nosūtīts</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Sev</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Atrasts</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Cits</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Ierakstiet meklējamo nosaukumu vai adresi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimālais daudzums</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopēt adresi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopēt nosaukumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopēt daudzumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
-        <translation type="unfinished"/>
+        <translation>Kopēt transakcijas ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Mainīt nosaukumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Rādīt transakcijas detaļas</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
-        <translation type="unfinished"/>
+        <translation>Eksportēt Transakciju Vēsturi</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
-        <translation type="unfinished"/>
+        <translation>Eksportēšana Neizdevās</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
-        <translation type="unfinished"/>
+        <translation>Eksportēšana Veiksmīga</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Fails ar komatu kā atdalītāju (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Apstiprināts</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Datums</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tips</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Nosaukums</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adrese</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Daudzums</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Diapazons:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>uz</translation>
     </message>
@@ -3192,166 +2528,135 @@ Adrese: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
-        <translation type="unfinished"/>
+        <translation>Neviens maciņš nav ielādēts.</translation>
     </message>
 </context>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
-        <translation type="unfinished"/>
+        <translation>Sūtīt Bitkoinus</translation>
     </message>
 </context>
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Eksportēt...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Izveidot maciņa rezerves kopiju</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Maciņa dati (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Rezerves kopēšana neizdevās</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation type="unfinished"/>
+        <translation>Notikusi kļūme mēģinot saglabāt maciņa datus uz %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation type="unfinished"/>
+        <translation>Maciņa dati tika veiksmīgi saglabāti uz %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
-        <translation type="unfinished"/>
+        <translation>Dublēšana Veiksmīga</translation>
     </message>
 </context>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Lietojums:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Komandu saraksts</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Palīdzība par komandu</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Iespējas:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Norādiet konfigurācijas failu (pēc noklusēšanas: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Norādiet pid failu (pēc noklusēšanas: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Norādiet datu direktoriju</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Uzstādiet datu bāzes bufera izmēru megabaitos (pēc noklusēšanas: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Gaidīt savienojumus portā &lt;port&gt; (pēc noklusēšanas: 8333 vai testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Uzturēt līdz &lt;n&gt; savienojumiem ar citiem mezgliem(pēc noklusēšanas: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Pievienoties mezglam, lai iegūtu citu mezglu adreses, un atvienoties</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Norādiet savu publisko adresi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Slieksnis pārkāpējmezglu atvienošanai (pēc noklusēšanas: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Sekundes, cik ilgi atturēt pārkāpējmezglus no atkārtotas pievienošanās (pēc noklusēšanas: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Pieņemt komandrindas un JSON-RPC komandas</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Darbināt fonā kā servisu un pieņemt komandas</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Izmantot testa tīklu</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3366,722 +2671,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
-        <source>&lt;category&gt; can be:</source>
+        <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>&lt;category&gt; can be:</source>
+        <translation>&lt;category&gt; var būt:</translation>
+    </message>
+    <message>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core Process</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
+        <translation>Pievienot maksu par kB tām transakcijām kuras tu sūti</translation>
+    </message>
+    <message>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
-        <translation type="unfinished"/>
+        <translation>Ja &lt;category&gt; nav norādīta, izvadīt visu atkļūdošanas informāciju.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
-        <translation type="unfinished"/>
+        <translation>RPC klienta iespējas:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
-        <translation type="unfinished"/>
+        <translation>Pārbauda blokus...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
-        <translation type="unfinished"/>
+        <translation>Pārbauda maciņu...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
-        <translation type="unfinished"/>
+        <translation>Maciņa iespējas:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
-        <translation type="unfinished"/>
+        <translation>Informācija</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Debug/trace informāciju izvadīt konsolē, nevis debug.log failā</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
-        <translation type="unfinished"/>
+        <translation>Transakcija ir pārāk liela</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>JSON-RPC savienojumu lietotājvārds</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Brīdinājums</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>versija</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>JSON-RPC savienojumu parole</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Atļaut JSON-RPC savienojumus no norādītās IP adreses</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Nosūtīt komandas mezglam, kas darbojas adresē &lt;ip&gt; (pēc noklusēšanas: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Izpildīt komandu, kad labāk atbilstošais bloks izmainās (%s cmd aizvieto ar bloka hešu)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Atjaunot maciņa formātu uz jaunāko</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Uzstādīt atslēgu bufera izmēru uz &lt;n&gt; (pēc noklusēšanas: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Atkārtoti skanēt bloku virkni, meklējot trūkstošās maciņa transakcijas</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>JSON-RPC savienojumiem izmantot OpenSSL (https)</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Servera sertifikāta fails (pēc noklusēšanas: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Servera privātā atslēga (pēc noklusēšanas: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Šis palīdzības paziņojums</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Nevar pievienoties pie %s šajā datorā (pievienošanās atgrieza kļūdu %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Atļaut DNS uzmeklēšanu priekš -addnode, -seednode un -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Ielādē adreses...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Nevar ielādēt wallet.dat: maciņš bojāts</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Nevar ielādēt wallet.dat: maciņa atvēršanai nepieciešama jaunāka Bitcoin versija</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Bija nepieciešams pārstartēt maciņu: pabeigšanai pārstartējiet Bitcoin</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Kļūda ielādējot wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Nederīga -proxy adrese: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>-onlynet komandā norādīts nepazīstams tīkls: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Pieprasīta nezināma -socks proxy versija: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Nevar uzmeklēt -bind adresi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Nevar atrisināt -externalip adresi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nederīgs daudzums priekš -paytxfree=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Nederīgs daudzums</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Nepietiek bitkoinu</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Ielādē bloku indeksu...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Pievienot mezglu, kam pievienoties un turēt savienojumu atvērtu</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Nevar pievienoties %s uz šī datora. Bitcoin droši vien jau darbojas.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Ielādē maciņu...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Nevar maciņa formātu padarīt vecāku</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Nevar ierakstīt adresi pēc noklusēšanas</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Skanēju no jauna...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Ielāde pabeigta</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Izmantot opciju %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Kļūda</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ms_MY.ts
+++ b/src/qt/locale/bitcoin_ms_MY.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Klik dua kali untuk mengubah alamat atau label</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Cipta alamat baru</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Salin alamat terpilih ke dalam sistem papan klip</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Padam</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Fail yang dipisahkan dengan koma</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>Pilihan</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Baki</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Fail yang dipisahkan dengan koma</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Alamat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_nb.ts
+++ b/src/qt/locale/bitcoin_nb.ts
@@ -1,18 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="nb" version="2.1">
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="nb" version="2.0">
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Om Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;Bitcoin Core&lt;/b&gt; versjon</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Distribuert under MIT/X11 programvarelisensen, se medfølgende fil COPYING eller
 Dette produktet inneholder programvare utviklet av OpenSSL Project for bruk i OpenSSL Toolkit (http://www.openssl.org/), kryptografisk programvare skrevet av Eric Young (eay@cryptsoft.com) og UPnP programvare skrevet av Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Core utviklerne</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
-        <translation>(%1-bit)</translation>
+        <source>(%1-bit)</source>
+        <translation> (%1-bit)</translation>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
-        <translation>Dobbeltklikk for å redigere adresse eller merkelapp</translation>
+        <translation>Dobbelklikk for å redigere adresse eller merkelapp</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Lag en ny adresse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Ny</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopier den valgte adressen til systemets utklippstavle</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopier</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>&amp;Lukk</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopier Adresse</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Slett den valgte adressen fra listen.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Eksporter data fra nåværende fane til fil</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Eksporter</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Slett</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Velg adressen å sende mynter til</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Velg adressen til å motta mynter med</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Velg</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Utsendingsadresser</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Mottaksadresser</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Dette er dine Bitcoin-adresser for å sende betalinger. Alltid sjekk beløp og mottakeradresse før sending av mynter.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Dette er dine Bitcoin-adresser for å sende betalinger. Det er anbefalt å bruk en ny mottaksadresse for hver transaksjon.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopier &amp;Merkelapp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Rediger</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Ekporter Adresseliste</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommaseparert fil (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Ekport Feilet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>En feil oppstod ved lagring av adresselisten til %1.</translation>
     </message>
@@ -169,17 +138,14 @@ Dette produktet inneholder programvare utviklet av OpenSSL Project for bruk i Op
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Merkelapp</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(ingen merkelapp)</translation>
     </message>
@@ -187,140 +153,106 @@ Dette produktet inneholder programvare utviklet av OpenSSL Project for bruk i Op
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Dialog for Adgangsfrase</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Angi adgangsfrase</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Ny adgangsfrase</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Gjenta ny adgangsfrase</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Skriv inn den nye adgangsfrasen for lommeboken.&lt;br/&gt;Vennligst bruk en adgangsfrase med &lt;b&gt;10 eller flere tilfeldige tegn&lt;/b&gt;, eller &lt;b&gt;åtte eller flere ord&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Krypter lommebok</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Denne operasjonen krever adgangsfrasen til lommeboken for å låse den opp.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Lås opp lommebok</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Denne operasjonen krever adgangsfrasen til lommeboken for å dekryptere den.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dekrypter lommebok</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Endre adgangsfrase</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Skriv inn gammel og ny adgangsfrase for lommeboken.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Bekreft kryptering av lommebok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Advarsel: Hvis du krypterer lommeboken og mister adgangsfrasen, så vil du &lt;b&gt;MISTE ALLE DINE BITCOINS&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Er du sikker på at du vil kryptere lommeboken?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>VIKTIG: Tidligere sikkerhetskopier av din lommebokfil bør erstattes med den nylig genererte og krypterte filen, da de blir ugyldiggjort av sikkerhetshensyn så snart du begynner å bruke den nye krypterte lommeboken.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Advarsel: Caps Lock er på!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Lommebok kryptert</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin vil nå lukkes for å fullføre krypteringsprosessen. Husk at kryptering av lommeboken ikke fullt ut kan beskytte dine bitcoins fra å bli stjålet om skadevare infiserer datamaskinen.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Kryptering av lommebok feilet</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Kryptering av lommebok feilet på grunn av en intern feil. Din lommebok ble ikke kryptert.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>De angitte adgangsfrasene er ulike.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Opplåsing av lommebok feilet</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Adgangsfrasen angitt for dekryptering av lommeboken var feil.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Dekryptering av lommebok feilet</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Adgangsfrase for lommebok endret.</translation>
     </message>
@@ -328,363 +260,286 @@ Dette produktet inneholder programvare utviklet av OpenSSL Project for bruk i Op
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>Signer &amp;melding...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synkroniserer med nettverk...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Oversikt</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>Node</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Vis generell oversikt over lommeboken</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transaksjoner</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Vis transaksjonshistorikk</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Avslutt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Avslutt applikasjonen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Vis informasjon om Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Om &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Vis informasjon om Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Innstillinger...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Krypter Lommebok...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>Lag &amp;Sikkerhetskopi av Lommebok...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Endre Adgangsfrase...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;Utsendingsadresser...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;Mottaksadresser...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Åpne &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importere blokker...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Reindekserer blokker på harddisk...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Send til en Bitcoin-adresse</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Endre oppsett for Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Sikkerhetskopier lommebok til annet sted</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Endre adgangsfrasen brukt for kryptering av lommebok</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Feilsøkingsvindu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Åpne konsoll for feilsøk og diagnostikk</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verifiser melding...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Lommebok</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;Send</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Motta</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Vis / Skjul</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Vis eller skjul hovedvinduet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Krypter de private nøklene som tilhører lommeboken din</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Signer en melding med Bitcoin-adressene dine for å bevise at du eier dem</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Bekreft meldinger for å være sikker på at de ble signert av en angitt Bitcoin-adresse</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Fil</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Innstillinger</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Hjelp</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Verktøylinje for faner</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnett]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Forespør betalinger (genererer QR-koder og bitcoin: URIer)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;Om Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Vis listen av brukte utsendingsadresser og merkelapper</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Vis listen over bruke mottaksadresser og merkelapper</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Åpne en Bitcoin: URI eller betalingsetterspørring</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Kommandolinjevalg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Vis Bitcoin Core hjelpemeldingen for å få en liste med mulige kommandolinjevalg</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin-klienten</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktiv forbindelse til Bitcoin-nettverket</numerusform><numerusform>%n aktive forbindelser til Bitcoin-nettverket</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Ingen kilde for blokker tilgjengelig...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Lastet %1 av %2 (estimert) blokker med transaksjonshistorikk.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Lastet %1 blokker med transaksjonshistorikk.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n time</numerusform><numerusform>%n timer</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n dag</numerusform><numerusform>%n dager</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n uke</numerusform><numerusform>%n uker</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 og %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n år</numerusform><numerusform>%n år</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 bak</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Siste mottatte blokk ble generert for %1 siden.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transaksjoner etter dette vil ikke være synlige enda.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informasjon</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Ajour</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Kommer ajour...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Sendt transaksjon</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Innkommende transaksjon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +552,14 @@ Adresse: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Lommeboken er &lt;b&gt;kryptert&lt;/b&gt; og for tiden &lt;b&gt;ulåst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Lommeboken er &lt;b&gt;kryptert&lt;/b&gt; og for tiden &lt;b&gt;låst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+441"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>En fatal feil har inntruffet. Det er ikke trygt å fortsette og Bitcoin må derfor avslutte.</translation>
     </message>
@@ -715,7 +567,6 @@ Adresse: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Nettverksvarsel</translation>
     </message>
@@ -723,291 +574,230 @@ Adresse: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Myntkontroll Adresse Valg</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Mengde:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Beløp:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioritet:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Avgift:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Lav Utdata:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Etter Gebyr:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Veksel:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>velg (fjern) alt</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Tremodus</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Listemodus</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Beløp</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Bekreftelser</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Bekreftet</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioritet</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Kopier adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopier merkelapp</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopier beløp</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopier transaksjons-ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Lås ubrukte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Lås opp ubrukte</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Kopier mengde</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Kopier gebyr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Kopier fra gebyr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopier bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopier prioritet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Kopier svake utdata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopier veksel</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>høyest</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>høyere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>høy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>medium-høy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>medium</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>lav-medium</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>lav</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>lavere</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>lavest</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 låst)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>ingen</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Støv</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>ja</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>nei</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Denne merkelappen blir rød, hvis transaksjonsstørrelsen er større enn 1000 bytes.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Dette betyr at et gebyr på minst %1 per KB er påkrevd.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Kan variere +/- 1 byte per input.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Transaksjoner med høyere prioritet har mer sannsynlighet for å bli inkludert i en blokk.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Denne merkelappen blir rød, hvis prioriteten er mindre enn &quot;medium&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Denne merkelappen blir rød, hvis en mottaker mottar en mengde på mindre enn %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Dette betyr at et gebyr på minst %1 er påkrevd.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Mengder under 0.546 ganger minimum relégebyr er vist som støv.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Denne merkelappen blir rød, hvis endringen er mindre enn %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+63"/>
         <source>(no label)</source>
         <translation>(ingen merkelapp)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>veksel fra %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(veksel)</translation>
     </message>
@@ -1015,67 +805,54 @@ Adresse: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Rediger adresse</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Merkelapp</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>Merkelappen koblet til denne adresseliste oppføringen</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Adressen til denne oppføringen i adresseboken. Denne kan kun endres for utsendingsadresser.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adresse</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Ny mottaksadresse</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Ny utsendingsadresse</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Rediger mottaksadresse</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Rediger utsendingsadresse</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Den oppgitte adressen &quot;%1&quot; er allerede i adresseboken.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Den angitte adressed &quot;%1&quot; er ikke en gyldig Bitcoin-adresse.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Kunne ikke låse opp lommeboken.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Generering av ny nøkkel feilet.</translation>
     </message>
@@ -1083,27 +860,22 @@ Adresse: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>En ny datamappe vil bli laget.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>navn</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Mappe finnes allerede. Legg til %1 hvis du vil lage en ny mappe her.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Snarvei finnes allerede, og er ikke en mappe.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Kan ikke lage datamappe her.</translation>
     </message>
@@ -1111,52 +883,46 @@ Adresse: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - Kommandolinjevalg</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versjon</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Bruk:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>kommandolinjevalg</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>valg i brukergrensesnitt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Sett språk, for eksempel &quot;nb_NO&quot; (standardverdi: fra operativsystem)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Start minimert</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>Sett SSL-rotsertifikat for betalingsforespørsel (standard: -system-)</translation>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Vis splashskjerm ved oppstart (standardverdi: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Velg datamappe ved oppstart (standard: 0)</translation>
     </message>
@@ -1164,57 +930,46 @@ Adresse: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Velkommen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Velkommen til Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Siden dette er første gang programmet starter, kan du nå velge hvor Bitcoin Core skal lagre sine data.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core vil laste ned og lagre en kopi av Bitcoin sin blokkjede. Minst %1GB av data vil bli lagret i denne mappen, og det vil vokse over tid. Lommeboken vil også bli lagret i denne mappen.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Bruk standard datamappe</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Bruk en egendefinert datamappe:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Feil: Spesifisert datamappe &quot;%1&quot; kan ikke opprettes.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB ledig lagringsplass</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(av %1GB behøvd)</translation>
     </message>
@@ -1222,27 +977,22 @@ Adresse: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Åpne URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Åpne betalingsetterspørring fra URI eller fil</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Velg fil for betalingsetterspørring</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Velg fil for betalingsetterspørring å åpne</translation>
     </message>
@@ -1250,258 +1000,206 @@ Adresse: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Innstillinger</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Hoved</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Valgfritt transaksjonsgebyr per kB som sikrer at dine transaksjoner blir raskt prosessert. De fleste transaksjoner er 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Betal &amp;transaksjonsgebyr</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Start Bitcoin automatisk etter innlogging.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Start Bitcoin ved systeminnlogging</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>Størrelse på &amp;database hurtigbuffer</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>Antall script &amp;verifikasjonstråder</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Sett antall script verifikasjonstråder (opp til 16, 0 = automatisk, &lt;0 = la så mange kjerner være ledig, standardvalg: 0)</translation>
-    </message>
-    <message>
-        <location line="+153"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Koble til Bitcoin-nettverket gjennom en SOCKS proxy.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>&amp;Koble til gjennom SOCKS proxy (standardvalg proxy):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>IP-adressen til proxyen (f.eks. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation>Aktive kommandolinjevalg som overstyrer valgene ovenfor:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Tilbakestill alle klient valg til standard</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Tilbakestill Instillinger</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Nettverk</translation>
     </message>
     <message>
-        <location line="-95"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation>(0 = automatisk, &lt;0 = la så mange kjerner være ledig)</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation>L&amp;ommebok</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>Ekspert</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation>Aktiver &amp;myntkontroll funksjoner</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>Hvis du sperrer for bruk av ubekreftet veksel, kan ikke vekselen fra transaksjonen bli brukt før transaksjonen har minimum en bekreftelse. Dette påvirker også hvordan balansen din blir beregnet.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation>&amp;Bruk ubekreftet veksel</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Åpne automatisk Bitcoin klientporten på ruteren. Dette virker kun om din ruter støtter UPnP og dette er påslått.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Sett opp port ved hjelp av &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Proxyens port (f.eks. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Versjon:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Proxyens SOCKS versjon (f.eks. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Vindu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Vis kun ikon i systemkurv etter minimering av vinduet.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimer til systemkurv istedenfor oppgavelinjen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimerer vinduet istedenfor å avslutte applikasjonen når vinduet lukkes. Når dette er slått på avsluttes applikasjonen kun ved å velge avslutt i menyen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimer ved lukking</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Visning</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Språk for brukergrensesnitt</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Språket for brukergrensesnittet kan settes her. Innstillingen trer i kraft ved omstart av Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Enhet for visning av beløper:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Velg standard delt enhet for visning i grensesnittet og for sending av bitcoins.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Om Bitcoin-adresser skal vises i transaksjonslisten eller ikke.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Vis adresser i transaksjonslisten</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Skal myntkontroll funksjoner vises eller ikke.</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Avbryt</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>standardverdi</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>ingen</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Bekreft tilbakestilling av innstillinger</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Omstart av klienten er nødvendig for å aktivere endringene.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>Klienten vil bli lukket, vil du fortsette?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Denne endringen krever omstart av klienten.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Angitt proxyadresse er ugyldig.</translation>
     </message>
@@ -1509,69 +1207,54 @@ Adresse: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Skjema</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Informasjonen som vises kan være foreldet. Din lommebok synkroniseres automatisk med Bitcoin-nettverket etter at tilkobling er opprettet, men denne prosessen er ikke ferdig enda.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Lommebok</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Tilgjengelig:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Din nåværende saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>Under behandling:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Totalt antall ubekreftede transaksjoner som ikke teller med i saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Umoden:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Minet saldo har ikke modnet enda</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Totalt:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Din nåværende saldo</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Siste transaksjoner&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>ute av synk</translation>
     </message>
@@ -1579,93 +1262,70 @@ Adresse: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI-håndtering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI kunne ikke tolkes! Dette kan forårsakes av en ugyldig Bitcoin-adresse eller feil i URI-parametere.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Forespurt betalingsmengde på %1 er for liten (betraktet som støv).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Betalingsforespørsel feil</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Kan ikke starte Bitcoin: klikk-og-betal håndterer</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Nettleder advarsel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>Din aktive proxy har ikke støtte for SOCKS5, som er påkrevd for betalingsforespørsler via proxy.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>Hentelenke for betalingsforespørsel er ugyldig: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Filhåndtering for betalingsforespørsel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>Fil for betalingsforespørsel kan ikke leses eller behandles! Dette kan skyldes en ugyldig fil for betalingsforespørsel.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Uverifiserte betalingsforespørsler til egentilpassede betalingscript er ikke støttet.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Refundering fra %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Feil i kommunikasjonen med %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>Betalingsforespørsler kan ikke analyseres eller behandles!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Dårlig svar fra server %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Betaling erkjent</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Nettverksforespørsel feil</translation>
     </message>
@@ -1673,23 +1333,22 @@ Adresse: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+14"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Feil: Spesifisert datamappe &quot;%1&quot; finnes ikke.</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Feil: Kan ikke lese konfigurasjonsfil: %1. Bruk kun syntaksen nøkkel=verdi.</translation>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Feil: Ugyldig kombinasjon av -regtest og -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Skriv inn en Bitcoin-adresse (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1697,22 +1356,18 @@ Adresse: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Lagre Bilde...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Kopier Bilde</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Lagre QR-kode</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG-bilde (*.png)</translation>
     </message>
@@ -1720,194 +1375,146 @@ Adresse: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Klientnavn</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Klientversjon</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informasjon</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Feilsøkingsvindu</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Generelt</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Bruker OpenSSL versjon</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Oppstartstidspunkt</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Nettverk</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Navn</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Antall tilkoblinger</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Blokkjeden</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Nåværende antall blokker</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Estimert totalt antall blokker</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Tidspunkt for siste blokk</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Åpne</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsoll</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Nettverkstrafikk</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Fjern</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totalt</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>Inn:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>Ut:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Byggedato</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Loggfil for feilsøk</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Åpne Bitcoin sin loggfil for feilsøk fra den gjeldende datamappen. Dette kan ta noen sekunder for store loggfiler.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Tøm konsoll</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Velkommen til Bitcoin sin RPC-konsoll.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Bruk opp og ned pil for å navigere historikken, og &lt;b&gt;Ctrl-L&lt;/b&gt; for å tømme skjermen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Skriv &lt;b&gt;help&lt;/b&gt; for en oversikt over kommandoer.</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 t</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 t %2 m</translation>
     </message>
@@ -1915,105 +1522,82 @@ Adresse: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Beløp:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Merkelapp:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Melding:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Gjenbruk en av de tidligere brukte mottaksadressene. Gjenbruk av adresser har sikkerhets- og personvernsutfordringer. Ikke bruk dette med unntak for å gjennopprette en betalingsforespørsel som ble gjort tidligere.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>Gj&amp;enbruk en eksisterende mottaksadresse (ikke anbefalt)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>En valgfri melding å tilknytte betalingsforespørselen, som vil bli vist når forespørselen er åpnet. Meldingen vil ikke bli sendt med betalingen over Bitcoin-nettverket.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>En valgfri merkelapp å tilknytte den nye mottakeradressen.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Bruk dette skjemaet til betalingsforespørsler. Alle felt er &lt;b&gt;valgfrie&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Et valgfritt beløp å etterspørre. La stå tomt eller null for ikke å etterspørre et spesifikt beløp.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Fjern alle felter fra skjemaet.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Fjern</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Etterspurt betalingshistorikk</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Etterspør betaling</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>Vis den valgte etterspørringen (gjør det samme som å dobbelklikke på en oppføring)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Vis</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation>Fjern de valgte oppføringene fra listen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Fjern</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Kopier merkelapp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Kopier melding</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopier beløp</translation>
     </message>
@@ -2021,67 +1605,54 @@ Adresse: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR-kode</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Kopier &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Kopier &amp;Adresse</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Lagre Bilde...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Etterspør betaling til %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Betalingsinformasjon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Beløp</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Merkelapp</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Melding</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Resultat URI for lang, prøv å redusere teksten for merkelapp / melding.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Feil ved koding av URI til QR-kode.</translation>
     </message>
@@ -2089,37 +1660,30 @@ Adresse: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Merkelapp</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Melding</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Beløp</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(ingen merkelapp)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(ingen melding)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(intet beløp)</translation>
     </message>
@@ -2127,247 +1691,194 @@ Adresse: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Send Bitcoins</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Myntkontroll Funksjoner</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Inndata...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>automatisk valgte</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Utilstrekkelige midler!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Mengde:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Beløp:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioritet:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Gebyr:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Svak Utdata:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Etter Gebyr:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Veksel:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Hvis dette er aktivert, men adressen for veksel er tom eller ugyldig, vil veksel bli sendt til en nylig generert adresse.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Egendefinert adresse for veksel</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Send til flere enn en mottaker</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Legg til &amp;Mottaker</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Fjern alle felter fra skjemaet.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Fjern &amp;Alt</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Bekreft sending</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>S&amp;end</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Bekreft sending av bitcoins</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 til %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Kopier mengde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopier beløp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Kopier gebyr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Kopier fra gebyr</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopier bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopier prioritet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Kopier svake utdata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopier veksel</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Totalt Beløp %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>eller</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresse for mottaker er ugyldig.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Beløpet som skal betales må være over 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Beløpet overstiger saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Totalbeløpet overstiger saldo etter at %1 transaksjonsgebyr er lagt til.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Doble antall adresser funnet. Kan bare sende en gang til hver adresse per operasjon.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Opprettelse av transaksjon feilet!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Transaksjonen ble avvist!  Dette kan skje hvis noen av myntene i lommeboken allerede er brukt, som hvis du kopierte wallet.dat og mynter ble brukt i kopien uten å bli markert som brukt her.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Advarsel: Ugyldig Bitcoin-adresse</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ingen merkelapp)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Advarsel: Ukjent adresse for veksel</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Er du sikker på at du vil sende?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>lagt til som transaksjonsgebyr</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Betalingsforespørsel utgått</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Ugyldig betalingsadresse %1</translation>
     </message>
@@ -2375,98 +1886,74 @@ Adresse: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Beløp:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Betal &amp;Til:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adressen betalingen skal sendes til  (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Skriv inn en merkelapp for denne adressen for å legge den til i din adressebok</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Merkelapp:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Velg tidligere brukt adresse</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Dette er en normal betaling.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Lim inn adresse fra utklippstavlen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Fjern denne oppføringen</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Melding:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Dette er en verifisert betalingsetterspørring</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Skriv inn en merkelapp for denne adressen for å legge den til listen av brukte adresser</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>En melding som var tilknyttet bitcoinen: URI vil bli lagret med transaksjonen for din oversikt. Denne meldingen vil ikke bli sendt over Bitcoin-nettverket.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Dette er en uverifisert betalingsetterspørring</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Betal Til:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memo:</translation>
     </message>
@@ -2474,12 +1961,10 @@ Adresse: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Core lukker...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Slå ikke av datamaskinen før dette vinduet forsvinner.</translation>
     </message>
@@ -2487,186 +1972,142 @@ Adresse: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Signaturer - Signer / Verifiser en Melding</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Signer Melding</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Du kan signere meldinger med dine adresser for å bevise at du eier dem. Ikke signer vage meldinger da phishing-angrep kan prøve å lure deg til å signere din identitet over til andre. Signer kun fullt detaljerte utsagn som du er enig i.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adressen for signering av meldingen (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Velg tidligere brukt adresse</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Lim inn adresse fra utklippstavlen</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Skriv inn meldingen du vil signere her</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Signatur</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Kopier valgt signatur til utklippstavle</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Signer meldingen for å bevise at du eier denne Bitcoin-adressen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Signer &amp;Melding</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Tilbakestill alle felter for meldingssignering</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Fjern &amp;Alt</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verifiser Melding</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Angi adresse for signering, melding (vær sikker på at du kopierer linjeskift, mellomrom, tab, etc. helt nøyaktig) og signatur under for å verifisere meldingen. Vær forsiktig med at du ikke gir signaturen mer betydning enn det som faktisk står i meldingen, for å unngå å bli lurt av såkalte &quot;man-in-the-middle&quot; angrep.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adressen meldingen var signert med (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verifiser meldingen for å være sikker på at den ble signert av den angitte Bitcoin-adressen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verifiser &amp;Melding</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Tilbakestill alle felter for meldingsverifikasjon</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Skriv inn en Bitcoin-adresse (f.eks. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Klikk &quot;Signer Melding&quot; for å generere signatur</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Angitt adresse er ugyldig.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Vennligst sjekk adressen og prøv igjen.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Angitt adresse refererer ikke til en nøkkel.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Opplåsing av lommebok ble avbrutt.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Privat nøkkel for den angitte adressen er ikke tilgjengelig.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Signering av melding feilet.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Melding signert.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Signaturen kunne ikke dekodes.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Vennligst sjekk signaturen og prøv igjen.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Signaturen passer ikke til meldingen.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Verifikasjon av melding feilet.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Melding verifisert.</translation>
     </message>
@@ -2674,17 +2115,14 @@ Adresse: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Core utviklerne</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnett]</translation>
     </message>
@@ -2692,7 +2130,6 @@ Adresse: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2700,184 +2137,138 @@ Adresse: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Åpen til %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>konflikt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/frakoblet</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/ubekreftet</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 bekreftelser</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, kringkast gjennom %n node</numerusform><numerusform>, kringkast gjennom %n noder</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Kilde</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generert</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Fra</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Til</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>egen adresse</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>merkelapp</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Kredit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>blir moden om %n blokk</numerusform><numerusform>blir moden om %n blokker</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>ikke akseptert</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debet</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Transaksjonsgebyr</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Nettobeløp</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Melding</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Transaksjons-ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Forhandler</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Genererte bitcoins må modnes %1 blokker før de kan brukes. Da du genererte denne blokken ble den kringkastet på nettverket for å bli lagt til i kjeden av blokker. Hvis den ikke kommer med i kjeden vil den endre seg til &quot;ikke akseptert&quot; og pengene vil ikke kunne brukes. Dette vil noen ganger skje hvis en annen node genererer en blokk noen sekunder i tid fra din egen.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Informasjon for feilsøk</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transaksjon</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Inndata</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Beløp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>sann</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>usann</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, har ikke blitt kringkastet med hell enda</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Åpen for %n blokk til</numerusform><numerusform>Åpen for %n blokker til</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>ukjent</translation>
     </message>
@@ -2885,12 +2276,10 @@ Adresse: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Transaksjonsdetaljer</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Her vises en detaljert beskrivelse av transaksjonen</translation>
     </message>
@@ -2898,127 +2287,102 @@ Adresse: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Beløp</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>Umoden (%1 bekreftelser, vil være tilgjengelig etter %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Åpen for %n blokk til</numerusform><numerusform>Åpen for %n blokker til</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Åpen til %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bekreftet (%1 bekreftelser)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Denne blokken har ikke blitt mottatt av noen andre noder og vil sannsynligvis ikke bli akseptert!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generert men ikke akseptert</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Frakoblet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Ubekreftet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Bekrefter (%1 av %2 anbefalte bekreftelser)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>Konflikt</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Mottatt med</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Mottatt fra</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Sendt til</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Betaling til deg selv</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Utvunnet</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>-</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transaksjonsstatus. Hold muspekeren over dette feltet for å se antall bekreftelser.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Dato og tid for da transaksjonen ble mottat.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Type transaksjon.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Mottaksadresse for transaksjonen.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Beløp fjernet eller lagt til saldo.</translation>
     </message>
@@ -3026,178 +2390,142 @@ Adresse: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Alle</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>I dag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Denne uken</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Denne måneden</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Forrige måned</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Dette året</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Intervall...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Mottatt med</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Sendt til</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Til deg selv</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Utvunnet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Andre</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Skriv inn adresse eller merkelapp for søk</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimumsbeløp</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopier adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopier merkelapp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopier beløp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopier transaksjons-ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Rediger merkelapp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Vis transaksjonsdetaljer</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Eksporter Transaksjonshistorikk</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Ekport Feilet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>En feil oppstod ved lagring av transaksjonshistorikken til %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Ekport Fullført</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>Transaksjonshistorikken ble lagret til %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommaseparert fil (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Bekreftet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Dato</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Merkelapp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresse</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Beløp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Intervall:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>til</translation>
     </message>
@@ -3205,7 +2533,6 @@ Adresse: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Ingen lommebok har blitt lastet.</translation>
     </message>
@@ -3213,7 +2540,6 @@ Adresse: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Send Bitcoins</translation>
     </message>
@@ -3221,42 +2547,34 @@ Adresse: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Eksporter</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Eksporter data fra nåværende fane til fil</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Sikkerhetskopier Lommebok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Lommebokdata (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Sikkerhetskopiering Feilet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>En feil oppstod ved lagring av lommebok til %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Lommeboken ble lagret til %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Sikkerhetskopiering Fullført</translation>
     </message>
@@ -3264,102 +2582,86 @@ Adresse: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+226"/>
         <source>Usage:</source>
         <translation>Bruk:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>List opp kommandoer</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Vis hjelpetekst for en kommando</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Innstillinger:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Angi konfigurasjonsfil (standardverdi: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Angi pid-fil (standardverdi: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Angi mappe for datafiler</translation>
     </message>
     <message>
-        <location line="-35"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Lytt etter tilkoblinger på &lt;port&gt; (standardverdi: 8333 eller testnett: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Hold maks &lt;n&gt; koblinger åpne til andre noder (standardverdi: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Koble til node for å hente adresser til andre noder, koble så fra igjen</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Angi din egen offentlige adresse</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Grenseverdi for å koble fra noder med dårlig oppførsel (standardverdi: 100)</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Antall sekunder noder med dårlig oppførsel hindres fra å koble til på nytt (standardverdi: 86400)</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>En feil oppstod ved opprettelse av RPC-port %u for IPv4: %s</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Lytt etter JSON-RPC tilkoblinger på &lt;port&gt; (standardverdi: 8332 eller testnett: 18332)</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Ta imot kommandolinje- og JSON-RPC-kommandoer</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation>Bitcoin Core RPC-klientversjon</translation>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Kjør i bakgrunnen som daemon og ta imot kommandoer</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Bruk testnettverket</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Ta imot tilkoblinger fra utsiden (standardverdi: 1 hvis uten -proxy eller -connect)</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3383,732 +2685,682 @@ Det er også anbefalt at å sette varselsmelding slik du får melding om problem
 For eksempel: varselmelding=echo %%s | mail -s &quot;Bitcoin Varsel&quot; admin@foo.com</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Akseptable krypteringsmetoder (standardverdi: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>En feil oppstod under oppsettet av RPC-port %u for IPv6, tilbakestilles til IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Bind til angitt adresse. Bruk [vertsmaskin]:port notasjon for IPv6</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation>Ratebegrens gratistransaksjoner kontinuerlig til &lt;n&gt;*1000 bytes per minutt (standard: 15)</translation>
+    </message>
+    <message>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Gå til modus for regresjonstesting, som bruker en spesiell blokkjede der blokker kan bli løst momentant. Dette er tenkt til verktøy for regresjonstesting og apputvikling.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>Gå til modus for regresjonstesting, som bruker en spesiell blokkjede der blokker kan bli løst momentant.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation>Feil: Lytting etter innkommende tilkoblinger feilet (lytting returnerte feil %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Feil: Transaksjonen ble avvist! Dette kan skje hvis noen av myntene i lommeboken allerede er blitt brukt, som om du brukte en kopi av wallet.dat og myntene ble brukt i kopien, men ikke markert som brukt her.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Feil: Denne transaksjonen trenger en gebyr på minst %s på grunn av beløpet, kompleksiteten eller bruk av allerede mottatte penger!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Kjør kommando når en lommeboktransaksjon endres (%s i kommando er erstattet med TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation>Gebyr mindre enn dette er betraktet som intet gebyr (for laging av transaksjoner) (standardverdi:</translation>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation>Overfør aktiviteten i databasen fra minnelageret til loggen på harddisken for hver &lt;n&gt; megabytes (standardverdi: 100)</translation>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation>Hvor grundig blokkverifiseringen til -checkblocks er (0-4, standard: 3)</translation>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation>I denne modusen kontrollerer -genproclimit hvor mange blokker som genereres øyeblikkelig.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation>Angi antall tråder for skriptverifisering (%u til %d, 0 = auto, &lt;0 = la det antallet kjerner være ledig, standard: %d)</translation>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation>Sett prosessorgrensen for når blokkutvinning er på (-1 = ubegrenset, standard: -1)</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Dette er en forhåndssluppet testversjon - bruk på egen risiko - ikke for bruk til blokkutvinning eller bedriftsapplikasjoner</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation>Ute av stand til å binde til %s på denne datamaskinen. Bitcoin Core kjører sannsynligvis allerede.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Bruk separate SOCKS5 proxyer for å nå noder via Tor skjulte tjenester (standardverdi: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Advarsel: -paytxfee er satt veldig høyt! Dette er transaksjonsgebyret du betaler når du sender transaksjoner.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Advarsel: Vennligst undersøk at din datamaskin har riktig dato og klokkeslett! Hvis klokken er stilt feil vil ikke Bitcoin fungere riktig.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Advarsel: Nettverket ser ikke ut til å være enig! Noen minere ser ut til å ha problemer.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Advarsel: Vi ser ikke ut til å være enige med våre noder! Du må oppgradere, eller andre noder må oppgradere.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Advarsel: Feil ved lesing av wallet.dat! Alle nøkler lest riktig, men transaksjonsdataene eller oppføringer i adresseboken mangler kanskje eller er feil.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Advarsel: wallet.dat korrupt, data reddet! Original wallet.dat lagret som wallet.{timestamp}.bak i %s; hvis din saldo eller dine transaksjoner ikke er korrekte bør du gjenopprette fra en backup.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation>(standardverdi: 1)</translation>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation>(standardverdi: wallet.dat)</translation>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; kan være:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Forsøk å berge private nøkler fra en korrupt wallet.dat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Bitcoin Core Daemon</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Bitcoin RPC klientversjon</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Valg for opprettelse av blokker:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Tøm listen over transaksjoner i lommeboken (diagnoseverktøy; impliserer -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Koble kun til angitt(e) node(r)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Koble til via SOCKS proxy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Koble til JSON-RPC på &lt;port&gt; (default: 8332 eller testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>Innstillinger for tilkobling:</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Oppdaget korrupt blokkdatabase</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation>Valg for feilsøking/testing:</translation>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation>Slå av sikkerhetsmodus, overstyr en virkelig sikkerhetsmodushendelse (standard: 0)</translation>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Oppdag egen IP-adresse (standardverdi: 1 ved lytting og uten -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Ikke last inn lommeboken og deaktiver RPC-kall</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Ønsker du å gjenopprette blokkdatabasen nå?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Feil under initialisering av blokkdatabase</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Feil under oppstart av lommeboken sitt databasemiljø %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Feil ved lasting av blokkdatabase</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Feil under åpning av blokkdatabase</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Feil: Lite ledig lagringsplass!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Feil: Lommebok låst, kan ikke opprette transaksjon!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Feil: systemfeil:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Kunne ikke lytte på noen port. Bruk -listen=0 hvis det er dette du vil.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Feil ved lesing av blokkinfo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Feil ved lesing av blokk</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Feil ved synkronisering av blokkindeks</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Ved feil skriving av blokkindeks</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Feil ved skriving av blokkinfo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Feil ved skriving av blokk</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Feil ved skriving av filinfo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Feil ved skriving til bitcoin sin database</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Feil ved skriving av transaksjonsindeks</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Feil ved skriving av angredata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Gebyr per kB for transaksjoner du sender</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation>Gebyrer mindre enn dette vil anses som gebyrfrie (for videresending) (standard:</translation>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Finn andre noder gjennom DNS-oppslag (standardverdi: 1 med mindre -connect er oppgitt)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation>Tving sikkerhetsmodus (standard: 0)</translation>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generer bitcoins (standardverdi: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Hvor mange blokker skal sjekkes ved oppstart (standardverdi: 288, 0 = alle)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Hvor grundig verifisering av blokker gjøres (0-4, standardverdi: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>Hvis &lt;category&gt; ikke er oppgitt, ta ut all informasjon om feilsøking.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Ugyldig eller ingen skaperblokk funnet. Feil datamappe for nettverk?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Ugyldig -onion adresse: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>For få fildeskriptorer tilgjengelig.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>Sett inn tidsstempel i front av feilsøkingsdata (standardverdi: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>Innstillinger for RPC-klient:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Gjenopprett blokkjedeindeks fra blk000??.dat filer</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Velg versjon av SOCKS -proxy (4 eller 5, standardverdi: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Send kommando til Bitcoin-tjener</translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation>Sett databasen sin størrelse på hurtigbufferen i megabytes (%d til %d, standardverdi: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Sett maks blokkstørrelse i bytes (standardverdi: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Sett nummer av tråder til betjening av RPC-kall (standardverdi: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Angi lommebokfil (inne i datamappe)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Bruk ubekreftet veksel ved sending av transaksjoner (standardverdi: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Start Bitcoin-tjener</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>Dette er tiltenkt verktøy for regresjonstesting og apputvikling.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Bruk (foreldet, bruk bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verifiserer blokker...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Verifiserer lommebok...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Vent på start av RPC-tjeneren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Lommebok %s befinner seg utenfor datamappe %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Valg for lommebok:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Advarsel: Utløpt argument -debugnet ignorert, bruk -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Du må gjenoppbygge databasen med å bruke -reindex for å endre -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importerer blokker fra ekstern fil blk000??.dat</translation>
     </message>
     <message>
-        <location line="-126"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation>Ute av stand til å låse datamappen %s. Bitcoin Core kjører sannsynligvis allerede.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Utfør kommando når et relevant varsel er mottatt eller vi ser en veldig lang gaffel (%s i kommando er erstattet med melding)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Ta ut feilsøkingsinformasjon (standardverdi: 0, bruk av &lt;category&gt; er valgfritt)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Sett maksimum størrelse for transaksjoner med høy prioritet / lavt gebyr, i bytes (standardverdi: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Sett antall script verifikasjonstråder (opp til 16, 0 = automatisk, &lt;0 = la så mange kjerner være ledig, standardvalg: 0)</translation>
-    </message>
-    <message>
-        <location line="+91"/>
         <source>Information</source>
         <translation>Informasjon</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ugyldig mengde for -minrelaytxfee=&lt;beløp&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ugyldig mengde for -mintxfee=&lt;beløp&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation>Begrens størrelsen på signatur-hurtigbufferen til &lt;n&gt; oppføringer (standard: 50000)</translation>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation>Logg transaksjonsprioritet og gebyr per kB under blokkutvinning (standard: 0)</translation>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Oppretthold en full transaksjonsindeks (standard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maks mottaksbuffer per forbindelse, &lt;n&gt;*1000 bytes (standardverdi: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maks sendebuffer per forbindelse, &lt;n&gt;*1000 bytes (standardverdi: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Aksepter kun en blokkjede som passer med innebygde sjekkpunkter (standardvalg: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Koble kun til noder i nettverket &lt;nett&gt; (IPv4, IPv6 eller Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation>Skriv ut blokken ved oppstart, hvis funnet i blokkindeksen</translation>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation>Skriv ut blokktreet ved oppstart (standardverdi: 0)</translation>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>RPC SSL-valg: (se Bitcoin Wiki for oppsettsinstruksjoner for SSL)</translation>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>Innstillinger for RPC-server:</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation>Slumpvis dropp 1 av hver &lt;n&gt; nettverksmeldinger</translation>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation>Slumpvis bland 1 av hver &lt;n&gt; nettverksmeldinger</translation>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation>Kjør en tråd som skriver lommeboken til disk periodisk (standard: 1)</translation>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL valg: (se Bitcoin Wiki for instruksjoner for oppsett av SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation>Send kommando til Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Send spor-/feilsøkingsinformasjon til konsollen istedenfor filen debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Sett minimum blokkstørrelse i bytes (standardverdi: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation>Setter flagget DB_PRIVATE i miljøet til lommebokdatabasen (standard: 1)</translation>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>Vis alle feilsøkingsvalg (bruk: --help -help-debug)</translation>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation>Vis informasjon om ytelsesmål (standard: 0)</translation>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Krymp filen debug.log når klienten starter (standardverdi: 1 hvis uten -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Signering av transaksjon feilet</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Angi tidsavbrudd for forbindelse i millisekunder (standardverdi: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation>Start Bitcoin Core Daemon</translation>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Systemfeil:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Transaksjonen er for liten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Transaksjonsbeløpet må være positivt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transaksjonen er for stor</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Bruk UPnP for lytteport (standardverdi: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Bruk UPnP for lytteport (standardverdi: 1 ved lytting)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Brukernavn for JSON-RPC forbindelser</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Advarsel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Advarsel: Denne versjonen er foreldet, oppgradering kreves!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Zapper alle transaksjoner fra lommeboken...</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>ved oppstart</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>versjon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat korrupt, bergning feilet</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Passord for JSON-RPC forbindelser</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Tillat JSON-RPC tilkoblinger fra angitt IP-adresse</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Send kommandoer til node på &lt;ip&gt; (standardverdi: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-134"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Utfør kommando når beste blokk endrer seg (%s i kommandoen erstattes med blokkens hash)</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Oppgrader lommebok til nyeste format</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Angi størrelsen på nøkkellageret til &lt;n&gt; (standardverdi: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Se gjennom blokkjeden etter manglende lommeboktransaksjoner</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Bruk OpenSSL (https) for JSON-RPC forbindelser</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Servers sertifikat (standardverdi: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Servers private nøkkel (standardverdi: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Denne hjelpemeldingen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Kan ikke binde til %s på denne datamaskinen (bind returnerte feil %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Tillat oppslag i DNS for -addnode, -seednode og -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Laster adresser...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Feil ved lasting av wallet.dat: Lommeboken er skadet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Feil ved lasting av wallet.dat: Lommeboken krever en nyere versjon av Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Lommeboken måtte skrives om: start Bitcoin på nytt for å fullføre</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Feil ved lasting av wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ugyldig -proxy adresse: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Ukjent nettverk angitt i -onlynet &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Ukjent -socks proxyversjon angitt: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kunne ikke slå opp -bind adresse: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Kunne ikke slå opp -externalip adresse: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ugyldig beløp for -paytxfee=&lt;beløp&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Ugyldig beløp</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Utilstrekkelige midler</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Laster blokkindeks...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Legg til node for tilkobling og hold forbindelsen åpen</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Loading wallet...</source>
         <translation>Laster lommebok...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Kan ikke nedgradere lommebok</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Kan ikke skrive standardadresse</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Leser gjennom...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Ferdig med lasting</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>For å bruke %s opsjonen</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Feil</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_nl.ts
+++ b/src/qt/locale/bitcoin_nl.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Over Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt; Bitcoin Core&lt;/b&gt; versie</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,18 +24,14 @@ Gedistribueerd onder de MIT/X11 software licentie, zie het bijgevoegde bestand C
 Dit product bevat software ontwikkeld door het OpenSSL Project voor gebruik in de OpenSSL Toolkit (http://www.openssl.org/) en cryptografische software gemaakt door Eric Young (eay@cryptsoft.com) en UPnP software geschreven door Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Auteursrecht</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>De Bitcoin Core ontwikkelaars</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation>(%1-bit)</translation>
     </message>
@@ -46,122 +39,98 @@ Dit product bevat software ontwikkeld door het OpenSSL Project voor gebruik in d
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dubbelklik om adres of label te wijzigen</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Maak een nieuw adres aan</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nieuw</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopieer het huidig geselecteerde adres naar het klembord</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopieer</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>S&amp;luiten</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopiëer Adres</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Verwijder het geselecteerde adres van de lijst</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exporteer de data in de huidige tab naar een bestand</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exporteer</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Verwijder</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Kies het adres om munten naar te versturen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Kies het adres om munten voor te ontvangen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>K&amp;iezen</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Bezig met versturen adressen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Adressen ontvangen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Dit zijn uw Bitcoinadressen om betalingen mee te verzenden. Check altijd het bedrag en het ontvangende adres voordat u uw bitcoins verzendt.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Dit zijn uw Bitcoin-adressen waarmee u kunt betalen. We raden u aan om een nieuw ontvangstadres voor elke transactie te gebruiken.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopiëer &amp;Label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Bewerk</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exporteer adreslijst</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommagescheiden bestand (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Export Mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Een fout is opgetreden tijdens het opslaan van deze adreslijst naar %1.</translation>
     </message>
@@ -169,17 +138,14 @@ Dit product bevat software ontwikkeld door het OpenSSL Project voor gebruik in d
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(geen label)</translation>
     </message>
@@ -187,140 +153,106 @@ Dit product bevat software ontwikkeld door het OpenSSL Project voor gebruik in d
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Wachtwoorddialoogscherm</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Voer wachtwoord in</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nieuw wachtwoord</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Herhaal nieuw wachtwoord</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Vul een nieuw wachtwoord in voor uw portemonnee. &lt;br/&gt; Gebruik een wachtwoord van &lt;b&gt;10 of meer lukrake karakters&lt;/b&gt;, of &lt;b&gt;acht of meer woorden&lt;/b&gt; . </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Versleutel portemonnee</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Deze operatie vereist uw portemonneewachtwoord om de portemonnee te openen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Open portemonnee</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Deze operatie vereist uw portemonneewachtwoord om de portemonnee te ontsleutelen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Ontsleutel portemonnee</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Wijzig wachtwoord</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Vul uw oude en nieuwe portemonneewachtwoord in.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Bevestig versleuteling van de portemonnee</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Waarschuwing: Als u uw portemonnee versleutelt en uw wachtwoord vergeet, zult u &lt;b&gt;AL UW BITCOINS VERLIEZEN&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Weet u zeker dat u uw portemonnee wilt versleutelen?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>BELANGRIJK: Elke eerder gemaakte backup van uw portemonneebestand dient u te vervangen door het nieuw gegenereerde, versleutelde portemonneebestand. Om veiligheidsredenen zullen eerdere backups van het niet-versleutelde portemonneebestand onbruikbaar worden zodra u uw nieuwe, versleutelde, portemonnee begint te gebruiken.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Waarschuwing: De Caps-Lock-toets staat aan!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Portemonnee versleuteld</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin zal nu afsluiten om het versleutelingsproces te voltooien. Onthoud dat het versleutelen van uw portemonnee u niet volledig kan beschermen: Malware kan uw computer infecteren en uw bitcoins stelen.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Portemonneeversleuteling mislukt</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Portemonneeversleuteling mislukt door een interne fout. Uw portemonnee is niet versleuteld.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>De opgegeven wachtwoorden komen niet overeen</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Portemonnee openen mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Het opgegeven wachtwoord voor de portemonnee-ontsleuteling is niet correct.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Portemonnee-ontsleuteling mislukt</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Portemonneewachtwoord is met succes gewijzigd.</translation>
     </message>
@@ -328,363 +260,286 @@ Dit product bevat software ontwikkeld door het OpenSSL Project voor gebruik in d
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;Onderteken bericht...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synchroniseren met netwerk...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Overzicht</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>Node</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Toon algemeen overzicht van de portemonnee</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transacties</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Blader door transactieverleden</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Afsluiten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Programma afsluiten</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Laat informatie zien over Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Over &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Toon informatie over Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>O&amp;pties...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Versleutel Portemonnee...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Backup Portemonnee...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Wijzig Wachtwoord</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;Adressen aan het versturen.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;Adressen aan het ontvangen...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Open &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Blokken aan het importeren vanaf harde schijf...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Bezig met herindexeren van blokken op harde schijf...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Verstuur munten naar een Bitcoinadres</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Wijzig instellingen van Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Backup portemonnee naar een andere locatie</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Wijzig het wachtwoord voor uw portemonneversleuteling</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Debugscherm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Open debugging en diagnostische console</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verifiëer bericht...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Portemonnee</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;Versturen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Ontvangen</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Toon / Verberg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Toon of verberg het hoofdvenster</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Versleutel de geheime sleutels die bij uw portemonnee horen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Onderteken berichten met uw Bitcoinadressen om te bewijzen dat u deze adressen bezit</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verifiëer handtekeningen om zeker te zijn dat de berichten zijn ondertekend met de gespecificeerde Bitcoinadressen</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Bestand</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Instellingen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Hulp</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Tab-werkbalk</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnetwerk]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Kern</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Vraag betaling aan (genereert QR codes en bitcoin: URIs)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;Over Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Toon de lijst met gebruikt verzend adressen en labels</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Toon de lijst met gebruikte ontvangst adressen en labels</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Open een bitcoin: URI of betalingsverzoek</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Commandoregel-opties</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Toon het Bitcoin Core hulpbericht om een lijst te krijgen met mogelijke Bitcoin commandoregelopties</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin client</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n actieve connectie naar Bitcoinnetwerk</numerusform><numerusform>%n actieve connecties naar Bitcoinnetwerk</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Geen bron van blokken beschikbaar...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>%1 van %2 (geschat) blokken van de transactiehistorie verwerkt.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>%1 blokken van transactiehistorie verwerkt.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n uur</numerusform><numerusform>%n uur</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n dag</numerusform><numerusform>%n dagen</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n week</numerusform><numerusform>%n weken</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 en %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n jaar</numerusform><numerusform>%n jaar</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 achter</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Laatst ontvangen blok was %1 geleden gegenereerd.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transacties na dit moment zullen nu nog niet zichtbaar zijn.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Bijgewerkt</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Aan het bijwerken...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Verzonden transactie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Binnenkomende transactie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +552,14 @@ Adres: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Portemonnee is &lt;b&gt;versleuteld&lt;/b&gt; en momenteel &lt;b&gt;geopend&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Portemonnee is &lt;b&gt;versleuteld&lt;/b&gt; en momenteel &lt;b&gt;gesloten&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Er is een fatale fout opgetreden. Bitcoin kan niet meer veilig doorgaan en zal nu afgesloten worden.</translation>
     </message>
@@ -715,7 +567,6 @@ Adres: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Netwerkwaarschuwing</translation>
     </message>
@@ -723,291 +574,230 @@ Adres: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Coin controle adres selectie</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Kwantiteit</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Bedrag:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioriteit:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Vergoeding:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Lage uitvoer:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Na vergoeding:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Wisselgeld:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(de)selecteer alles</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Boom modus</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Lijst modus</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Bevestigingen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Bevestigd</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioriteit</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Kopieer adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopieer label</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopieer transactie-ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Blokeer niet gebruikte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Deblokkeer ongebruikte</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Kopieer aantal</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Kopieer vergoeding</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Kopieer na vergoeding</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopieer bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopieer prioriteit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Kopieer lage uitvoer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopieer wisselgeld</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>hoogste</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>hoger</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>hoog</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>gemiddeld hoog</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>gemiddeld</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>laag gemiddeld</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>laag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>lager</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>laagste</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 geblokeerd)</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation>geen</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Stof</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>ja</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>nee</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Dit label wordt rood, als de transactie grootte meer dan 1000 bytes is.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Dit betekent dat een vergoeding van minimaal %1 per kB nodig is.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Kan +/- byte per invoer variëren.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Transacties met een hogere prioriteit zullen eerder in een block gezet worden.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Als dit label rood is, is de prioriteit minder dan &quot;medium&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Dit label wordt rood, als een ontvanger een bedrag van minder dan %1 gekregen heeft.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Dit betekend dat een minimale vergoeding van %1 nodig is.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Bedragen beneden 0.546 keer het minimum relais vergoeding, worden als stof aangemerkt.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Dit label wordt rood, als de wijziging is kleiner dan %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(geen label)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation>wijzig van %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(wijzig)</translation>
     </message>
@@ -1015,67 +805,54 @@ Adres: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Bewerk Adres</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Label</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>Het label dat bij dit adres item hoort</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Het adres dat bij dit adres item hoort. Dit kan alleen bewerkt worden voor verstuur adressen.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adres</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nieuw ontvangstadres</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nieuw adres om naar te verzenden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Bewerk ontvangstadres</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Bewerk adres om naar te verzenden</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Het opgegeven adres &quot;%1&quot; bestaat al in uw adresboek.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Het opgegeven adres &quot;%1&quot; is een ongeldig Bitcoinadres</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Kon de portemonnee niet openen.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Genereren nieuwe sleutel mislukt.</translation>
     </message>
@@ -1083,27 +860,22 @@ Adres: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation>Een nieuwe gegevensmap wordt aangemaakt.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>naam</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Map bestaat al. Voeg %1 toe als u van plan bent hier een nieuwe map aan te maken.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Communicatiepad bestaat al, en is geen folder.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Kan hier geen gegevensmap aanmaken.</translation>
     </message>
@@ -1111,57 +883,46 @@ Adres: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - Commandoregel-opties</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Kern</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versie</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Gebruik:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>commandoregel-opties</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>gebruikersinterfaceopties</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Stel taal in, bijvoorbeeld &apos;&apos;de_DE&quot; (standaard: systeeminstellingen)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Geminimaliseerd starten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation>Zet SSL root certificaten voor betalingsverzoek (standaard: -sytem-)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Laat laadscherm zien bij het opstarten. (standaard: 1)</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Kies de gegevensmap tijdens het opstarten (standaard: 0)</translation>
     </message>
@@ -1169,57 +930,46 @@ Adres: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Welkom</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Welkom bij Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Omdat dit de eerste keer is dat het programma gestart is, kunt u nu kiezen waar Bitcoin Core de data moet opslaan.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core zal een kopie van de Bitcoin blokketen downloaden en opslaan. Tenminste %1 GB aan data wordt opgeslagen in deze map en het zal groeien in de tijd. De portemonnee wordt ook in deze map opgeslagen.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Gebruik de standaard gegevensmap</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Gebruik een persoonlijke gegevensmap:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Fout: Opgegeven gegevensmap &quot;%1&quot; kan niet aangemaakt worden.</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB aan vrije opslagruimte beschikbaar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(van %1GB benodigd)</translation>
     </message>
@@ -1227,27 +977,22 @@ Adres: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Open URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Open betalingsverzoek via URI of bestand</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Selecteer betalingsverzoek bestand</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Selecteer betalingsverzoek bestand om te openen</translation>
     </message>
@@ -1255,258 +1000,206 @@ Adres: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Algemeen</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Optionele transactiekosten per kB. Transactiekosten helpen ervoor te zorgen dat uw transacties snel verwerkt worden. De meeste transacties zijn 1kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Betaal &amp;transactiekosten</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Start Bitcoin automatisch na inloggen in het systeem</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>Start &amp;Bitcoin bij het inloggen in het systeem</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>Grootte van de &amp;database cache</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>Aantal threads voor &amp;scriptverificatie</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Verbind met het Bitcoin-netwerk via een SOCKS-proxy.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>&amp;Verbind via een SOCKS-proxy (standaardproxy):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>IP-adres van de proxy (bijv. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation>Actieve commandoregelopties die bovenstaande opties overschrijven:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Reset alle clientopties naar de standaardinstellingen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Reset Opties</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Netwerk</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation>(0 = auto, &lt;0 = laat dit aantal kernen vrij)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation>W&amp;allet</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>Expert</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation>Coin &amp;Control activeren</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>Indien het uitgeven van onbevestigd wisselgeld uitgeschakeld wordt dan kan het wisselgeld van een transactie niet worden gebruikt totdat de transactie ten minste een bevestiging heeft. Dit heeft ook invloed op de manier waarop uw saldo wordt berekend.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation>&amp;Spendeer onbevestigd wisselgeld</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Open de Bitcoin-poort automatisch op de router. Dit werkt alleen als de router UPnP ondersteunt en het aanstaat.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Portmapping via &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Poort:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Poort van de proxy (bijv. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS-&amp;Versie:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS-versie van de proxy (bijv. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Scherm</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Laat alleen een systeemvak-icoon zien wanneer het venster geminimaliseerd is</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimaliseer naar het systeemvak in plaats van de taakbalk</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimaliseer het venster in de plaats van de applicatie af te sluiten als het venster gesloten wordt. Wanneer deze optie aan staan, kan de applicatie alleen worden afgesloten door Afsluiten te kiezen in het menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>Minimaliseer bij sluiten van het &amp;venster</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Interface</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Taal &amp;Gebruikersinterface:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>De taal van de gebruikersinterface kan hier ingesteld worden. Deze instelling zal pas van kracht worden nadat Bitcoin herstart wordt.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Eenheid om bedrag in te tonen:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Kies de standaard onderverdelingseenheid om weer te geven in uw programma, en voor het versturen van munten</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Of Bitcoinadressen getoond worden in de transactielijst</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>Toon a&amp;dressen in de transactielijst</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Munt controle functies weergeven of niet.</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>Ann&amp;uleren</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>standaard</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>geen</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation>Bevestig reset opties</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Herstart van de client is vereist om veranderingen door te voeren.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>De client zal worden afgesloten, wilt u doorgaan?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Om dit aan te passen moet de client opnieuw gestart worden.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Het opgegeven proxyadres is ongeldig.</translation>
     </message>
@@ -1514,69 +1207,54 @@ Adres: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Vorm</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>De weergegeven informatie kan verouderd zijn. Uw portemonnee synchroniseert automaticsh met het Bitcoinnetwerk nadat een verbinding is gelegd, maar dit proces is nog niet voltooid.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Portemonnee</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Beschikbaar:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Uw beschikbare saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>Afwachtend:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>De som van de transacties die nog bevestigd moeten worden, en nog niet meetellen in uw beschikbare saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Immatuur:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Gedolven saldo dat nog niet tot wasdom is gekomen</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Totaal:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Uw totale saldo</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Recente transacties&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>niet gesynchroniseerd</translation>
     </message>
@@ -1584,93 +1262,70 @@ Adres: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI-behandeling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI kan niet worden geïnterpreteerd. Dit kan komen door een ongeldig Bitcoinadres of misvormde URI-parameters.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Het gevraagde betalingsbedrag van %1 is te weinig (beschouwd als stof).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Fout bij betalingsverzoek</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Kan bitcoin niet starten: click-to-pay handler</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Netmanager waarschuwing</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>Uw actieve proxy ondersteunt geen SOCKS5, dewelke vereist is voor betalingsverzoeken via proxy.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>URL om betalingsverzoek te verkrijgen is ongeldig: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Betalingsverzoek bestandsafhandeling</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>Betalingsverzoek-bestand kan niet gelezen of verwerkt worden! Dit kan veroorzaakt worden door een ongeldig betalingsverzoek-bestand.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Niet-geverifieerde betalingsverzoeken naar aangepaste betaling scripts worden niet ondersteund.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Restitutie van %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Fout bij communiceren met %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>Betalingsverzoek kan niet juist worden ontleed of verwerkt!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Ongeldige respons van server %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Betaling bevestigd</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Netwerkfout bij verzoek</translation>
     </message>
@@ -1678,29 +1333,22 @@ Adres: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Fout: Opgegeven gegevensmap &quot;%1&quot; bestaat niet.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation>Fout: Kan configuratiebestand niet parsen: %1. Gebruik enkel de key=value syntax.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Fout: Ongeldige combinatie van -regtest en -testnet</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Vul een Bitcoinadres in (bijv. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1708,22 +1356,18 @@ Adres: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Afbeelding opslaan...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Afbeelding kopiëren</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Sla QR-code op</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG afbeelding (*.png)</translation>
     </message>
@@ -1731,194 +1375,146 @@ Adres: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Clientnaam</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>N.v.t.</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Clientversie</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informatie</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Debug venster</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Algemeen</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Gebruikt OpenSSL versie</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Opstarttijd</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Netwerk</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Naam</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Aantal connecties</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Blokketen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Huidig aantal blokken</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Geschat totaal aantal blokken</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Tijd laatste blok</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Open</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Console</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Netwerkverkeer</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Wissen</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totalen</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>In;</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>Uit:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Bouwdatum</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Debug-logbestand</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Open het Bitcoindebug-logbestand van de huidige datamap. Dit kan een aantal seconden duren voor grote logbestanden.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Maak console leeg</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Welkom bij de Bitcoin RPC-console.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Gebruik de pijltjestoetsen om door de geschiedenis te navigeren, en &lt;b&gt;Ctrl-L&lt;/b&gt; om het scherm leeg te maken.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Typ &lt;b&gt;help&lt;/b&gt; voor een overzicht van de beschikbare commando&apos;s.</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 Kb</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 Gb</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 uur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1926,105 +1522,82 @@ Adres: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Bedrag</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Label:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Bericht</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Gebruik een van de eerder gebruikte ontvangstadressen opnieuw. Het opnieuw gebruiken van adressen heeft beveiliging- en privacy problemen. Gebruik dit niet, behalve als er eerder een betalingsverzoek opnieuw gegenereerd is.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>H&amp;ergebruik en bestaand ontvangstadres (niet aanbevolen)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>Een optioneel bericht om bij te voegen aan het betalingsverzoek, dewelke zal getoond worden wanneer het verzoek is geopend. Opermerking: Het bericht zal niet worden verzonden met de betaling over het Bitcoin netwerk.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Een optioneel label om te associëren met het nieuwe ontvangende adres</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Gebruik dit formulier om te verzoeken tot betaling. Alle velden zijn &lt;b&gt;optioneel&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Een optioneel te verzoeken bedrag. Laat dit leeg, of nul, om geen specifiek bedrag aan te vragen.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Wis alle velden op het formulier.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Wissen</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Geschiedenis van de betalingsverzoeken</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Betalingsverzoek</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>Toon het geselecteerde verzoek (doet hetzelfde als dubbelklikken)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Toon</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation>Verwijder de geselecteerde items van de lijst</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Verwijder</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Kopieer label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Kopieer bericht</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
@@ -2032,67 +1605,54 @@ Adres: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Kopieer &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Kopieer &amp;adres</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Sla afbeelding op...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Betalingsverzoek tot %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Betalingsinformatie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Bericht</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Resulterende URI te lang, probeer de tekst korter te maken voor het label/bericht.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Fout tijdens encoderen URI in QR-code</translation>
     </message>
@@ -2100,37 +1660,30 @@ Adres: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Bericht</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(geen label)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(geen bericht)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(geen bedrag)</translation>
     </message>
@@ -2138,247 +1691,194 @@ Adres: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Verstuur munten</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Coin controle opties</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Invoer...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>automatisch geselecteerd</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Onvoldoende fonds!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Kwantiteit</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Bedrag:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioriteit:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Vergoeding:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Lage uitvoer:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Na vergoeding:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Wisselgeld:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Als dit is geactiveerd, maar het wisselgeldadres is leeg of ongeldig, dan wordt het wisselgeld verzonden naar een nieuw gegenereerd adres.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Aangepast wisselgeldadres</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Verstuur aan verschillende ontvangers ineens</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Voeg &amp;Ontvanger Toe</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Wis alle velden van het formulier.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Verwijder &amp;Alles</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Bevestig de verstuuractie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Verstuur</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Bevestig versturen munten</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 tot %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Kopieer aantal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Kopieer vergoeding</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Kopieer na vergoeding</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopieer bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopieer prioriteit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Kopieer lage uitvoer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopieer wijziging</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Totaal bedrag %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>of</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Het ontvangstadres is niet geldig, controleer uw invoer.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Het ingevoerde bedrag moet groter zijn dan 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Bedrag is hoger dan uw huidige saldo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Totaal overschrijdt uw huidige saldo wanneer de %1 transactiekosten worden meegerekend</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Dubbel adres gevonden, u kunt slechts eenmaal naar een bepaald adres verzenden per verstuurtransactie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Transactie creatie niet gelukt!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>De transactie was afgewezen. Dit kan gebeuren als u eerder uitgegeven munten opnieuw wilt versturen, zoals wanneer u een kopie van uw wallet.dat heeft gebruikt en in de kopie deze munten zijn gemarkeerd als uitgegeven, maar in de huidige nog niet.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Waarschuwing: Ongeldig Bitcoin adres</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(geen label)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Waarschuwing: Onbekend wisselgeldadres</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Weet u zeker dat u wilt verzenden?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>toegevoegd als transactiekosten</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Betalingsverzoek verlopen</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Ongeldig betalingsadres %1</translation>
     </message>
@@ -2386,98 +1886,74 @@ Adres: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Bedra&amp;g:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Betaal &amp;Aan:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Het adres waaraan u wilt betalen  (bijv. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Vul een label in voor dit adres om het toe te voegen aan uw adresboek</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Label:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Kies een eerder gebruikt adres</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Dit is een normale betaling.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Plak adres vanuit klembord</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Verwijder deze toevoeging</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Bericht:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Dit is een geverifieerd betalingsverzoek.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Vul een label voor dit adres in om het aan de lijst met gebruikte adressen toe te voegen</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>Een bericht dat werd toegevoegd aan de bitcoin: URI dewelke wordt opgeslagen met de transactie ter referentie. Opmerking: Dit bericht zal niet worden verzonden over het Bitcoin netwerk.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Dit is een ongeverifieerd betalingsverzoek.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Betaal Aan:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memo:</translation>
     </message>
@@ -2485,12 +1961,10 @@ Adres: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Core is aan het afsluiten...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Sluit de computer niet af totdat dit venster verdwenen is.</translation>
     </message>
@@ -2498,186 +1972,142 @@ Adres: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Handtekeningen - Onderteken een bericht / Verifiëer een handtekening</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>O&amp;nderteken Bericht</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>U kunt berichten ondertekenen met een van uw adressen om te bewijzen dat u dit adres bezit. Pas op dat u geen onduidelijke dingen ondertekent, want phishingaanvallen zouden u kunnen misleiden om zo uw identiteit te stelen. Onderteken alleen berichten waarmee u het volledig eens bent.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Het adres om het bericht mee te ondertekenen (Vb.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L).</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Kies een eerder gebruikt adres</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Plak adres vanuit klembord</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Typ hier het bericht dat u wilt ondertekenen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Handtekening</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Kopieer de huidige handtekening naar het systeemklembord</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Onderteken een bericht om te bewijzen dat u een bepaald Bitcoinadres bezit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Onderteken &amp;Bericht</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Verwijder alles in de invulvelden</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Verwijder &amp;Alles</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verifiëer Bericht</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Voer het ondertekenende adres, bericht en handtekening hieronder in (let erop dat u nieuwe regels, spaties en tabs juist overneemt) om de handtekening te verifiëren. Let erop dat u niet meer uit het bericht interpreteert dan er daadwerkelijk staat,  om te voorkomen dat u wordt misleid in een man-in-the-middle-aanval.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Het adres waarmee bet bericht was ondertekend (Vb.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L).</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Controleer een bericht om te verifiëren dat het gespecificeerde Bitcoinadres het bericht heeft ondertekend.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verifiëer &amp;Bericht</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Verwijder alles in de invulvelden</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Vul een Bitcoinadres in (bijv. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Klik &quot;Onderteken Bericht&quot; om de handtekening te genereren</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Het opgegeven adres is ongeldig.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Controleer s.v.p. het adres en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Het opgegeven adres verwijst niet naar een sleutel.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Portemonnee-ontsleuteling is geannuleerd</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Geheime sleutel voor het ingevoerde adres is niet beschikbaar.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Ondertekenen van het bericht is mislukt.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Bericht ondertekend.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>De handtekening kon niet worden gedecodeerd.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Controleer s.v.p. de handtekening en probeer het opnieuw.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>De handtekening hoort niet bij het bericht.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Berichtverificatie mislukt.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Bericht correct geverifiëerd.</translation>
     </message>
@@ -2685,17 +2115,14 @@ Adres: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Kern</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>De Bitcoin Core ontwikkelaars</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnetwerk]</translation>
     </message>
@@ -2703,7 +2130,6 @@ Adres: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2711,184 +2137,138 @@ Adres: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Openen totdat %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>conflicterend</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/onbevestigd</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 bevestigingen</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, uitgezonden naar %n node</numerusform><numerusform>, uitgezonden naar %n nodes</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Bron</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Gegenereerd</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Van</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Aan</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>eigen adres</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>label</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Credit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>komt tot wasdom na %n nieuw blok</numerusform><numerusform>komt tot wasdom na %n nieuwe blokken</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>niet geaccepteerd</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debet</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Transactiekosten</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Netto bedrag</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Bericht</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Opmerking</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Transactie-ID:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Handelaar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Gegenereerde munten moeten %1 blokken rijpen voordat ze kunnen worden besteed. Toen dit blok gegenereerd werd, werd het uitgezonden naar het netwerk om aan de blokketen toegevoegd te worden. Als het niet lukt om in de keten toegevoegd te worden, zal de status te veranderen naar &quot;niet geaccepteerd&quot; en het zal deze niet besteedbaar zijn. Dit kan soms gebeuren als een ander knooppunt een blok genereert binnen een paar seconden na die van u.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Debug-informatie</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transactie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Inputs</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>waar</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>onwaar</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, is nog niet met succes uitgezonden</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Open voor nog %n blok</numerusform><numerusform>Open voor nog %n blokken</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>onbekend</translation>
     </message>
@@ -2896,12 +2276,10 @@ Adres: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Transactiedetails</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Dit venster laat een uitgebreide beschrijving van de transactie zien</translation>
     </message>
@@ -2909,127 +2287,102 @@ Adres: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>immatuur (%1 bevestigingen, zal beschikbaar zijn na %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Open voor nog %n blok</numerusform><numerusform>Open voor nog %n blokken</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Open tot %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bevestigd (%1 bevestigingen)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Dit blok is niet ontvangen bij andere nodes en zal waarschijnlijk niet worden geaccepteerd!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Gegenereerd maar niet geaccepteerd</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Niet verbonden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Onbevestigd</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Bevestigen (%1 van %2 aanbevolen bevestigingen)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>Conflicterend</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Ontvangen met</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Ontvangen van</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Verzonden aan</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Betaling aan uzelf</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Gedolven</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(nvt)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transactiestatus. Houd de muiscursor boven dit veld om het aantal bevestigingen te laten zien.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Datum en tijd waarop deze transactie is ontvangen.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Type transactie.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Ontvangend adres van transactie.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Bedrag verwijderd van of toegevoegd aan saldo</translation>
     </message>
@@ -3037,178 +2390,142 @@ Adres: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Alles</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Vandaag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Deze week</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Deze maand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Vorige maand</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Dit jaar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Bereik...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Ontvangen met</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Verzonden aan</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Aan uzelf</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Gedolven</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Anders</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Vul adres of label in om te zoeken</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Min. bedrag</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopieer adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopieer label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopieer bedrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopieer transactie-ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Bewerk label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Toon transactiedetails</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Exporteer Transactieverleden</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Export Mislukt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Er is een fout opgetreden bij het opslaan van het transactieverleden naar %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Export Succesvol</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>Het transactieverleden was succesvol bewaard in %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommagescheiden bestand (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Bevestigd</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Type</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Bedrag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Bereik:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>naar</translation>
     </message>
@@ -3216,7 +2533,6 @@ Adres: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Portemonnee werd niet geladen.</translation>
     </message>
@@ -3224,7 +2540,6 @@ Adres: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Verstuur munten</translation>
     </message>
@@ -3232,42 +2547,34 @@ Adres: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation>&amp;Exporteer</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exporteer de data in de huidige tab naar een bestand</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation>Portemonnee backuppen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Portemonnee-data (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Backup Mislukt</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Er is een fout opgetreden bij het wegschrijven van de portemonnee-data naar %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>De portemonneedata is succesvol opgeslagen in %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Backup Succesvol</translation>
     </message>
@@ -3275,109 +2582,88 @@ Adres: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>Gebruik:</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>Lijst van commando&apos;s</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Toon hulp voor een commando</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>Opties:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Specificeer configuratiebestand (standaard: bitcoin.conf)
 </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Specificeer pid-bestand (standaard: bitcoind.pid)
 </translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Stel datamap in</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Luister voor verbindingen op &lt;poort&gt; (standaard: 8333 of testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Onderhoud maximaal &lt;n&gt; verbindingen naar peers (standaard: 125)</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Verbind naar een node om adressen van anderen op te halen, en verbreek vervolgens de verbinding</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation>Specificeer uw eigen publieke adres</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Drempel om verbinding te verbreken naar zich misdragende peers (standaard: 100)</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Aantal seconden dat zich misdragende peers niet opnieuw mogen verbinden (standaard: 86400)</translation>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Er is een fout opgetreden tijdens het instellen van de inkomende RPC-poort %u op IPv4: %s</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Wacht op JSON-RPC-connecties op poort &lt;port&gt; (standaard: 8332 of testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Aanvaard commandoregel- en JSON-RPC-commando&apos;s</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation>Bitcoin Core RPC-client versie</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Draai in de achtergrond als daemon en aanvaard commando&apos;s</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>Gebruik het testnetwerk</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Accepteer verbindingen van buitenaf (standaard: 1 als geen -proxy of -connect is opgegeven)</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3400,852 +2686,682 @@ Het is ook aan te bevelen &quot;alertnotify&quot; in te stellen zodat u op de ho
 bijvoorbeeld: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.com</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Aanvaardbare cijfers (standaard: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Er is een fout opgetreden tijdens het instellen van de inkomende RPC-poort %u op IPv6, terugval naar IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Bind aan opgegeven adres en luister er altijd op. Gebruik [host]:port notatie voor IPv6</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation>Doorlopend tarief-limiet op gratis transacties toepassen tot &lt;n&gt;*1000 bytes per minuut (standaard: 15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Schakel regressietest-modus in, die een speciale blokketen gebruikt waarin blokken instantaan opgelost kunnen worden. Dit is bedoeld voor regressietestsoftware en app-ontwikkeling.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>Schakel regressietest-modus in, die een speciale blokketen gebruikt waarin blokken onmiddellijk opgelost kunnen worden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation>Fout: Luisteren naar inkomende connecties mislukt (listen geeft fout terug %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Fout: De transactie was afgewezen! Dit kan gebeuren als sommige munten in uw portemonnee al eerder uitgegeven zijn, zoals wanneer u een kopie van uw wallet.dat heeft gebruikt en in de kopie deze munten zijn uitgegeven, maar in deze portemonnee die munten nog niet als zodanig zijn gemarkeerd.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Fout: Deze transactie vereist transactiekosten van tenminste %s, vanwege zijn grootte, complexiteit, of het gebruik van onlangs ontvangen munten!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Voer opdracht uit zodra een portemonneetransactie verandert (%s in cmd wordt vervangen door TxID)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation>Toeslagen kleiner dan dit worden beschouwd als geen vergoeding (voor transactie aanmaak) (standaard:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation>Leeg database-activiteit uit de geheugenpool naar schijf log elke &lt;n&gt; megabytes (standaard: 100) </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation>Hoe grondig de blokverificatie van -checkblocks is (0-4, standaard: 3)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation>In deze modus, -genproclimit controleert hoeveel blokken er onmiddellijk worden gegenereerd.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation>Kies het aantal script verificatie processen (%u tot %d, 0 = auto, &lt;0 = laat dit aantal kernen vrij, standaard: %d)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation>Kies de processorlimiet wanneer generation is aan (-1 = ongelimiteerd, standaard: -1)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Dit is een pre-release testversie - gebruik op eigen risico! Gebruik deze niet voor het delven van munten of handelsdoeleinden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation>Niet in staat om %s te verbinden op deze computer. Bitcoin Core draait waarschijnlijk al.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Gebruik een aparte SOCKS5 proxy om &apos;Tor hidden services&apos; te bereiken (standaard: hetzelfde als -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Waarschuwing: -paytxfee is zeer hoog ingesteld.  Dit zijn de transactiekosten die u betaalt bij het versturen van een transactie.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Waarschuwing: Controleer dat de datum en tijd op uw computer correct zijn ingesteld. Als uw klok fout staat zal Bitcoin niet correct werken.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Waarschuwing: Het lijkt erop dat het netwerk geen consensus kan vinden! Sommige delvers lijken problemen te ondervinden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Waarschuwing: Het lijkt erop dat we geen consensus kunnen vinden met onze peers! Mogelijk dient u te upgraden, of andere nodes moeten wellicht upgraden.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Waarschuwing: Fout bij het lezen van wallet.dat! Alle sleutels zijn in goede orde uitgelezen, maar transactiedata of adresboeklemma&apos;s zouden kunnen ontbreken of fouten bevatten.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Waarschuwing: wallet.dat is corrupt, data is veiliggesteld! Originele wallet.dat is opgeslagen als wallet.{tijdstip}.bak in %s; als uw balans of transacties incorrect zijn dient u een backup terug te zetten.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation>(standaard: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation>(standaard: wallet.dat)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; kan zijn:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Poog de geheime sleutels uit een corrupt wallet.dat bestand terug te halen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Bitcoin Core Daemon</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation>Blokcreatie-opties:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Leeg lijst met wallet transacties (diagnostisch instrument; impliceert -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Verbind alleen naar de gespecificeerde node(s)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Verbind via een SOCKS-proxy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Verbinden met JSON-RPC op &lt;poort&gt; (standaard: 8332 of testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation>Verbindingsopties:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation>Corrupte blokkendatabase gedetecteerd</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation>Foutopsporing/Testopties:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation>Veilige modus uitschakelen, hef een echte veilige modus gebeurtenis uit (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Ontdek eigen IP-adres (standaard: 1 als er wordt geluisterd en geen -externalip is opgegeven)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Laad de wallet niet en schakel wallet RPC oproepen uit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Wilt u de blokkendatabase nu herbouwen?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Fout bij intialisatie blokkendatabase</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Probleem met initializeren van de database-omgeving %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Fout bij het laden van blokkendatabase</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Fout bij openen blokkendatabase</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Fout: Weinig vrije diskruimte!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Fout: Portemonnee vergrendeld, aanmaak transactie niet mogelijk!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Fout: Systeemfout:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Mislukt om op welke poort dan ook te luisteren. Gebruik -listen=0 as u dit wilt.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Lezen van blokinformatie mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Lezen van blok mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Synchroniseren van blokindex mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Schrijven van blokindex mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Schrijven van blokinformatie mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Schrijven van blok mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Schrijven van bestandsinformatie mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Schrijven naar coindatabase mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Schrijven van transactieindex mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Schrijven van undo-data mislukt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Transactiekosten per kB om toe te voegen aan transacties die u verzendt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation>Toeslagen kleiner dan dit worden beschouwd als geen vergoeding (voor relaying) (standaard:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Vind andere nodes d.m.v. DNS-naslag (standaard: 1 tenzij -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation>Forceer veilige modus (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation>Genereer munten (standaard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Aantal te checken blokken bij het opstarten (standaard: 288, 0 = allemaal)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>Als er geen &lt;category&gt; is opgegeven, laat dan alle debugging informatie zien.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Incorrect of geen genesis-blok gevonden. Verkeerde datamap voor het netwerk?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Ongeldig -onion adres &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation>Niet genoeg file descriptors beschikbaar.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>Prepend debug output met tijdstempel (standaard: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation>RPC client opties:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Blokketen opnieuw opbouwen met behulp van huidige blk000??.dat-bestanden</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Selecteer de versie van de SOCKS-proxy om te gebruiken (4 of 5, standaard is 5)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation>Zet database cache grootte in megabytes (%d tot %d, standaard: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Stel maximum blokgrootte in in bytes (standaard: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Stel het aantal threads in om RPC-aanvragen mee te bedienen (standaard: 4)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Specificeer het portemonnee bestand (vanuit de gegevensmap)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Spendeer onbevestigd wisselgeld wanneer transacties verstuurd worden (standaard: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>Dit is bedoeld voor regressie test toepassingen en applicatie onwikkeling.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Gebruik (vervangen; gebruik Bitcoin-cli);</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Blokken aan het controleren...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Portemonnee aan het controleren...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Wacht voor RPC server om te starten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Portemonnee %s bevindt zich buiten de gegevensmap %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Portemonnee instellingen:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Waarschuwing: Afgekeurd argument -debugnet genegeerd, use -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Om -txindex te kunnen veranderen dient u de database opnieuw te bouwen met gebruik van -reindex.</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importeert blokken van extern blk000??.dat bestand</translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation>Kan geen lock verkrijgen op gegevensmap %s. Bitcoin Core draait waarschijnlijk al.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Voer commando uit zodra een waarschuwing is ontvangen of wanneer we een erg lange fork detecteren (%s in commando wordt vervangen door bericht)</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Output extra debugginginformatie (standaard: 0, het leveren van &lt;category&gt; is optioneel)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Stel maximumgrootte in bytes in voor hoge-prioriteits-/lage-transactiekosten-transacties (standaard: %d)</translation>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>Informatie</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ongeldig bedrag voor -minrelaytxfee=&lt;bedrag&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ongeldig bedrag voor -mintxfee=&lt;bedrag&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation>Limiteer grootte van de handtekening cache tot &lt;n&gt; entries (default: 50000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation>Log transactieprioriteit en vergoeding per kB bij mijnen blocks (standaard: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Onderhoud een volledige transactieindex (standaard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maximum per-connectie ontvangstbuffer, &lt;n&gt;*1000 bytes (standaard: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maximum per-connectie zendbuffer, &lt;n&gt;*1000 bytes (standaard: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Accepteer alleen blokketen die overeenkomt met de ingebouwde checkpoints (standaard: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Verbind alleen naar nodes in netwerk &lt;net&gt; (IPv4, IPv6 of Tor)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation>Toon block bij opstarten, wanneer gevonden in block index</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation>Toon block structuur bij opstarten (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>RPC SSL opties: (zie de Bitcoin Wiki voor SSL installatie-instructies)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation>RPC server opties:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation>Laat willekeurig 1 elke &lt;n&gt; netwerkberichten vallen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation>Fuzz willekeurig 1 van elke &lt;n&gt; netwerkberichten</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation>Draai een proces om de wallet periodiek te flushen (default: 1)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL-opties: (zie de Bitcoin wiki voor SSL-instructies)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation>Stuur commando naar Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Stuur trace/debug-info naar de console in plaats van het debug.log bestand</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Stel minimum blokgrootte in in bytes (standaard: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation>Plaatst de DB_PRIVATE vlag in de wallet db omgeving (default: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation>Toon alle foutopsporingsopties (gebruik: --help -help-debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation>Toon benchmark-informatie (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Verklein debug.log-bestand bij het opstarten van de client (standaard: 1 als geen -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Ondertekenen van transactie mislukt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Specificeer de time-outtijd in milliseconden (standaard: 5000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation>Start Bitcoin Core Daemon</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>Systeemfout:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Transactiebedrag te klein</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Transactiebedragen moeten positief zijn</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transactie te groot</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Gebruik UPnP om de luisterende poort te mappen (standaard: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Gebruik UPnP om de luisterende poort te mappen (standaard: 1 als er wordt geluisterd)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Gebruikersnaam voor JSON-RPC-verbindingen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Waarschuwing</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Waarschuwing: Deze versie is verouderd, een upgrade is vereist!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Bezig met het zappen van alle transacties van de portemonnee...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation>bij opstarten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>versie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corrupt, veiligstellen mislukt</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Wachtwoord voor JSON-RPC-verbindingen</translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Sta JSON-RPC verbindingen van opgegeven IP-adres toe</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Verstuur commando&apos;s naar proces dat op &lt;ip&gt; draait (standaard: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Voer commando uit zodra het beste blok verandert (%s in cmd wordt vervangen door blockhash)</translation>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Vernieuw portemonnee naar nieuwste versie</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Stel sleutelpoelgrootte in op &lt;n&gt; (standaard: 100)</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Doorzoek de blokketen op ontbrekende portemonnee-transacties</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Gebruik OpenSSL (https) voor JSON-RPC-verbindingen</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Certificaat-bestand voor server (standaard: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Geheime sleutel voor server (standaard: server.pem)</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>Dit helpbericht</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Niet in staat om aan %s te binden op deze computer (bind gaf error %d, %s)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Sta DNS-naslag toe voor -addnode, -seednode en -connect</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>Adressen aan het laden...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Fout bij laden wallet.dat: Portemonnee corrupt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Fout bij laden wallet.dat: Portemonnee vereist een nieuwere versie van Bitcoin</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Portemonnee moest herschreven worden: Herstart Bitcoin om te voltooien</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>Fout bij laden wallet.dat</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ongeldig -proxy adres: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Onbekend netwerk gespecificeerd in -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Onbekende -socks proxyversie aangegeven: %i</translation>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kan -bind adres niet herleiden: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Kan -externlip adres niet herleiden: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ongeldig bedrag voor -paytxfee=&lt;bedrag&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Ongeldig bedrag</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Ontoereikend saldo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>Blokindex aan het laden...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Voeg een node om naar te verbinden toe en probeer de verbinding open te houden</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>Portemonnee aan het laden...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation>Kan portemonnee niet downgraden</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Kan standaardadres niet schrijven</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>Blokketen aan het doorzoeken...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>Klaar met laden</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>Om de %s optie te gebruiken</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>Fout</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_pam.ts
+++ b/src/qt/locale/bitcoin_pam.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -25,141 +22,113 @@ Me-distribute ya lalam na ning lisensya na ning MIT/X11 software, lawan ye ing m
 Ing produktung ini atin yang makayabeng software a gewa dareng OpenSSL Project para gamit king OpenSSL Toolkit(http://www.openssl.org/) at cryptographic software a sinulat ng Eric Young (eay@cryptsoft.com) at UPnp software a sinulat ng Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Karapatan ning Pamangopya</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Pindutan meng makatidduang besis ban ayalilan me ing address o label</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Maglalang kang bayung address</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopyan me ing salukuyan at makipiling address keng system clipboard</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopyan ing address</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Ilako ya ing kasalungsungan makapiling address keng listahan</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Ilako</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Reni reng kekang Bitcoin address king pamagpadalang kabayaran. Lawan mulang masalese reng alaga ampo ing address na ning tumanggap bayu ka magpadalang barya.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopyan ing &amp;Label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Alilan</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Comma separated file (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -167,17 +136,14 @@ Ing produktung ini atin yang makayabeng software a gewa dareng OpenSSL Project p
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(alang label)</translation>
     </message>
@@ -185,140 +151,106 @@ Ing produktung ini atin yang makayabeng software a gewa dareng OpenSSL Project p
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Dialogo ning Passphrase</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Mamalub kang passphrase</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Panibayung passphrase</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Pasibayuan ya ing bayung passphrase</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Palub ye ing bayung passphrase king wallet.&lt;br/&gt;Maliari pu sanang gumamit kayung passphrase a maki&lt;/b&gt; 10 or dakal pang miyayaliuang characters&lt;/b&gt;, o ualu o dakal pang salita&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>I-encrypt ye ing wallet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Ing operasyun a ini kailangan ne ing kekayung wallet passphrase, ban a-unlock ya ing wallet</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Unlock ya ing wallet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Ing operasyun a ini kailangan ne ing kekang wallet passphrase ban a-decrypt ne ing wallet.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>I-decrypt ya ing wallet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Alilan ya ing passphrase</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Palub ye ing luma ampo ing bayung passphrase king wallet.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Kumpirman ya ing wallet encryption</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Kapabaluan: Istung in-encrypt me ing kekang wallet at meala ya ing passphrase na, ma-&lt;b&gt;ALA NO NGAN RING KEKANG BITCOINS&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Siguradu na kang buri meng i-encrypt ing kekang wallet?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>Mayalaga: Reng milabas a backups a gewa mu gamit ing wallet file mu dapat lamung mialilan bayung gawang encrypted wallet file. Para keng seguridad , reng milabas a backups dareng ali maka encrypt a wallet file ma-ala nala istung inumpisan mu nalang gamitan reng bayu, at me encrypt a wallet. </translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Kapabaluan: Makabuklat ya ing Caps Lock key!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Me-encrypt ne ing wallet</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Ing Bitcoin ngeni magsara ya ban ayari ing proseso ning pamag-encrypt. Tandanan yu king pamag-encrypt wallet, ali nala aprotektan king kabuuan reng bitcoins yu kareng malware a kasalunsungan atiu kareng computer yu.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Memali ya ing pamag-encrypt king wallet </translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Memali ya ing encryption uli na ning ausan dang internal error. E ya me-encrypt ing wallet yu.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>E la mitutugma ring mibieng passphrase</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Memali ya ing pamag-unlock king wallet </translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>E ya istu ing passphrase a pepalub da para king wallet decryption</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Me-mali ya ing pamag-decrypt king wallet</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Mi-alilan ne ing passphrase na ning wallet.</translation>
     </message>
@@ -326,362 +258,286 @@ Ing produktung ini atin yang makayabeng software a gewa dareng OpenSSL Project p
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>I-sign ing &amp;mensayi</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Mag-sychronize ne king network...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Overview</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Ipakit ing kabuuang lawe ning wallet</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transaksion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Lawan ing kasalesayan ning transaksion</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>L&amp;umwal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Tuknangan ing aplikasyon</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Ipakit ing impormasyun tungkul king Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Tungkul &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Magpakit impormasion tungkul king Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Pipamilian...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>I-&amp;Encrypt in Wallet...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>I-&amp;Backup ing Wallet...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Alilan ing Passphrase...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Magpadalang barya king Bitcoin address</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Alilan ing pipamilian konpigurasion para keng Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>I-backup ing wallet king aliwang lugal</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Alilan ya ing passphrase a gagamitan para king wallet encryption</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>I-&amp;Debug ing awang</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Ibuklat ing debugging at diagnostic console</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Beripikan ing message...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Ipalto / Isalikut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Ipalto o isalikut ing pun a awang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;File</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Pamag-ayus</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Saup</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Gamit para king Tabs</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Kapilubluban ning Bitcoin</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin client</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n ya ing aktibong koneksion keng Bitcoin network</numerusform><numerusform>%n lareng aktibong koneksion keng Bitcoin network</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Me-prosesu %1 kareng %2 (me-estima) blocks ning kasalesayan ning transaksion.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n oras</numerusform><numerusform>%n oras</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n aldo</numerusform><numerusform>%n aldo</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n dominggu</numerusform><numerusform>%n dominggu</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Ing tatauling block a metanggap,  me-generate ya %1 ing milabas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Ing transaksion kaibat na nini ali yapa magsilbing ipakit.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Mali</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Kapabaluan</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Impormasion</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Makatuki ya king aldo</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Catching up...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Mipadalang transaksion</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Paparatang a transaksion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -694,17 +550,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Maka-&lt;b&gt;encrypt&lt;/b&gt; ya ing wallet at kasalukuyan yang maka-&lt;b&gt;unlocked&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Maka-&lt;b&gt;encrypt&lt;/b&gt; ya ing wallet at kasalukuyan yang maka-&lt;b&gt;locked&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Atin kamalian a milyari. Ali ne magsilbing sumulung pa ing Bitcoin at kailangan na ng tuknang.</translation>
     </message>
@@ -712,7 +565,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Alertu ning Network</translation>
     </message>
@@ -720,291 +572,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Alaga</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Kaaldauan</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Me-kumpirma</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopyan ing address</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopyan ing label</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopyan ing alaga</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(alang label)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1012,67 +803,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Alilan ing Address</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Label</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Address</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Bayung address king pamagtanggap</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Bayung address king pamagpadala</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Alilan ya ing address king pamagpadala</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Alilan ya ing address king pamagpadala</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Ing pepalub yung address &quot;%1&quot; ati na yu king aklat dareng address</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Ing pepalub yung address &quot;%1&quot; ali ya katanggap-tanggap a Bitcoin address.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Ali ya bisang mag-unlock ing wallet</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Memali ya ing pamangaua king key</translation>
     </message>
@@ -1080,27 +858,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1108,52 +881,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Kapilubluban ning Bitcoin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>bersion</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Pamanggamit:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>pipamilian command-line</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Pipamilian ning UI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Mamiling Amanu, alimbawa &quot;de_DE&quot;(default: system locale)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Umpisan ing pamaglati</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Ipalto ing splash screen keng umpisa (default: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1161,57 +928,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Malaus ka</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Mali</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1219,27 +975,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1247,253 +998,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Pipamilian</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Pun</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Mamayad &amp;bayad para king transaksion </translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Umpisan yang antimu ing Bitcoin kaibat mekapag-log in king sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Umpisan ya ing Bitcoin king pamag-log-in na ning sistema.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Network</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Ibuklat yang antimanu ing Bitcoin client port king router. Gagana yamu ini istung ing router mu susuporta yang UPnP at magsilbi ya.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapa ng ning port gamit ing &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Port na ning proxy(e.g. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Bersion na ning SOCKS</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Bersion a SOCKS ning proxy (e.g 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Awang</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Ipakit mu ing tray icon kaibat meng pelatian ing awang.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Latian ya ing tray kesa king taskbar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Palatian namu kesa king iluwal ya ing aplikasion istung makasara ya ing awang. Istung ing pipamilian a ini atiu king &quot;magsilbi&quot;, ing aplikasion misara yamu kaibat meng pinili ing &quot;Tuknangan&quot; king menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>P&amp;alatian istung isara</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Ipalto</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Amanu na ning user interface:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Ing amanu na ning user interface maliari yang i-ayus o ilage keni. Ing ayus a ini magsilbi yamu istung pesibayuan meng pasibayu ing Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Ing &amp;Unit a ipakit king alaga ning:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Pilinan ing default subdivision unit a ipalto o ipakit king interface at istung magpadala kang barya.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Ipakit man ing Bitcoin address king listahan naning transaksion o ali.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Ipakit ing address king listahan naning transaksion</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>I-&amp;Cancel</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>default</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Ing milageng proxy address eya katanggap-tanggap.</translation>
     </message>
@@ -1501,69 +1205,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Ing makaltong impormasion mapalyaring luma ne. Ing kekang wallet otomatiku yang mag-synchronize keng Bitcoin network istung mekakonekta ne king network, oneng ing prosesung ini ali ya pa kumpletu.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Wallet</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Ing kekang kasalungsungan balanse a malyari mung gastusan</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Ing kabuuan dareng transaksion a kasalungsungan ali pa me-kumpirma, at kasalungsungan ali pa mebilang kareng kekang balanseng malyari mung gastusan</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Immature:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Reng me-minang balanse a epa meg-matured</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Kabuuan:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Ing kekang kasalungsungan kabuuang balanse</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Reng kapilan pamung transaksion&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>ali ya maka-sync</translation>
     </message>
@@ -1571,93 +1260,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1665,23 +1331,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Magpalub kang Bitcoin address(e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1689,22 +1354,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1712,192 +1373,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Lagyu ning kliente</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Bersion ning Cliente</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Impormasion</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Gagamit bersion na ning OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Oras ning umpisa</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Network</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Bilang dareng koneksion</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Block chain</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Kasalungsungan bilang dareng blocks</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Estima kareng kabuuan dareng blocks</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Tatauling oras na ning block</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Ibuklat</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Console</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Kaaldauan ning pamaglalang</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Debug log file</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Ibuklat ing Bitcoin debug log file menibat king kasalungsungan data directory. Magluat ya ining pilan segundu para kareng mamaragul a log files.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>I-Clear ing console</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Malaus kayu king Bitcoin RPC console.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Gamitan me ing patas at pababang arrow para alibut me ing kasalesayan, at &lt;b&gt;Ctrl-L&lt;/b&gt; ban I-clear ya ing screen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>I-type ing &lt;b&gt;help&lt;/b&gt; ban akit la reng ati at magsilbing commands.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1905,105 +1520,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Label:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopyan ing label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopyan ing alaga</translation>
     </message>
@@ -2011,67 +1603,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Alaga</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mensayi</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2079,37 +1658,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Kaaldauan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mensayi</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Alaga</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(alang label)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2117,247 +1689,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Magpadalang Barya</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Misanang magpadala kareng alialiuang tumanggap</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Maglage &amp;Tumanggap</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>I-Clear &amp;Eganagana</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Balanse:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Kumpirman ing aksion king pamagpadala</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>Ipadala</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Kumpirman ing pamagpadalang barya</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopyan ing alaga</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Ing address na ning tumanggap ali ya katanggap-tanggap, maliari pung pakilaue pasibayu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Ing alaga na ning bayaran dapat mung mas matas ya king 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Ing alaga mipasobra ya king kekang balanse.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Ing kabuuan mipasobra ya king kekang balanse istung inabe ya ing %1 a bayad king transaksion </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Atin meakit a milupang address, maliari kamung magpadalang misan king metung a address king misan a pamagpadalang transaksion.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(alang label)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2365,98 +1884,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>A&amp;laga:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Ibayad &amp;kang:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ing address nung nokarin ipadala ya ing kabayaran (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Magpalub kang label para king address a ini ban a-iabe me king aklat dareng address</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Label:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Idikit ing address menibat king clipboard</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2464,12 +1959,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2477,186 +1970,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Pirma - Pirman / I-beripika ing mensayi</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Pirman ing Mensayi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Maliari kang mamirmang mensayi king kekang address bilang patune na keka ya ini. Mimingat mu king pamag-pirmang  e malino uling mapalyari kang mabiktimang phishing attack a manloku keka na pirman me ing sarili mu para king karela. Only sign fully-detailed statements you agree to.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ing address ban a -pirman ya ing mensayi kayabe ning (e.g.1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Idikit ing address menibat clipboard</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Ipalub ing mensayi a buri mung pirman keni</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Pirma</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Kopyan ing kasalungsungan pirma king system clipboard</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Pirman ing mensayi ban patune na keka ya ining Bitcoin address</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Pirman ing &amp;Mensayi</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Ibalik keng dati reng ngan fields keng pamamirmang mensayi</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>I-Clear &amp;Eganagana</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Beripikan ing Mensayi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ing address na ning mensayi nung nokarin me pirma ya ini (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Beripikan ing mensayi ban asiguradu a me pirma ya ini gamit ing mepiling Bitcoin address</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Beripikan ing &amp;Mensayi</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Ibalik king dati reng ngan fields na ning pamag beripikang mensayi</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Magpalub kang Bitcoin address(e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>I-click ing &quot;Pirman ing Mensayi&quot; ban agawa ya ing metung a pirma</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Ing milub a address e ya katanggap-tanggap.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Maliaring pakilawe pasibayu ing address at pasibayuan ya iti.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Ing milub a address ali ya mag-refer king metung a key.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Me-kansela ya ing pamag-unlock king wallet.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Ing private key para king milub a address, ala ya.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Me-mali ya ing pamag-pirma king mensayi .</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Me-pirman ne ing mensayi.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Ing pirma ali ya bisang ma-decode.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Maliaring pakilawe pasibayu ing pirma kaibat pasibayuan ya iti.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Ing pirma ali ya makatugma king message digest.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Me-mali ya ing pamag-beripika king mensayi.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Me-beripika ne ing mensayi.</translation>
     </message>
@@ -2664,17 +2113,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Kapilubluban ning Bitcoin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2682,7 +2128,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2690,184 +2135,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Makabuklat anggang %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/ali me-kumpirma</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 kumpirmasion</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Kabilian</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Kaaldauan</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Pikuanan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Megawa</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Menibat</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Para kang</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>sariling address</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>label</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Credit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>ali metanggap</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debit</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Bayad king Transaksion</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Alaga dareng eganagana</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mensayi</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Komentu</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID ning Transaksion</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Impormasion ning Debug</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transaksion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Alaga</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>tutu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>e tutu</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, eya matagumpeng mibalita</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>e miya balu</translation>
     </message>
@@ -2875,12 +2274,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detalye ning Transaksion</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Ining pane a ini magpakit yang detalyadung description ning transaksion</translation>
     </message>
@@ -2888,127 +2285,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Kaaldauan</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Klase</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Alaga</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Makabuklat anggang %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Me-kumpirma(%1 kumpirmasion)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Ing block a ini ali de atanggap deng aliwa pang nodes ania ali ya magsilbing tanggapan</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Me-generate ya oneng ali ya metanggap</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Atanggap kayabe ning</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Atanggap menibat kang</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Mipadala kang</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Kabayaran keka</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Me-mina</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status ning Transaksion: Itapat me babo na ning field a ini ban ipakit dala reng bilang dareng me-kumpirma na</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Aldo at oras nung kapilan me tanggap ya ing transaksion</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Klase ning transaksion</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Kepuntalan a address ning transaksion</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Alagang milako o miragdag king balanse.</translation>
     </message>
@@ -3016,178 +2388,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Eganagana</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Aldo iti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Paruminggung iti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Bulan a iti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Milabas a bulan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Banuang iti</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Angganan...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Atanggap kayabe ning</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Mipadala kang</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Keng sarili mu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Me-mina</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Aliwa</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Magpalub kang address o label para pantunan</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Pekaditak a alaga</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopyan ing address</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopyan ing label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopyan ing alaga</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Alilan ing label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Ipakit ing detalye ning transaksion</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Comma separated file (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Me-kumpirma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Kaaldauan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Klase</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Label</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Address</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Alaga</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Angga:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>para kang</translation>
     </message>
@@ -3195,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3203,7 +2538,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Magpadalang Barya</translation>
     </message>
@@ -3211,42 +2545,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3254,107 +2580,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Pamanggamit:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Listahan dareng commands</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Maniauad saup para kareng command</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Pipamilian:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Pilinan ing configuration file(default: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Pilinan ing pid file(default: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Pilinan ing data directory</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Ilage ya ing dagul o lati na ing database cache king megabytes (default: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Makiramdam king koneksion king &lt;port&gt;(default: 8333 o testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Mag-maintain peka &lt;n&gt; koneksion keng peers (default: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Kumunekta king note ban ayakua mula reng peer address, at mako king panga konekta</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Sabyan me ing kekang pampublikong address</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Threshold for disconnecting misbehaving peers (default: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Atin kamalian a milyari kabang ayusan ya ing RPC port %u para keng pamakiramdam king IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Tumanggap command line at JSON-RPC commands</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Gumana king gulut bilang daemon at tumanggap commands</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Gamitan ing test network</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Tumanggap koneksion menibat king kilwal (default: 1 if no -proxy or -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3369,722 +2674,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Kapabaluan: Sobra ya katas ing makalage king -paytxfee. Ini ing maging bayad mu para king bayad na ning transaksion istung pepadala me ing transaksion a ini.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Kapabaluan: Maliaring pakilawe ing oras at aldo a makalage king kekayung kompyuter nung istu la! Istung ing oras yu mali ya ali ya gumanang masalese ing Bitcoin.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Pipamilian king pamag-gawang block:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Kumunekta mu king mepiling node(s)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Mekapansin lang me-corrupt a block database</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>I-discover ing sariling IP address (default: 1 istung makiramdam at -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Buri meng buuan pasibayu ing block database ngene?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Kamalian king pamag-initialize king block na ning database</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Kamalian king pamag buklat king block database</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Kamalian: Mababa ne ing espasyu king disk!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Kamalian: kamalian na ning sistema:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Memali ya ing pamakiramdam kareng gang nanung port. Gamita me ini -listen=0 nung buri me ini.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Me-mali king pamagbasa king impormasion ning block</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Me-mali king pamagbasa keng block</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Me-mali para i-sync ing block index</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Me-mali king pamanyulat king block index</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Me-mali king pamanyulat king block info</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Me-mali king pamanyulat block</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Me-mali king pamanyulat king file info</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Me-mali king pamanyulat king coin database</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Me-mali king pamanyulat king index ning transaksion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Me-mali king pamanyulat king undo data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Mantun peers gamit ing pamamantun DNS (default: 1 unless -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Pilan la reng block a lawan keng umpisa (default: 288, 0 = all)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>&amp;Impormasion</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Pipamilian ning SSL: (lawen ye ing Bitcoin Wiki para king SSL setup instructions)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Magpadalang trace/debug info okeng console kesa keng debug.log file</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Ilage ing pekaditak a dagul na ning block king bytes (default: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Kamalian ning sistema:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Maragul yang masiadu ing transaksion</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Username para king JSON-RPC koneksion</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Kapabaluan</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Kapabaluan: Ing bersioin a ini laus ne, kailangan nang mag-upgrade!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>bersion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Password para king JSON-RPC koneksion</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Payagan ya i JSON-RPC koneksion para king metung a IP address</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Magpadalang command king node a gagana king &lt;ip&gt;(default: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>I-execute ing command istung mialilan ya ing best block (%s in cmd is replaced by block hash)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>I-upgrade ing wallet king pekabayung porma</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>I-set ing key pool size king &lt;n&gt;(default: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>I-scan pasibayu ing block chain para kareng mauaualang transaksion</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Gumamit OpenSSL(https) para king JSON-RPC koneksion</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Server certificate file (default: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Server private key (default: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Ining saup a mensayi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Ali ya magsilbing mag-bind keng %s kening kompyuter a ini (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Payagan ing pamaglawe DNS para king -addnode, -seednode and -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Lo-load da ne ing address...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Me-mali ya ing pamag-load king wallet.dat: Me-corrupt ya ing wallet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Me-mali ya ing pamag-load na ning wallet.dat: Ing wallet mangailangan yang bayung bersion na ning Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Ing wallet mangailangan yang misulat pasibayu: Umpisan yang pasibayu ing Bitcoin ban ma-kumpleto ya</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Me-mali ya ing pamag-load king wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ali katanggap-tanggap a -proxy addresss: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>E kilalang network ing mepili king -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>E kilalang -socks proxy version requested: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Eya me-resolve ing -bind address: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Eya me-resolve ing -externalip address: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Eya maliari ing alaga keng -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Ing alaga e ya katanggap-tanggap</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Kulang a pondo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Lo-load dane ing block index...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Magdagdag a node ban kumunekta at subuknan apanatili yang makabuklat ing koneksion</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Eya megsilbing idikit king %s na ning kompyuter a ini. Mapaliaring mamandar ne ing Bitcoin.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Lo-load dane ing wallet...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Ali ya magsilbing i-downgrade ing wallet</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Eya misulat ing default address</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>I-scan deng pasibayu...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Yari ne ing pamag-load</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Para agamit ing %s a pimamilian</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Mali</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_pl.ts
+++ b/src/qt/locale/bitcoin_pl.ts
@@ -1,18 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="pl" version="2.1">
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="pl" version="2.0">
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>O Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>Wersja &lt;b&gt;Bitcoin Core&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Distributed under the MIT/X11 software license, see the accompanying file COPYIN
 This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/) and cryptographic software written by Eric Young (eay@cryptsoft.com) and UPnP software written by Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Prawo autorskie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Deweloperzy Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
-        <translation>(%1-bit)</translation>
+        <source>(%1-bit)</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Kliknij dwukrotnie, aby edytować adres lub etykietę</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Utwórz nowy adres</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nowy</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Skopiuj aktualnie wybrany adres do schowka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopiuj</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>Z&amp;amknij</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopiuj adres</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Usuń zaznaczony adres z listy</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Eksportuj dane z aktywnej karty do pliku</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Eksportuj</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Usuń</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Wybierz adres żeby wysłać bitcoins</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Wybierz adres do otrzymania monet.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>W&amp;ybierz</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Adres wysyłania</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Adres odbiorczy</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Tutaj znajdują się Twoje adresy Bitcoin do wysyłania płatności. Zawsze sprawdzaj ilość i adres odbiorcy przed wysyłką monet.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>To twoje adresy bitcoin do odbierania płatności. Zaleca się używanie nowych adresów odbiorczych dla każdej tranzakcji.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopiuj &amp;Etykietę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Modyfikuj</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Eksportuj listę adresową</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Plik *.CSV (rozdzielany przecinkami)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Błąd przy próbie eksportu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etykieta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(bez etykiety)</translation>
     </message>
@@ -187,140 +153,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Okienko Hasła</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Wpisz hasło</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nowe hasło</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Powtórz nowe hasło</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Wprowadź nowe hasło dla portfela.&lt;br/&gt;Proszę użyć hasła składającego się z &lt;b&gt;10 lub więcej losowych znaków&lt;/b&gt; lub &lt;b&gt;ośmiu lub więcej słów&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Zaszyfruj portfel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Ta operacja wymaga hasła do portfela ażeby odblokować portfel.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Odblokuj portfel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Ta operacja wymaga hasła do portfela ażeby odszyfrować portfel.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Odszyfruj portfel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Zmień hasło</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Podaj stare i nowe hasło do portfela.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Potwierdź szyfrowanie portfela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Uwaga: Jeśli zaszyfrujesz swój portfel i zgubisz hasło to &lt;b&gt;STRACISZ WSZYSTKIE SWOJE BITCOIN&apos;Y&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Jesteś pewien, że chcesz zaszyfrować swój portfel?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>WAŻNE: Wszystkie wykonane wcześniej kopie pliku portfela powinny być zamienione na nowe, szyfrowane pliki. Z powodów bezpieczeństwa, poprzednie kopie nieszyfrowanych plików portfela staną się bezużyteczne jak tylko zaczniesz korzystać z nowego, szyfrowanego portfela.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Uwaga: Klawisz Caps Lock jest włączony</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Portfel zaszyfrowany</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Program Bitcoin zamknie się aby dokończyć proces szyfrowania. Pamiętaj, że szyfrowanie portfela nie zabezpiecza w pełni Twoich bitcoinów przed kradzieżą przez wirusy lub trojany mogące zainfekować Twój komputer.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Szyfrowanie portfela nie powiodło się</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Szyfrowanie portfela nie powiodło się z powodu wewnętrznego błędu. Twój portfel nie został zaszyfrowany.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Podane hasła nie są takie same.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Odblokowanie portfela nie powiodło się</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Wprowadzone hasło do odszyfrowania portfela jest niepoprawne.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Odszyfrowanie portfela nie powiodło się</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Hasło portfela zostało pomyślnie zmienione.</translation>
     </message>
@@ -328,363 +260,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>Podpisz wiado&amp;mość...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synchronizacja z siecią...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>P&amp;odsumowanie</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Pokazuje ogólny zarys portfela</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transakcje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Przeglądaj historię transakcji</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Zakończ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Zamknij program</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Pokaż informację o Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Pokazuje informacje o Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opcje...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>Zaszyfruj Portf&amp;el</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>Wykonaj kopię zapasową...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Zmień hasło...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>Adres wysyłania</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>Adres odbiorczy</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Otwórz URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importowanie bloków z dysku...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Ponowne indeksowanie bloków na dysku...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Wyślij monety na adres Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Zmienia opcje konfiguracji bitcoina</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Zapasowy portfel w innej lokalizacji</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Zmień hasło użyte do szyfrowania portfela</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Okno debugowania</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Otwórz konsolę debugowania i diagnostyki</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Zweryfikuj wiadomość...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Portfel</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>Wyślij</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>Odbie&amp;rz</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Pokaż / Ukryj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Pokazuje lub ukrywa główne okno</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Szyfruj klucze prywatne, które są powiązane z twoim portfelem</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Podpisz wiadomości swoim adresem aby udowodnić jego posiadanie</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Zweryfikuj wiadomość,  aby upewnić się, że została podpisana odpowiednim adresem Bitcoin.</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Plik</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>P&amp;referencje</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>Pomo&amp;c</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Pasek zakładek</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Rdzeń BitCoin</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Żądaj płatności (generuje kod QR oraz bitcoin URI)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;O Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Pokaż listę użytych adresów wysyłających i etykiety</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Pokaż listę użytych adresów odbiorczych i etykiety</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin klient</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktywne połączenie do sieci Bitcoin</numerusform><numerusform>%n aktywne połączenia do sieci Bitcoin</numerusform><numerusform>%n aktywnych połączeń do sieci Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Brak dostępnych źródeł bloków...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Przetworzono (w przybliżeniu) %1 z %2 bloków historii transakcji.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Pobrano %1 bloków z historią transakcji.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n godzina</numerusform><numerusform>%n godzin</numerusform><numerusform>%n godzin</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n dzień</numerusform><numerusform>%n dni</numerusform><numerusform>%n dni</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n tydzień</numerusform><numerusform>%n tygodni</numerusform><numerusform>%n tygodni</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 i %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n rok</numerusform><numerusform>%n lata</numerusform><numerusform>%n lat</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 wstecz</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Ostatni otrzymany blok został wygenerowany %1 temu.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transakcje po tym momencie nie będą jeszcze widoczne.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Ostrzeżenie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informacja</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Aktualny</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Łapanie bloków...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transakcja wysłana</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transakcja przychodząca</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +552,14 @@ Adres: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Portfel jest &lt;b&gt;zaszyfrowany&lt;/b&gt; i obecnie &lt;b&gt;niezablokowany&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Portfel jest &lt;b&gt;zaszyfrowany&lt;/b&gt; i obecnie &lt;b&gt;zablokowany&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+441"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Błąd krytyczny. Bitcoin nie może kontynuować bezpiecznie więc zostanie zamknięty.</translation>
     </message>
@@ -715,7 +567,6 @@ Adres: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Sieć Alert</translation>
     </message>
@@ -723,291 +574,230 @@ Adres: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Ilość:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bajtów:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Kwota:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Priorytet:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Opłata:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Po opłacie:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Reszta:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>Zaznacz/Odznacz wszystko</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Widok drzewa</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Widok listy</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Kwota</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Potwierdzenia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Potwierdzony</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Priorytet</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Kopiuj adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopiuj etykietę</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopiuj kwotę</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Skopiuj ID transakcji</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Zablokuj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Odblokuj</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Skopiuj ilość</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Skopiuj opłatę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Skopiuj ilość po opłacie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Skopiuj ilość bajtów</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Skopiuj priorytet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Skopiuj resztę</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>najwyższa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>wyższa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>wysoka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>średnio wysoki</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>średnia</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>średnio niski</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>niski</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>niższy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>najniższy</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 zablokowane)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>tak</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>nie</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Etykieta staje się czerwona kiedy transakcja jest większa niż 1000 bajtów.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Oznacza to wymaganą opłatę minimum %1 na kB.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Waha się +/- 1 bajt na wejście.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Transakcje o wyższym priorytecie zostają szybciej dołączone do bloku.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Ta etykieta jest czerwona, jeżeli priorytet jest mniejszy niż &quot;średni&quot;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Etykieta staje się czerwona kiedy którykolwiek odbiorca otrzymuje kwotę mniejszą niż %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Oznacza to, że wymagana jest opłata przynajmniej %1.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Etykieta staje się czerwona kiedy reszta jest mniejsza niż %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+63"/>
         <source>(no label)</source>
         <translation>(bez etykiety)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>reszta z %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(reszta)</translation>
     </message>
@@ -1015,67 +805,54 @@ Adres: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Zmień adres</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etykieta</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>Etykieta skojarzona z tym wpisem na liście adresów</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Ten adres jest skojarzony z wpisem na liście adresów. Może być zmodyfikowany jedynie dla adresów wysyłających.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adres</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nowy adres odbiorczy</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nowy adres wysyłania</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Zmień adres odbioru</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Zmień adres wysyłania</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Wprowadzony adres &quot;%1&quot; już istnieje w książce adresowej.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Wprowadzony adres &quot;%1&quot; nie jest poprawnym adresem Bitcoin.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Nie można było odblokować portfela.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Tworzenie nowego klucza nie powiodło się.</translation>
     </message>
@@ -1083,27 +860,22 @@ Adres: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Utworzono nowy folder danych.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nazwa</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Katalog już istnieje. Dodaj %1 jeśli masz zamiar utworzyć tutaj nowy katalog.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Ścieżka już istnieje i nie wskazuje na folder.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Nie można było tutaj utworzyć folderu.</translation>
     </message>
@@ -1111,52 +883,46 @@ Adres: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Opcje konsoli</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Rdzeń BitCoin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>wersja</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Użycie:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>opcje konsoli</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI opcje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Ustaw Język, na przykład &quot;pl_PL&quot; (domyślnie: systemowy)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Uruchom zminimalizowany</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Pokazuj okno powitalne przy starcie (domyślnie: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Wybierz folder danych przy starcie (domyślnie: 0)</translation>
     </message>
@@ -1164,57 +930,46 @@ Adres: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Witaj</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Witam w Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Ponieważ jest to pierwsze uruchomienie programu, możesz wybrać gdzie będą przechowywane informacje.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Program pobierze i będzie przechowywał kopię łańcucha bloków Bitcoin. W wybranym katalogu musi być przynajmniej %1GB miejsca, a z czasem wielkość danych będzie rosła. Portfel będzie przechowywany w tym samym katalogu.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Użyj domyślnego folderu danych</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Użyj wybranego folderu dla danych</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Błąd: Określony folder danych &quot;%1&quot; nie mógł zostać utworzony.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB dostępnego wolnego miejsca</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(z %1GB potrzebnego)</translation>
     </message>
@@ -1222,27 +977,22 @@ Adres: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Otwórz URI:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Otwórz żądanie zapłaty z URI lub pliku</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1250,258 +1000,206 @@ Adres: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opcje</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>Główne</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Opcjonalna prowizja za transakcje za kB, wspomaga ona szybkość przebiegu transakcji. Większość transakcji jest 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Płać prowizję za transakcje</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Automatycznie uruchamia Bitcoin po zalogowaniu do systemu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>Uruchamiaj Bitcoin wraz z zalogowaniem do &amp;systemu</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Ustaw liczbę wątków skryptu weryfikacji (do 16, 0 = auto, &lt;0 = zostawia taką ilość rdzenie wolnych, domyślnie: 0)</translation>
-    </message>
-    <message>
-        <location line="+153"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>Adres IP serwera proxy (np. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Przywróć domyślne wszystkie ustawienia klienta.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>Z&amp;resetuj Ustawienia</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Sieć</translation>
     </message>
     <message>
-        <location line="-95"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation>Portfel</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>Ekspert</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Automatycznie otwiera port klienta Bitcoin na routerze. Ta opcja dzieła tylko jeśli twój router wspiera UPnP i jest ono włączone.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapuj port używając &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy &amp;IP: </translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Port proxy (np. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>Wersja &amp;SOCKS</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS wersja serwera proxy (np. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Okno</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Pokazuj tylko ikonę przy zegarku po zminimalizowaniu okna.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimalizuj do paska przy zegarku zamiast do paska zadań</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimalizuje zamiast zakończyć działanie programu przy zamykaniu okna. Kiedy ta opcja jest włączona, program zakończy działanie po wybieraniu Zamknij w menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimalizuj przy zamknięciu</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Wyświetlanie</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Język &amp;Użytkownika:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Można tu ustawić język interfejsu uzytkownika. Żeby ustawienie przyniosło skutek trzeba uruchomić ponownie Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Jednostka pokazywana przy kwocie:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Wybierz podział jednostki pokazywany w interfejsie  oraz podczas wysyłania monet</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Pokazuj adresy Bitcoin na liście transakcji.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Wyświetlaj adresy w liście transakcji</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Anuluj</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>domyślny</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Potwierdź reset ustawień</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Wymagany restart programu, aby uaktywnić zmiany.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>Program zostanie wyłączony. Czy chcesz kontynuować?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Ta zmiana może wymagać ponownego uruchomienia klienta.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Adres podanego proxy jest nieprawidłowy</translation>
     </message>
@@ -1509,69 +1207,54 @@ Adres: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formularz</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Wyświetlana informacja może być nieaktualna. Twój portfel synchronizuje się automatycznie z siecią bitcoin, zaraz po tym jak uzyskano połączenie, ale proces ten nie został jeszcze ukończony.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Portfel</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Dostępne:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Twoje obecne saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>W toku:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Suma transakcji, które nie zostały jeszcze potwierdzone, a które nie zostały wliczone do twojego obecnego salda</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Niedojrzały: </translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Balans wydobycia, który jeszcze nie dojrzał</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Wynosi ogółem:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Twoje obecne saldo</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Ostatnie transakcje&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>desynchronizacja</translation>
     </message>
@@ -1579,93 +1262,70 @@ Adres: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Obsługa URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI nie może zostać przetworzony! Prawdopodobnie błędny adres Bitcoin bądź nieprawidłowe parametry URI.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Żądana kwota %1 jest za niska (uznano za kurz).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Błąd żądania płatności</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Nie można rozpocząć bitcoin: kliknij-by-zapłacić opiekunowi</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Zwrot z %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Błąd komunikacji z %1 : %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Błędna odpowiedź z serwera %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Płatność potwierdzona</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Błąd żądania sieci</translation>
     </message>
@@ -1673,23 +1333,22 @@ Adres: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+14"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Błąd: Określony folder danych &quot;%1&quot; nie istnieje.</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Błąd: Nie można przetworzyć pliku konfiguracyjnego: %1. Używaj tylko składni klucz=wartość.</translation>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Błąd: Niepoprawna kombinacja -regtest i -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Wprowadź adres Bitcoin (np. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1697,22 +1356,18 @@ Adres: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Zapisz obraz...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Kopiuj obraz</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Zapisz Kod QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>Obraz PNG (*.png)</translation>
     </message>
@@ -1720,194 +1375,146 @@ Adres: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nazwa klienta</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>NIEDOSTĘPNE</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Wersja klienta</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informacje</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Okno debugowania</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Ogólne</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Używana wersja OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Czas uruchomienia</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Sieć</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nazwa</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Liczba połączeń</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Ciąg bloków</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Aktualna liczba bloków</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Szacowana ilość bloków</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Czas ostatniego bloku</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Otwórz</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>$Ruch sieci</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Wyczyść</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Kwota ogólna</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>Wejście:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>Wyjście:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Data kompilacji</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Plik logowania debugowania</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Otwórz plik logowania debugowania Bitcoin z obecnego katalogu z danymi. Może to potrwać kilka sekund przy większych plikach.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Wyczyść konsolę</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Witam w konsoli Bitcoin RPC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Użyj strzałek do przewijania historii i &lt;b&gt;Ctrl-L&lt;/b&gt; aby wyczyścić ekran</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Wpisz &lt;b&gt;help&lt;/b&gt; aby uzyskać listę dostępnych komend</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1915,105 +1522,82 @@ Adres: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Ilość:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etykieta:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Wiadomość:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Użyj jeden z poprzednio użytych adresów odbiorczych. Podczas ponownego używania adresów występują problemy z bezpieczeństwem i prywatnością. Nie korzystaj z tej opcji, chyba że odtwarzasz żądanie płatności wykonane już wcześniej.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>U%żyj ponownie istniejący adres odbiorczy (niepolecane)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Opcjonalna etykieta do skojarzenia z nowym adresem odbiorczym.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Wyczyść pola formularza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Wyczyść</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Żądanie historii płatności</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Żądaj płatności</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Pokaż</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation>Usuń zaznaczone z listy</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Usuń</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Kopiuj etykietę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Kopiuj wiadomość</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiuj kwotę</translation>
     </message>
@@ -2021,67 +1605,54 @@ Adres: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Kod QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Kopiuj &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Kopiuj &amp;adres</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Zapisz obraz...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Żądaj płatności do %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Informacje o płatności</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Kwota</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etykieta</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Wiadomość</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Wynikowy URI jest zbyt długi, spróbuj zmniejszyć tekst etykiety / wiadomości</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Błąd kodowania URI w Kodzie QR.</translation>
     </message>
@@ -2089,37 +1660,30 @@ Adres: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etykieta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Wiadomość</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Kwota</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(bez etykiety)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(brak wiadomości)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(brak kwoty)</translation>
     </message>
@@ -2127,247 +1691,194 @@ Adres: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Wyślij Monety</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Wejścia...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>zaznaczone automatycznie</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Niewystarczające środki</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Ilość:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bajtów:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Kwota:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Priorytet:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Opłata:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Po opłacie:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Reszta:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Kiedy ta opcja jest wybrana, ale adres reszty jest pusty lub nieprawidłowy to reszta będzie wysyłana na adres nowo-wygenerowany.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Wyślij do wielu odbiorców na raz</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Dodaj Odbio&amp;rce</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Wyczyść wszystkie pola formularza</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Wyczyść &amp;wszystko</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Potwierdź akcję wysyłania</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>Wy&amp;syłka</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Potwierdź wysyłanie monet</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 do %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Skopiuj ilość</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiuj kwotę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Skopiuj opłatę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Skopiuj ilość po opłacie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Skopiuj ilość bajtów</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Skopiuj priorytet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Skopiuj resztę</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Łączna kwota %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>lub</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adres odbiorcy jest nieprawidłowy, proszę poprawić</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Kwota do zapłacenia musi być większa od 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Kwota przekracza twoje saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Suma przekracza twoje saldo, gdy doliczymy %1 prowizji transakcyjnej.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Znaleziono powtórzony adres, można wysłać tylko raz na każdy adres podczas operacji wysyłania.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Utworzenie transakcji nie powiodło się!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Transakcja została odrzucona! Może się to zdarzyć jeśli część monet z portfela została już wydana używając kopii pliku wallet.dat i nie zostało to tutaj uwzględnione.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Ostrzeżenie: nieprawidłowy adres Bitcoin</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(bez etykiety)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Ostrzeżenie: Nieznany adres</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Czy na pewno chcesz wysłać?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>dodano jako opłata transakcyjna</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Zażądanie płatności upłynęło</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>błędny adres płatności %1</translation>
     </message>
@@ -2375,98 +1886,74 @@ Adres: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Su&amp;ma:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Zapłać &amp;dla:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adres, na który wysłasz płatności (np. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Wprowadź etykietę dla tego adresu by dodać go do książki adresowej</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etykieta:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Wybierz wcześniej użyty adres </translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>To jest standardowa płatność</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Wklej adres ze schowka</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Usuń ten wpis</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Wiadomość:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Zweryfikowano żądanie zapłaty.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Wprowadź etykietę dla tego adresu by dodać go do listy użytych adresów</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>To żądanie zapłaty nie zostało zweryfikowane.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Wpłać do:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Notatka:</translation>
     </message>
@@ -2474,12 +1961,10 @@ Adres: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Core się zamyka...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Nie wyłączaj komputera dopóki to okno nie zniknie.</translation>
     </message>
@@ -2487,186 +1972,142 @@ Adres: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Podpisy - Podpisz / zweryfikuj wiadomość</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>Podpi&amp;sz Wiadomość</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Możesz podpisywać wiadomości swoimi adresami aby udowodnić, że jesteś ich właścicielem. Uważaj, aby nie podpisywać niczego co wzbudza Twoje podejrzenia, ponieważ ktoś może stosować phishing próbując nakłonić Cię do ich podpisania. Akceptuj i podpisuj tylko w pełni zrozumiałe komunikaty i wiadomości.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Wprowadź adres Bitcoin (np. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Wybierz wcześniej użyty adres</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Wklej adres ze schowka</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Wprowadź wiadomość, którą chcesz podpisać, tutaj</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Podpis</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Kopiuje aktualny podpis do schowka systemowego</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Podpisz wiadomość aby dowieść, że ten adres jest twój</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Podpisz Wiado&amp;mość</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Zresetuj wszystkie pola podpisanej wiadomości</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Wyczyść &amp;wszystko</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Zweryfikuj wiadomość</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Wpisz adres podpisu, wiadomość (upewnij się, że dokładnie skopiujesz wszystkie zakończenia linii, spacje, tabulacje itp.) oraz podpis poniżej by sprawdzić wiadomość. Uważaj by nie dodać więcej do podpisu niż do samej podpisywanej wiadomości by uniknąć ataku man-in-the-middle (człowiek pośrodku)</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Wprowadź adres Bitcoin (np. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Zweryfikuj wiadomość,  aby upewnić się, że została podpisana odpowiednim adresem Bitcoin.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Zweryfikuj Wiado&amp;mość</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Resetuje wszystkie pola weryfikacji wiadomości</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Wprowadź adres Bitcoin (np. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Kliknij &quot;Podpisz Wiadomość&quot; żeby uzyskać podpis</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Podany adres jest nieprawidłowy.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Proszę sprawdzić adres i spróbować ponownie.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Wprowadzony adres nie odnosi się do klucza.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Odblokowanie portfela zostało anulowane.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Klucz prywatny dla podanego adresu nie jest dostępny</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Podpisanie wiadomości nie powiodło się</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Wiadomość podpisana.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Podpis nie może zostać zdekodowany.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Sprawdź podpis i spróbuj ponownie.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Podpis nie odpowiadał streszczeniu wiadomości</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Weryfikacja wiadomości nie powiodła się.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Wiadomość zweryfikowana.</translation>
     </message>
@@ -2674,17 +2115,14 @@ Adres: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Rdzeń BitCoin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Deweloperzy Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2692,7 +2130,6 @@ Adres: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2700,184 +2137,138 @@ Adres: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Otwórz do %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/niezatwierdzone</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potwierdzeń</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, emitowany przez %n węzeł</numerusform><numerusform>, emitowany przez %n węzły</numerusform><numerusform>, emitowany przez %n węzłów</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Źródło</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Wygenerowano</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Od</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Do</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>własny adres</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etykieta</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Przypisy</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>potwierdzona przy %n bloku więcej</numerusform><numerusform>potwierdzona przy %n blokach więcej</numerusform><numerusform>potwierdzona przy %n blokach więcej</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>niezaakceptowane</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debet</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Prowizja transakcji</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Kwota netto</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Wiadomość</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Komentarz</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID transakcji</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Kupiec</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Wygenerowane monety muszą dojrzeć przez %1 bloków zanim będzie można je wysłać. Gdy wygenerowałeś ten blok został on ogłoszony w sieci i dodany do łańcucha bloków. Jeżeli nie uda mu się wejść do łańcucha jego status zostanie zmieniony na &quot;nie zaakceptowano&quot; i nie będzie można go wydać. To czasem zdarza się gdy inny węzeł wygeneruje blok w kilka sekund od twojego.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Informacje debugowania</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transakcja</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Wejścia</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Kwota</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>prawda</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>fałsz</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, nie został jeszcze pomyślnie wyemitowany</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Otwórz dla %n bloku</numerusform><numerusform>Otwórz dla %n następnych bloków</numerusform><numerusform>Otwórz dla %n następnych bloków</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>nieznany</translation>
     </message>
@@ -2885,12 +2276,10 @@ Adres: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Szczegóły transakcji</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Ten panel pokazuje szczegółowy opis transakcji</translation>
     </message>
@@ -2898,127 +2287,102 @@ Adres: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Kwota</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform>Otwórz dla %n następnych bloków</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Otwórz do %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Zatwierdzony (%1 potwierdzeń)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Ten blok nie został odebrany przez jakikolwiek inny węzeł i prawdopodobnie nie zostanie zaakceptowany!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Wygenerowano ale nie zaakceptowano</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Niepotwierdzone:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Potwierdzanie (%1 z %2 rekomendowanych potwierdzeń)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Otrzymane przez</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Odebrano od</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Wysłano do</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Płatność do siebie</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Wydobyto</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(brak)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status transakcji. Najedź na pole, aby zobaczyć liczbę potwierdzeń.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Data i czas odebrania transakcji.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Rodzaj transakcji.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Adres docelowy transakcji.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Kwota usunięta z lub dodana do konta.</translation>
     </message>
@@ -3026,178 +2390,142 @@ Adres: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Wszystko</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Dzisiaj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>W tym tygodniu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>W tym miesiącu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>W zeszłym miesiącu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>W tym roku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Zakres...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Otrzymane przez</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Wysłano do</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Do siebie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Wydobyto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Inne</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Wprowadź adres albo etykietę żeby wyszukać</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Min suma</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopiuj adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopiuj etykietę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiuj kwotę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Skopiuj ID transakcji</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Zmień etykietę</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Pokaż szczegóły transakcji</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Eksport historii transakcji</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Błąd przy próbie eksportu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Wystąpił błąd przy próbie zapisu historii transakcji do %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Eksport powiódł się</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>Historia transakcji została zapisana do %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>CSV (rozdzielany przecinkami)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Potwierdzony</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etykieta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Kwota</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Zakres:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>do</translation>
     </message>
@@ -3205,7 +2533,6 @@ Adres: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Nie załadowano żadnego portfela.</translation>
     </message>
@@ -3213,7 +2540,6 @@ Adres: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Wyślij płatność</translation>
     </message>
@@ -3221,42 +2547,34 @@ Adres: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Eksportuj</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Eksportuj dane z aktywnej karty do pliku</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Kopia Zapasowa Portfela</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Dane Portfela (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Nie udało się wykonać kopii zapasowej</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Wystąpił błąd przy próbie zapisu pliku portfela do %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Plik portfela został zapisany do %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Wykonano Kopię Zapasową</translation>
     </message>
@@ -3264,102 +2582,86 @@ Adres: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+226"/>
         <source>Usage:</source>
         <translation>Użycie:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Lista poleceń</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Uzyskaj pomoc do polecenia</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Opcje:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Wskaż plik konfiguracyjny (domyślnie: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Wskaż plik pid (domyślnie: bitcoin.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Wskaż folder danych</translation>
     </message>
     <message>
-        <location line="-35"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Nasłuchuj połączeń na &lt;port&gt; (domyślnie: 8333 lub testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Utrzymuj maksymalnie &lt;n&gt; połączeń z peerami (domyślnie: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Podłącz się do węzła aby otrzymać adresy peerów i rozłącz</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Podaj swój publiczny adres</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Próg po którym nastąpi rozłączenie nietrzymających się zasad peerów (domyślnie: 100)</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Czas w sekundach, przez jaki nietrzymający się zasad peerzy nie będą mogli ponownie się podłączyć (domyślnie: 86400)</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Wystąpił błąd podczas ustawiania portu RPC %u w tryb nasłuchu: %s</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Nasłuchuj połączeń JSON-RPC na &lt;port&gt; (domyślnie: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Akceptuj linię poleceń oraz polecenia JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Uruchom w tle jako daemon i przyjmuj polecenia</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Użyj sieci testowej</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Akceptuj połączenia z zewnątrz (domyślnie: 1 jeśli nie ustawiono -proxy lub -connect)</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3383,732 +2685,682 @@ Zalecane jest ustawienie alertnotify aby poinformować o problemach:⏎
 na przykład: alertnotify=echo %%s | mail -s &quot;Alarm Bitcoin&quot; admin@foo.com⏎</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Dopuszczalne szyfry (domyślnie: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Wystąpił błąd podczas ustawiania portu RPC %u w tryb nasłuchu dla IPv6, korzystam z IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Skojarz z podanym adresem. Użyj formatu [host]:port dla IPv6 </translation>
     </message>
     <message>
-        <location line="+6"/>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Wejście w tryb testów regresji, który wykorzystuje specjalny łańcuch, w którym bloki można rozwiązać natychmiast. To jest przeznaczone dla narzędzi testowania regresji i rozwoju aplikacji.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Błąd: transakcja została odrzucona. Może się to zdarzyć, gdy monety z Twojego portfela zostały już wydane, na przykład gdy używałeś kopii wallet.dat i bitcoiny które tam wydałeś nie zostały jeszcze odjęte z portfela z którego teraz korzystasz.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Transakcja przekracza limit. Możesz wysłać ją płacąc prowizję %s, która zostaje przekazana do węzłów, które ją prześlą i pomoże wspierać sieć Bitcoin. Czy chcesz zapłacić prowizję?</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Wykonaj polecenie, kiedy transakcja portfela ulegnie zmianie (%s w poleceniu zostanie zastąpione przez TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>To jest testowa wersja - używaj na własne ryzyko - nie używaj do wykopywania oraz przy aplikacjach kupieckich</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Ostrzeżenie: -paytxfee jest bardzo duży. To jest prowizja za transakcje, którą płacisz, gdy wysyłasz monety.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Uwaga: Sprawdź czy data i czas na Twoim komputerze są prawidłowe! Jeśli nie to Bitcoin nie będzie działał prawidłowo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Ostrzeżenie: Sieć nie wydaje się w pełni zgodna! Niektórzy górnicy wydają się doświadczać problemów.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Uwaga: Wygląda na to, że nie ma pełnej zgodności z naszymi peerami! Możliwe, że potrzebujesz aktualizacji bądź inne węzły jej potrzebują</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Ostrzeżenie: błąd odczytu wallet.dat! Wszystkie klucze zostały odczytane, ale może brakować pewnych danych transakcji lub wpisów w książce adresowej lub mogą one być nieprawidłowe.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Ostrzeżenie: Odtworzono dane z uszkodzonego pliku wallet.dat! Oryginalny wallet.dat został zapisany jako wallet.{timestamp}.bak w %s; jeśli twoje saldo lub transakcje są niepoprawne powinieneś odtworzyć kopię zapasową.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Próbuj odzyskać klucze prywatne z uszkodzonego wallet.dat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>wersja klienta RPC bitcoin</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Opcje tworzenia bloku:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Wyczyść listę transakcji portfela (narzędzie diagnostyczne; implikuje -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Łącz tylko do wskazanego węzła</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Połącz przez SOCKS proxy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>podłącz do JSON-RPC na &lt;port&gt; (domyślnie: 8332 lub sieć testowa: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>Opcje połączenia:</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Wykryto uszkodzoną bazę bloków</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation>Opcje debugowania/testowania:</translation>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Odkryj własny adres IP (domyślnie: 1 kiedy w trybie nasłuchu i brak -externalip )</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Nie ładuj portfela i wyłącz odwołania RPC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Czy chcesz teraz przebudować bazę bloków?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Błąd inicjowania bloku bazy danych</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Błąd inicjowania środowiska bazy portfela %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Błąd ładowania bazy bloków</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Błąd ładowania bazy bloków</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Błąd: Mało miejsca na dysku!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Błąd: Zablokowany portfel, nie można utworzyć transakcji!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Błąd: błąd systemu:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Próba otwarcia jakiegokolwiek portu nie powiodła się. Użyj -listen=0 jeśli tego chcesz.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Nie udało się odczytać informacji bloku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Nie udało się odczytać bloku.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Nie udało się zsynchronizować indeksu bloków.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Nie udało się zapisać indeksu bloków.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Nie udało się zapisać informacji bloku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Nie udało się zapisać bloku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Nie udało się zapisać informacji o pliku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Nie udało się zapisać do bazy monet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Nie udało się zapisać indeksu transakcji</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Nie udało się zapisać danych odtwarzających</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Prowizja za kB dodawana do wysyłanej transakcji</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Wyszukaj połączenia wykorzystując zapytanie DNS (domyślnie 1 jeśli nie użyto -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generuj monety (domyślnie: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Ile bloków sprawdzić przy starcie (domyślnie: 288, 0 = wszystkie)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Jak dokładna jest weryfikacja bloku (0-4, domyślnie: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Nieprawidłowy lub brak bloku genezy. Błędny folder_danych dla sieci?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Nieprawidłowy adres -onion: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Brak wystarczającej liczby deskryptorów plików. </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>Opcje klienta RPC:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Odbuduj indeks łańcucha bloków z obecnych plików blk000??.dat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Wybierz wersję proxy SOCKS (4 lub 5, domyślnie 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Wyślij polecenie do serwera Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation>Ustaw wielkość pamięci podręcznej w megabajtach (%d do %d, domyślnie: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Ustaw maksymalną wielkość bloku w bajtach (domyślnie: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Ustaw liczbę wątków do odwołań RPC (domyślnie: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Określ plik portfela (w obrębie folderu danych)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Wydawaj niepotwierdzoną resztę podczas wysyłania transakcji (domyślnie: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Startowanie serwera Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Użycie (przestarzałe, użyj bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Weryfikacja bloków...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Weryfikacja portfela...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Portfel %s znajduje się poza folderem danych %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Opcje portfela:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Musisz przebudować bazę używając parametru -reindex aby zmienić -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importuj bloki z zewnętrznego pliku blk000??.dat</translation>
     </message>
     <message>
-        <location line="-126"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Uruchom polecenie przy otrzymaniu odpowiedniego powiadomienia lub gdy zobaczymy naprawdę długie rozgałęzienie (%s w poleceniu jest podstawiane za komunikat)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Ustaw maksymalny rozmiar transakcji o wysokim priorytecie/niskiej prowizji w bajtach (domyślnie: 27000)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Ustaw liczbę wątków skryptu weryfikacji (do 16, 0 = auto, &lt;0 = zostawia taką ilość rdzenie wolnych, domyślnie: 0)</translation>
-    </message>
-    <message>
-        <location line="+91"/>
         <source>Information</source>
         <translation>Informacja</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nieprawidłowa kwota dla -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nieprawidłowa kwota dla -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Utrzymuj pełen indeks transakcji (domyślnie: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maksymalny bufor odbioru na połączenie, &lt;n&gt;*1000 bajtów (domyślnie: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maksymalny bufor wysyłu na połączenie, &lt;n&gt;*1000 bajtów (domyślnie: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Akceptuj tylko łańcuch bloków zgodny z wbudowanymi punktami kontrolnymi (domyślnie: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Łącz z węzłami tylko w sieci &lt;net&gt; (IPv4, IPv6 lub Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>Opcje serwera RPC:</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Opcje SSL: (odwiedź Bitcoin Wiki w celu uzyskania instrukcji)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Wyślij informację/raport do konsoli zamiast do pliku debug.log.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Ustaw minimalny rozmiar bloku w bajtach (domyślnie: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Zmniejsz plik debug.log przy starcie programu (domyślnie: 1 jeśli nie użyto -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Podpisywanie transakcji nie powiodło się</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Wskaż czas oczekiwania bezczynności połączenia w milisekundach (domyślnie: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Błąd systemu:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Zbyt niska kwota transakcji </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Kwota transakcji musi być dodatnia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transakcja zbyt duża</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Używaj UPnP do mapowania portu nasłuchu (domyślnie: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Używaj UPnP do mapowania portu nasłuchu (domyślnie: 1 gdy nasłuchuje)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nazwa użytkownika dla połączeń JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Ostrzeżenie</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Uwaga: Ta wersja jest przestarzała, aktualizacja wymagana!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>wersja</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat uszkodzony, odtworzenie się nie powiodło</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Hasło do połączeń JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Przyjmuj połączenia JSON-RPC ze wskazanego adresu IP</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Wysyłaj polecenia do węzła działającego na &lt;ip&gt; (domyślnie: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-134"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Wykonaj polecenie kiedy najlepszy blok ulegnie zmianie (%s w komendzie zastanie zastąpione przez hash bloku)</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Zaktualizuj portfel do najnowszego formatu.</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Ustaw rozmiar puli kluczy na &lt;n&gt; (domyślnie: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Przeskanuj blok łańcuchów żeby znaleźć zaginione transakcje portfela</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Użyj OpenSSL (https) do połączeń JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Plik certyfikatu serwera (domyślnie: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Klucz prywatny serwera (domyślnie: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Ta wiadomość pomocy</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Nie można przywiązać %s na tym komputerze (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Zezwól -addnode, -seednode i -connect na łączenie się z serwerem DNS</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Wczytywanie adresów...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Błąd ładowania wallet.dat: Uszkodzony portfel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Błąd ładowania wallet.dat: Portfel wymaga nowszej wersji Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Portfel wymaga przepisania: zrestartuj Bitcoina żeby ukończyć</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Błąd ładowania wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Nieprawidłowy adres -proxy: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Nieznana sieć w -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Nieznana wersja proxy w -socks: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Nie można uzyskać adresu -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Nie można uzyskać adresu -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Nieprawidłowa kwota dla -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Nieprawidłowa kwota</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Niewystarczające środki</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Ładowanie indeksu bloku...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Dodaj węzeł do łączenia się and attempt to keep the connection open</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Loading wallet...</source>
         <translation>Wczytywanie portfela...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Nie można dezaktualizować portfela</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Nie można zapisać domyślnego adresu</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Ponowne skanowanie...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Wczytywanie zakończone</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Aby użyć opcji %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Błąd</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_pt_BR.ts
+++ b/src/qt/locale/bitcoin_pt_BR.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Sobre o Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>versão do &lt;b&gt;Bitcoin Core&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Distribuido sob a licença de software MIT/X11, veja o arquivo anexo COPYING ou 
 Este produto inclui software desenvolvido pelo Projeto OpenSSL para uso no OpenSSL Toolkit (http://www.openssl.org/), software de criptografia escrito por Eric Young (eay@cryptsoft.com) e sofware UPnP escrito por Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Programadores do Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation>(%1-bit)</translation>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
-        <translation>Clique duas vezes para editar o endereço ou a etiqueta</translation>
+        <translation>Duplo-clique para editar o endereço ou o rótulo</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Criar um novo endereço</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Novo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copie o endereço selecionado para a área de transferência do sistema</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiar</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>&amp;Fechar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copiar Endereço</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Excluir os endereços selecionados da lista</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar os dados na aba atual para um arquivo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Excluir</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Escolha o endereço para enviar moedas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Escolha o endereço para receber moedas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>Escol&amp;ha</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Enviando endereços</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Recebendo endereços</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Estes são os seus endereços Bitcoin para receber pagamentos. Você pode querer enviar um endereço diferente para cada remetente, para acompanhar quem está pagando.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Estes são os seus endereços Bitcoin para receber pagamentos. Recomenda-se a utilização de um novo endereço de recebimento para cada transação.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
-        <translation>Copiar &amp;Etiqueta</translation>
+        <translation>Copiar &amp;Rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exportar lista de endereços</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Arquivo separado por vírgulas (*. csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Exportação Falhou</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Ocorreu um erro ao tentar salvar a lista de endereço em %1.</translation>
     </message>
@@ -169,17 +138,14 @@ Este produto inclui software desenvolvido pelo Projeto OpenSSL para uso no OpenS
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Rótulo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(Sem rótulo)</translation>
     </message>
@@ -187,140 +153,106 @@ Este produto inclui software desenvolvido pelo Projeto OpenSSL para uso no OpenS
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Janela da Frase de Segurança</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Digite a frase de segurança</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nova frase de segurança</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repita a nova frase de segurança</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Digite a nova frase de seguraça da sua carteira. &lt;br/&gt; Por favor, use uma frase de &lt;b&gt;10 ou mais caracteres aleatórios,&lt;/b&gt; ou &lt;b&gt;oito ou mais palavras.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Criptografar carteira</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Esta operação precisa de sua frase de segurança para desbloquear a carteira.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desbloquear carteira</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Esta operação precisa de sua frase de segurança para descriptografar a carteira.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Descriptografar carteira</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Alterar frase de segurança</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Digite a frase de segurança antiga e nova para a carteira.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar criptografia da carteira</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
-        <translation>Aviso: Se você criptografar sua carteira e perder sua senha, você vai &lt;b&gt;perder todos os seus BITCOINS!&lt;/b&gt;</translation>
+        <translation>Atenção: Se você criptografar sua carteira e perder sua senha, você vai &lt;b&gt;perder todos os seus BITCOINS!&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Tem certeza de que deseja criptografar sua carteira?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>IMPORTANTE: Qualquer backup prévio que você tenha feito do seu arquivo wallet deve ser substituído pelo novo e encriptado arquivo wallet gerado. Por razões de segurança, qualquer backup do arquivo wallet não criptografado se tornará inútil assim que você começar  a usar uma nova carteira criptografada.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
-        <translation>Cuidado: A tecla Caps Lock está ligada!</translation>
+        <translation>Atenção: A tecla Caps Lock está ligada!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Carteira criptografada</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>O Bitcoin irá fechar agora para finalizar o processo de encriptação. Lembre-se de que encriptar sua carteira não protege totalmente suas bitcoins de serem roubadas por malwares que tenham infectado o seu computador.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>A criptografia da carteira falhou</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>A criptografia da carteira falhou devido a um erro interno. Sua carteira não estava criptografada.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>A frase de segurança fornecida não confere.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
-        <translation>A abertura da carteira falhou</translation>
+        <translation>O desbloqueio da carteira falhou</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>A frase de segurança digitada para a descriptografia da carteira estava incorreta.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>A descriptografia da carteira falhou</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>A frase de segurança da carteira foi alterada com êxito.</translation>
     </message>
@@ -328,362 +260,286 @@ Este produto inclui software desenvolvido pelo Projeto OpenSSL para uso no OpenS
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;Assinar Mensagem...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sincronizando com a rede...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Visão geral</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation>Nó</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Mostrar visão geral da carteira</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transações</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Navegar pelo histórico de transações</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>S&amp;air</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Sair da aplicação</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Mostrar informação sobre Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Sobre &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Mostrar informações sobre o Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opções...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Criptografar Carteira...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Backup Carteira...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Mudar frase de segurança...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>Enviando endereço&amp;s...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;Receber endereços...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Abrir &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importando blocos do disco...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Reindexando blocos no disco...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Enviar moedas para um endereço bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modificar opções de configuração para bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Fazer cópia de segurança da carteira para uma outra localização</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Mudar a frase de segurança utilizada na criptografia da carteira</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Janela de &amp;Depuração</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Abrir console de depuração e diagnóstico</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verificar mensagem...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Carteira</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Receber</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Exibir/Ocultar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Mostrar ou esconder a Janela Principal.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Criptografar as chaves privadas que pertencem à sua carteira</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Assine mensagems com seus endereços Bitcoin para provar que você é dono deles</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verificar mensagens para se assegurar que elas foram assinadas pelo dono de Endereços Bitcoin específicos</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Arquivo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Configurações</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Ajuda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra de ferramentas</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Núcleo Bitcoin</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Solicitações de pagamentos (gera códigos QR e bitcoin: URIs)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;A respeito do Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
-        <translation>Mostrar a lista de endereços de envio e etiquetas usadas</translation>
+        <translation>Mostrar a lista de endereços de envio e rótulos usados</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation>Mostrar a lista de endereços de recebimento usados ​​e etiquetas</translation>
+        <translation>Mostrar a lista de endereços de recebimento usados ​​e rótulos</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Abrir um bitcoin: URI ou cobrança</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>Opções de linha de &amp;comando</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Mostra a mensagem de ajuda do Bitcoin Core para pegar a lista com os comandos possíveis</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Cliente Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n conexão ativa na rede Bitcoin</numerusform><numerusform>%n conexões ativas na rede Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Nenhum servidor disponível...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Processado %1 de %2 blocos (estimado) de histórico de transações.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Processado %1 blocos do histórico de transações.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hora</numerusform><numerusform>%n horas</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n dia</numerusform><numerusform>%n dias</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n semana</numerusform><numerusform>%n semanas</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 e %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n ano</numerusform><numerusform>%n anos</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 atrás</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Último bloco recebido foi gerado %1 atrás.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transações após isso ainda não estão visíveis.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
-        <translation>Cuidado</translation>
+        <translation>Atenção</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informação</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Atualizado</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Recuperando o atraso ...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transação enviada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transação recebida</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -695,17 +551,14 @@ Tipo: %3
 Endereço: %4</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Carteira está &lt;b&gt;criptografada&lt;/b&gt; e atualmente &lt;b&gt;desbloqueada&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Carteira está &lt;b&gt;criptografada&lt;/b&gt; e atualmente &lt;b&gt;bloqueada&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Um erro fatal ocorreu. Bitcoin não pode continuar em segurança e irá fechar.</translation>
     </message>
@@ -713,7 +566,6 @@ Endereço: %4</translation>
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Alerta da Rede</translation>
     </message>
@@ -721,291 +573,230 @@ Endereço: %4</translation>
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Coin Control Address Selection</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Quantidade:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Quantia:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioridade:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Rendimento baixo:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Depois da taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>trocar</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(de)selecionar tudo</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Modo árvore</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Modo lista</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Confirmações</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioridade</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Copiar endereço</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
-        <translation>Copiar etiqueta</translation>
+        <translation>Copiar rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID da transação</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Travar não gasto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Destravar não gasto</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Copiar quantidade</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Copiar taxa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copia pós-taxa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copia prioridade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copia saída de pouco valor</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copia alteração</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation>mais alta possível</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>muito alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>média-alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>média</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>média-baixa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>baixa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>muito baixa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>a mais baixa possível</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 travado)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>nenhum</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Sujeira</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>sim</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>não</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Esse marcador fica vermelho se a transação ultrapassar 1000 bytes.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Isso significa que uma taxa de pelo menos %1 por kB é necessária.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Pode variar +/- 1 byte por entrada.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Transações de alta prioridade são mais propensas a serem incluídas em um bloco.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Esse marcador fica vermelho se a prioridade for menor que &quot;média&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Esse marcador fica vermelho se qualquer destinatário receber uma quantia menor que %1</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Isso significa que uma taxa de pelo menos %1 é necessária.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Quantias abaixo de 0,546 multiplicado pela taxa mínima é mostrada como sujeira.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Esse marcador fica vermelho se o troco for menor que %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(Sem rótulo)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>troco de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(troco)</translation>
     </message>
@@ -1013,67 +804,54 @@ Endereço: %4</translation>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editar Endereço</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
-        <translation>&amp;Etiqueta</translation>
+        <translation>&amp;Rótulo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
-        <translation>A etiqueta associada com esta lista de endereço de entrada</translation>
+        <translation>O rótulo associado a esta entrada na lista de endereços</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>O endereço associado a esta lista de endereços de entrada. Isso só pode ser modificado para o envio de endereços.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Endereço</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Novo endereço de recebimento</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Novo endereço de envio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editar endereço de recebimento</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editar endereço de envio</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>O endereço digitado &quot;%1&quot; já se encontra no catálogo de endereços.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>O endereço digitado &quot;%1&quot; não é um endereço Bitcoin válido.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
-        <translation>Não foi possível destravar a carteira.</translation>
+        <translation>Não foi possível desbloquear a carteira.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>A geração de nova chave falhou.</translation>
     </message>
@@ -1081,27 +859,22 @@ Endereço: %4</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Um novo diretório de dados será criado.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nome</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>O diretório já existe. Adicione %1 se você pretende criar um novo diretório aqui.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Esta pasta já existe, e não é um diretório.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Não é possível criar um diretório de dados aqui.</translation>
     </message>
@@ -1109,52 +882,46 @@ Endereço: %4</translation>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - Opções de linha de comando</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Núcleo Bitcoin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versão</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>opções da linha de comando</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>opções da UI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Escolher língua, por exemplo &quot;de_DE&quot; (padrão: localização do sistema)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Inicializar minimizado</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>Define certificados SSL root para requisição de pagamento (padrão: -system-)</translation>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Mostrar tela inicial ao ligar (padrão: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Escolha o diretório de dados na inicialização (padrão: 0)</translation>
     </message>
@@ -1162,57 +929,46 @@ Endereço: %4</translation>
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Bem-vindo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Bem vindo ao Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>A primeira vez que o programa é aberto você pode escolher onde o Bitcoin Core vai guardar os dados.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core vai fazer download e guardar uma cópia da longa e única cadeia de blocos do Bitcoin: Blockchain. Pelo menos %1 GB de dados serão armazenados nesse diretório e isso aumentará ao longo do tempo. Sua carteira também será armazenada nesse diretório.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Use o diretório de dados padrão</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Use um diretório de dados personalizado:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Erro: dados especificados diretório &quot;% 1&quot; não pode ser criado.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB de espaço disponível</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(Mais de 1GB necessário)</translation>
     </message>
@@ -1220,27 +976,22 @@ Endereço: %4</translation>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Abrir URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Cobrança aberta de URI ou arquivo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Selecione o arquivo de cobrança</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Selecione o arquivo de cobrança para ser aberto</translation>
     </message>
@@ -1248,253 +999,206 @@ Endereço: %4</translation>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opções</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>Principal</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Taxa de transação opcional por kB que ajuda a garantir que suas transações sejam processadas rapidamente. A maioria das transações são de 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Pagar taxa de &amp;transação</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Iniciar Bitcoin automaticamente após se logar no sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>Iniciar Bitcoin no login do sistema</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>Tamanho do banco de &amp;dados do cache</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>Número de threads do script de &amp;verificação</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Defina o número de linhas de verificação (até 16, 0 = auto, &lt;0 = deixar muitos núcleos livres, padrão: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation>Ga&amp;star troco não confirmado (avançado)</translation>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Conectado na rede do Bitcoin através de proxy SOCKS.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>&amp;Conectado via proxy SOCKS (padrão proxy):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>Endereço de IP do proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation>Ativa as opções de linha de comando que sobrescreve as opções acima:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Redefinir todas as opções do cliente para opções padrão.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Redefinir opções</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>Rede</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation>(0 = automático, &lt;0 = número de cores deixados livres)</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation>C&amp;arteira</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation>Avançado</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>Habilitar opções de &amp;controle de moedas</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>Se você desabilitar o gasto de um troco não confirmado, o troco da transação não poderá ser utilizado até a transação ter pelo menos uma confirmação. Isso também afeta seu saldo computado.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>Ga&amp;star mudança não confirmada</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Abrir as portas do cliente Bitcoin automaticamente no roteador. Isto só funcionará se seu roteador suportar UPnP e esta função estiver habilitada.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapear porta usando &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP do proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Porta:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Porta do serviço de proxy (ex. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Versão do SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Versão do proxy SOCKS (ex. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Janela</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Mostrar apenas um ícone na bandeja ao minimizar a janela.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimizar para a bandeja em vez da barra de tarefas.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimizar em vez de sair do aplicativo quando a janela for fechada. Quando esta opção é escolhida, o aplicativo só será fechado selecionando Sair no menu Arquivo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimizar ao sair</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Mostrar</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Língua da interface com usuário:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>A língua da interface com usuário pode ser escolhida aqui. Esta configuração só surtirá efeito após reiniciar o Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unidade usada para mostrar quantidades:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Escolha a unidade padrão de subdivisão para interface mostrar quando enviar bitcoins.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Mostrar ou não endereços Bitcoin na lista de transações.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>Mostrar en&amp;dereços na lista de transações</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Mostrar ou não opções de controle da moeda.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation>Mostrar opções de &amp;controle de moeda (avançado)</translation>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>padrão</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>nenhum</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Confirmar redefinição de opções</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Reinicialização do aplicativo necessária para efetivar alterações.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>O aplicativo vai desligar, deseja continuar?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Essa mudança requer uma reinicialização do aplicativo.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>O endereço proxy fornecido é inválido.</translation>
     </message>
@@ -1502,69 +1206,54 @@ Endereço: %4</translation>
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulário</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>A informação mostrada pode estar desatualizada. Sua carteira sincroniza automaticamente com a rede Bitcoin depois que a conexão é estabelecida, mas este processo pode não estar completo ainda.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Carteira</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Disponível:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Seu saldo atual spendable</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>Pendente:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Total de transações que ainda têm de ser confirmados, e ainda não contam para o equilíbrio spendable</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Imaturo:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Saldo minerado que ainda não maturou</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Seu saldo total atual</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transações recentes&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>fora de sincronia</translation>
     </message>
@@ -1572,93 +1261,70 @@ Endereço: %4</translation>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Manipulação de URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI não pode ser decodificado! Isso pode ter sido causado por um endereço Bitcoin inválido ou por parâmetros URI malformados.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Valor do pagamento solicitado de 1% é muito pequeno (Considerado poeira).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Erro no pedido de pagamento</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Não foi possível iniciar bitcoin: manipulador clique-para-pagar</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Gerenciador de rede problemático</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>Seu proxy ativo não suporta SOCKS5, que é obrigatório para cobranças via proxy.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>URL de cobrança é inválida: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Manipulação de arquivo de cobrança</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>Arquivo de cobrança não pôde ser lido ou processado! Isso pode ter sido causado por um arquivo de cobrança inválido.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Cobrança não verificada para scripts de pagamento personalizados não é suportado.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Reembolso de 1%</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Erro na comunicação com% 1:% 2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>Cobrança não pôde ser processada!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Resposta ruim do servidor% 1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Pagamento reconhecido</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Erro de solicitação de rede</translation>
     </message>
@@ -1666,23 +1332,22 @@ Endereço: %4</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Erro: diretório de dados especificado &quot;% 1&quot; não existe.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Erro: Não foi possível interpretar arquivo de configuração: %1. Utilize apenas a sintaxe chave=valor.</translation>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Erro: Combinação inválida de-regtest e testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Digite um endereço Bitcoin (exemplo: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1690,22 +1355,18 @@ Endereço: %4</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Salvar imagem</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Copiar Imagem</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Salvar código QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG Imagem (*.png)</translation>
     </message>
@@ -1713,192 +1374,146 @@ Endereço: %4</translation>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nome do cliente</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versão do cliente</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informação</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Janela de debug</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Geral</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Usando OpenSSL versão</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Horário de inicialização</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Rede</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Número de conexões</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Corrente de blocos</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Quantidade atual de blocos</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Total estimado de blocos</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Horário do último bloco</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Console</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>Tráfico de Rede</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Limpar</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totais</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>Entrada:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>Saída:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Data do &apos;build&apos;</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Arquivo de log de Depuração</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Abrir o arquivo de log de depuração do Bitcoin do diretório atual de dados. Isso pode levar alguns segundos para arquivos de log grandes.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Limpar console</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bem-vindo ao console Bitcoin RPC.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Use as setas para cima e para baixo para navegar pelo histórico, e &lt;b&gt;Ctrl-L&lt;/b&gt; para limpar a tela.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Digite &lt;b&gt;help&lt;/b&gt; para uma visão geral dos comandos disponíveis.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>1% B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>1% KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1906,105 +1521,82 @@ Endereço: %4</translation>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>Qu&amp;antia:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
-        <translation>&amp;Etiqueta:</translation>
+        <translation>&amp;Rótulo:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Mensagem</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Reutilize um dos endereços de recebimento anteriormente utilizados. Reutilizar um endereço implica em problemas com segurança e privacidade. Não reutilize a menos que esteja refazendo uma cobrança já feita anteriormente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>R&amp;eutilize um endereço de recebimento (não recomendado)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>Uma mensagem opcional que será anexada na cobrança e será mostrada quando ela for aberta. Nota: A mensagem não será enviada com o pagamento pela rede Bitcoin.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Um marcador opcional para associar ao novo endereço de recebimento.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Use esse formulário para fazer cobranças. Todos os campos são &lt;b&gt;opcionais&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Uma quantia opcional para cobrar. Deixe vazio ou em branco se o pagador puder especificar a quantia.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Limpa todos os campos do formulário.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Limpar</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Histórico de cobranças</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Requisitar Pagamento</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>Mostra a cobrança selecionada (o mesmo que clicar duas vezes em um registro)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation>Remove o registro selecionado da lista</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
-        <translation>Copiar etiqueta</translation>
+        <translation>Copiar rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Copiar mensagem</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
@@ -2012,67 +1604,54 @@ Endereço: %4</translation>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Copiar &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>&amp;Copiar Endereço</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Salvar Imagem...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Requisitar pagamento para %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Informação de pagamento</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation>Rótulo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mensagem</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI resultante muito longa. Tente reduzir o texto do rótulo ou da mensagem.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Erro ao codigicar o URI em código QR</translation>
     </message>
@@ -2080,37 +1659,30 @@ Endereço: %4</translation>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation>Rótulo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mensagem</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(Sem rótulo)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(sem mensagem)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(sem quantia especificada)</translation>
     </message>
@@ -2118,247 +1690,194 @@ Endereço: %4</translation>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Enviar dinheiro</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Opções de Controle da Moeda</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Entradas...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>automaticamente selecionado</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Saldo insuficiente!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Quantidade:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Quantia:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioridade:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Rendimento baixo:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Depois da taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>trocar</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Se isso estiver ativo e o endereço de troco estiver vazio ou inválido, o troco será enviado a um novo endereço gerado na hora.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Endereço específico de troco</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Enviar para vários destinatários de uma só vez</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Adicionar destinatário</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Limpar todos os campos do formulário.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Limpar Tudo</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Confirmar o envio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>Enviar</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirmar envio de dinheiro</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 para %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Copiar quantidade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Copiar taxa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copia pós-taxa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copia prioridade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copia saída de pouco valor</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copia alteração</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Quantidade Total %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>ou</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>O endereço do destinatário não é válido, favor verificar.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>A quantidade a ser paga precisa ser maior que 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>A quantidade excede seu saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>O total excede seu saldo quando uma taxa de transação de %1 é incluída.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Endereço duplicado: pode-se enviar para cada endereço apenas uma vez por transação.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>A criação de transação falhou!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>A transação foi rejeitada! Isso pode acontecer se alguns bitcoins na sua carteira já foram gastos em outro local, por exemplo se você tiver uma cópia do wallet.dat e os bitcoins tiverem sido gastos na cópia mas não marcados como gastos aqui ainda.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Atenção: endereço de Bitcoin inválido</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(Sem rótulo)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Atenção: endereço de troco desconhecido</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Tem certeza que quer enviar?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>Adicionado como taxa de transação</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Pedido de pagamento expirado</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Endereço de pagamento inválido %1</translation>
     </message>
@@ -2366,98 +1885,74 @@ Endereço: %4</translation>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Q&amp;uantidade:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Pagar &amp;Para:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>O endereço para onde enviar o pagamento (ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
-        <translation>Digite uma etiqueta para este endereço para adicioná-lo ao catálogo de endereços</translation>
+        <translation>Digite um rótulo para este endereço para adicioná-lo ao catálogo de endereços</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
-        <translation>&amp;Etiqueta:</translation>
+        <translation>&amp;Rótulo:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Escolher endereço usado anteriormente</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Este é um pagamento normal.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Colar o endereço da área de transferência</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Remover esta entrada</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Mensagem:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Essa é cobrança verificada.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation>Digite um nome para este endereço para adicioná-lo no catálogo</translation>
+        <translation>Digite um rótulo para este endereço para adicioná-lo no catálogo</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>A mensagem que foi anexada ao bitcoin: URI na qual será gravada na transação para sua referência. Nota: Essa mensagem não será gravada publicamente na rede Bitcoin.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Essa é uma cobrança não verificada.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Pague Para:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memorizar:</translation>
     </message>
@@ -2465,12 +1960,10 @@ Endereço: %4</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Core está desligando...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Não desligue o computador até esta janela desaparece.</translation>
     </message>
@@ -2478,186 +1971,142 @@ Endereço: %4</translation>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Assinaturas - Assinar / Verificar uma mensagem</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Assinar Mensagem</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Você pode assinar mensagens com seus endereços para provar que você é o dono deles. Seja cuidadoso para não assinar algo vago, pois ataques de pishing podem tentar te enganar para dar sua assinatura de identidade para eles. Apenas assine afirmações completamente detalhadas com as quais você concorda.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Endereço a ser usado para assinar a mensagem (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Escolha um endereço usado anteriormente</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Colar o endereço da área de transferência</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Entre a mensagem que você quer assinar aqui</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Assinatura</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copiar a assinatura para a área de transferência do sistema</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Assinar mensagem para provar que você é dono deste endereço Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Assinar &amp;Mensagem</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Limpar todos os campos de assinatura da mensagem</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Limpar Tudo</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verificar Mensagem</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Forneça o endereço da assinatura, a mensagem (se assegure que você copiou quebras de linha, espaços, tabs, etc. exatamente) e a assinatura abaixo para verificar a mensagem. Cuidado para não ler mais na assinatura do que está escrito na mensagem propriamente, para evitar ser vítima de uma ataque do tipo &quot;man-in-the-middle&quot;.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>O endereço usado para assinar a mensagem (ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verificar mensagem para se assegurar que ela foi assinada pelo dono de um endereço Bitcoin específico.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verificar %Mensagem</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Limpar todos os campos de assinatura da mensagem</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Digite um endereço Bitcoin (exemplo: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Clique em &quot;Assinar Mensagem&quot; para gerar a assinatura</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>O endereço fornecido é inválido.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Por favor, verifique o endereço e tente novamente.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>O endereço fornecido não se refere a uma chave.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
-        <translation>Destravamento da Carteira foi cancelado.</translation>
+        <translation>Desbloqueamento da Carteira foi cancelado.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>A chave privada para o endereço fornecido não está disponível.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Assinatura da mensagem falhou.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Mensagem assinada.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>A assinatura não pode ser decodificada.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Por favor, verifique a assinatura e tente novamente.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>A assinatura não corresponde ao &quot;resumo da mensagem&quot;.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Verificação da mensagem falhou.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Mensagem verificada.</translation>
     </message>
@@ -2665,17 +2114,14 @@ Endereço: %4</translation>
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Núcleo Bitcoin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Programadores do Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2683,7 +2129,6 @@ Endereço: %4</translation>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2691,184 +2136,138 @@ Endereço: %4</translation>
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Aberto até %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>em conflito</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/não confirmadas</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmações</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, difundir atráves de %n nó</numerusform><numerusform>, difundir atráves de %n nós</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Fonte</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Gerados</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>seu próprio endereço</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
-        <translation>etiqueta</translation>
+        <translation>rótulo</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Crédito</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>matura em mais %n bloco</numerusform><numerusform>matura em mais %n blocos</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>não aceito</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Débito</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Taxa de transação</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Valor líquido</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mensagem</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Comentário</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID da transação</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Mercador</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Bitcoins recém minerados precisam aguardar %1 blocos antes de serem gastos. Quando o bloco foi gerado, ele foi disseminado pela rede para ser adicionado à cadeia de blocos: blockchain. Se ele falhar em ser inserido na cadeia, seu estado será modificado para &quot;não aceito&quot; e ele não poderá ser gasto. Isso pode acontecer eventualmente quando blocos são gerados quase que simultaneamente.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Informação de depuração</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transação</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Entradas</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>verdadeiro</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, ainda não foi propagada na rede com sucesso.</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abrir para mais %n bloco</numerusform><numerusform>Abrir para mais %n blocos</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>desconhecido</translation>
     </message>
@@ -2876,12 +2275,10 @@ Endereço: %4</translation>
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detalhes da transação</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Este painel mostra uma descrição detalhada da transação</translation>
     </message>
@@ -2889,127 +2286,102 @@ Endereço: %4</translation>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>Recém-criado (%1 confirmações, disponível somente após %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Abrir para mais %n bloco</numerusform><numerusform>Abrir para mais %n blocos</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Aberto até %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmado (%1 confirmações)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Este bloco não foi recebido por nenhum outro participante da rede e provavelmente não será aceito!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Gerado mas não aceito</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Offline</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Não confirmado</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Confirmando (%1 de %2 confirmações recomendadas)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>Conflitou</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Recebido por</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Recebido de</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Enviado para</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pagamento para você mesmo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minerado</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status da transação. Passe o mouse sobre este campo para mostrar o número de confirmações.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Data e hora em que a transação foi recebida.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipo de transação.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Endereço de destino da transação.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Quantidade debitada ou creditada ao saldo.</translation>
     </message>
@@ -3017,178 +2389,142 @@ Endereço: %4</translation>
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Todos</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hoje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Esta semana</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Este mês</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Mês passado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Este ano</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Intervalo...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Recebido por</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Enviado para</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Para você mesmo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minerado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Outro</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
-        <translation>Procure um endereço ou etiqueta</translation>
+        <translation>Procure um endereço ou rótulo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Quantidade mínima</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copiar endereço</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
-        <translation>Copiar etiqueta</translation>
+        <translation>Copiar rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID da transação</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
-        <translation>Editar etiqueta</translation>
+        <translation>Editar rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Mostrar detalhes da transação</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation>Exportar Histórico de Transação</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Exportação Falhou</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Ocorreu um erro ao tentar salvar o histórico de transação em %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Exportação feita com sucesso</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>O histórico de transação foi gravado com sucesso em %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Arquivo separado por vírgulas (*. csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
-        <translation>Etiqueta</translation>
+        <translation>Rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Quantidade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Intervalo: </translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>para</translation>
     </message>
@@ -3196,7 +2532,6 @@ Endereço: %4</translation>
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Nenhuma carteira foi carregada.</translation>
     </message>
@@ -3204,7 +2539,6 @@ Endereço: %4</translation>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Send Coins</translation>
     </message>
@@ -3212,42 +2546,34 @@ Endereço: %4</translation>
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar os dados na aba atual para um arquivo</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Fazer cópia de segurança da Carteira</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Dados da Carteira (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Cópia de segurança Falhou</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Ocorreu um erro ao tentar salvar os dados da carteira em %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Os dados da carteira foram salvos com sucesso em %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Backup feito com sucesso</translation>
     </message>
@@ -3255,107 +2581,86 @@ Endereço: %4</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Uso:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Lista de comandos</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Obtenha ajuda sobre um comando</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Opções:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Especifique um arquivo de configurações (padrão: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Especifique um arquivo de pid (padrão: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Especificar diretório de dados</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Definir o tamanho do cache do banco de dados em megabytes (padrão: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Procurar por conexões em &lt;port&gt; (padrão: 8333 ou testnet:18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Manter no máximo &lt;n&gt; conexões aos peers (padrão: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Conectar a um nó para receber endereços de participantes, e desconectar.</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Especificar seu próprio endereço público</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Limite para desconectar peers mal comportados (padrão: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Número de segundos para impedir que peers mal comportados reconectem (padrão: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Um erro ocorreu ao configurar a porta RPC %u para escuta em IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Escutar conexões JSON-RPC na porta &lt;porta&gt; (padrão: 8332 ou testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Aceitar linha de comando e comandos JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation>Versão do cliente Bitcoin Core RPC</translation>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Rodar em segundo plano como serviço e aceitar comandos</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Usar rede de teste</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Aceitar conexões externas (padrão: 1 se opções -proxy ou -connect não estiverem presentes)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3380,722 +2685,682 @@ por exemplo: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
-        <translation>Codificadores aceitos (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
+        <translation>Codificadores aceitos (padrão: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Um erro ocorreu ao configurar a porta RPC %u para escuta em IPv6, voltando ao IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Vincular ao endereço fornecido e sempre escutar nele. Use a notação [host]:port para IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Não foi possível obter exclusividade de escrita no endereço %s. O Bitcoin provavelmente já está rodando.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation>Restringe a taxa de transações gratuitas para &lt;n&gt;*1000 bytes por minuto (padrão:15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Entre em modo de teste de regressão, que utiliza uma cadeia especial em que os blocos podem ser resolvido imediatamente. Este destina-se a ferramentas de teste de regressão e de desenvolvimento de aplicativos.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>Entra no modo de teste de regressão, que usa uma cadeia especial onde os blocos podem ser resolvidos instantaneamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation>Erro: Falha ao tentar aguardar conexões de entrada (erro retornado %d)</translation>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Erro: A transação foi rejeitada. Isso pode acontecer se alguns dos bitcoins de sua carteira já haviam sido gastos, por exemplo se você usou uma cópia do arquivo wallet.dat e alguns bitcoins foram gastos na cópia mas não foram marcados como gastos aqui.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Erro: Esta transação requer uma taxa de transação de pelo menos %s, por causa sua quantidade, complexidade ou uso de dinheiro recebido recentemente.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Executar comando quando uma transação da carteira mudar (%s no comando será substituído por TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation>Taxas menores que esta são consideradas taxa zero (para criação da transação) (padrão:</translation>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation>Descarrega a atividade do banco de dados da memória para log em disco a cada &lt;n&gt; megabytes (padrão: 100)</translation>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation>Quão completa a verificação de blocos do -checkblocks é (0-4, padrão: 3)</translation>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation>Neste modo -genproclimit controla quantos blocos são gerados imediatamente.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation>Define o número de threads de verificação de script (%u a %d, 0 = automático, &lt;0 = número de cores deixados livres, padrão: %d)</translation>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation>Define o limite de processador para quando geração está ativa (-1 = ilimitada, padrão: -1)</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Este pode ser um build de teste pré-lançamento - use por sua conta e risco - não use para mineração ou aplicações de comércio.</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation>Impossível ouvir em %s neste computador. Bitcoin Core já está sendo executado provavelmente.</translation>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Use proxy SOCKS5 separado para alcançar nós via Tor hidden services (padrão: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
-        <translation>Cuidado: valor de -paytxfee escolhido é muito alto! Este é o valor da taxa de transação que você irá pagar se enviar a transação.</translation>
+        <translation>Atenção: valor de -paytxfee escolhido é muito alto! Este é o valor da taxa de transação que você irá pagar se enviar a transação.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
-        <translation>Cuidado: Por favor, verifique que a data e hora do seu computador estão corretas! If o seu relógio estiver errado, o Bitcoin não irá funcionar corretamente.</translation>
+        <translation>Atenção: Por favor, verifique que a data e hora do seu computador estão corretas! Se o seu relógio estiver errado, o Bitcoin não irá funcionar corretamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
-        <translation>Aviso: A rede não parecem concordar plenamente! Alguns mineiros parecem estar enfrentando problemas.</translation>
+        <translation>Atenção: A rede não parecem concordar plenamente! Alguns mineiros parecem estar enfrentando problemas.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation>Aviso: Nós não parecem concordar plenamente com nossos colegas! Você pode precisar atualizar ou outros nós pode precisar atualizar.</translation>
+        <translation>Atenção: Nós não parecemos concordar plenamente com nossos colegas! Você pode precisar atualizar ou outros nós podem precisar atualizar.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
-        <translation>Cuidado: erro ao ler arquivo wallet.dat! Todas as chaves foram lidas corretamente, mas dados transações e do catálogo de endereços podem estar faltando ou estar incorretas.</translation>
+        <translation>Atenção: erro ao ler arquivo wallet.dat! Todas as chaves foram lidas corretamente, mas dados de transações e do catálogo de endereços podem estar faltando ou incorretos.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
-        <translation>Aviso: wallet.dat corrompido, dados recuperados! Arquivo wallet.dat original salvo como wallet.{timestamp}.bak em %s; se seu saldo ou transações estiverem incorretos, você deve restauras o backup.</translation>
+        <translation>Atenção: wallet.dat corrompido, dados recuperados! Arquivo wallet.dat original salvo como wallet.{timestamp}.bak em %s; se seu saldo ou transações estiverem incorretos, você deve restaurar o backup.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation>(padrão: 1)</translation>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation>(padrão: wallet.dat)</translation>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; pode ser:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Tentar recuperar chaves privadas de um arquivo wallet.dat corrompido</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Bitcoin Core Daemon</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Bitcoin RPC versão do cliente</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Opções de criação de blocos:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Limpa a lista de transações da carteira (ferramenta de diagnóstico; implica -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Conectar apenas a nó(s) específico(s)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Conecta através de proxy SOCKS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
-        <translation>Conectar-se ao JSON-RPC em &lt;port&gt; (default: 8332 or testnet: 18332)</translation>
+        <translation>Conectar-se ao JSON-RPC em &lt;port&gt; (padrão: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>Opções de conexão:</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Detectado Banco de dados de blocos corrompido</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation>Opções de Debug/Teste:</translation>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation>Desabilita modo seguro, sobrepõe um evento de modo seguro real (padrão: 0)</translation>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Descobrir os próprios endereços IP (padrão: 1 quando no modo listening e opção -externalip não estiver presente)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Não carrega a carteira e desabilita as chamadas RPC para a carteira</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Você quer reconstruir o banco de dados de blocos agora?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Erro ao inicializar banco de dados de blocos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Erro ao inicializar ambiente de banco de dados de carteira %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Erro ao carregar banco de dados de blocos</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Erro ao abrir banco de dados de blocos</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Erro: Espaço em disco insuficiente!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
-        <translation>Erro: Carteira travada, impossível criar transação!</translation>
+        <translation>Erro: Carteira bloqueada, impossível criar transação!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Erro: erro de sistema</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Falha ao escutar em qualquer porta. Use -listen=0 se você quiser isso.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Falha ao ler informação de bloco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Falha ao ler bloco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Falha ao sincronizar índice de blocos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Falha ao escrever índice de blocos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Falha ao escrever informações de bloco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Falha ao escrever bloco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Falha ao escrever informções de arquivo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Falha ao escrever banco de dados de moedas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Falha ao escrever índice de transações</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Falha ao escrever dados para desfazer ações</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Taxa por kB para adicionar às transações que você envia</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation>Taxas menores que esta são consideradas taxa zero (para relay) (padrão:</translation>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Procurar pares usando consulta de DNS (padrão: 1 a menos que a opção -connect esteja presente)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation>Força modo seguro (padrão: 0)</translation>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Gerar moedas (padrão: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Quantos blocos checar ao inicializar (padrão: 288, 0 = todos)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Quão minuciosa é a verificação dos blocos (0-4, padrão: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>Se &lt;category&gt; não for informada, logar toda informação de debug.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Bloco gênese incorreto ou não encontrado. Datadir errado para a rede?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Endereço -onion inválido: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Decriptadores de arquivos disponíveis insuficientes.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>Adiciona timestamp como prefixo no debug (padrão: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>Opções de cliente RPC:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Reconstruir índice de blockchain a partir dos arquivos atuais blk000??.dat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Seleciona versão SOCKS para -proxy (4 ou 5, padrão: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Enviar comando para um servidor Bitcoin</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation>Define o tamanho do cache do banco de dados em megabytes (%d para %d, padrão: %d)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Define o tamanho máximo de cada bloco em bytes (padrão: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
-        <translation>Defina o número de threads de script de verificação. (Padrão: 4)</translation>
+        <translation>Defina o número de threads de chamadas RPC (padrão: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Especifique o arquivo da carteira (dentro do diretório de dados)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Permite gastar troco não confirmado ao criar transações (padrão: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Iniciar servidor Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>Isso é usado para testes de regressão e ferramentas de desenvolvimento.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Exemplo de uso (obsoleto, use bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verificando blocos...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Verificando carteira...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Aguarde um servidor RPC para iniciar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Carteira de% s reside fora de dados do diretório% s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Opções da Carteira:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Atenção: Parâmetro obsoleto -debugnet foi ignorado, use -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Você precisa reconstruir o banco de dados utilizando-reindexar a mudar-txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importar blocos de um arquivo externo blk000??.dat</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation>Não foi possível obter proteção exclusiva ao diretório de dados %s. Bitcoin Core já está sendo executado provavelmente.</translation>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Executa o comando quando um alerta relevante é recebido ou vemos um longo garfo (% s em cmd é substituída pela mensagem)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Informação de saída de debug (padrão: 0, definir &lt;category&gt; é opcional)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Define o tamanho máximo de alta-prioridade por taxa baixa nas transações em bytes (padrão: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Defina o número de linhas de verificação (até 16, 0 = auto, &lt;0 = deixar muitos núcleos livres, padrão: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informação</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantidade inválida para -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Inválido montante for-mintxfee = &lt;amount&gt;: &apos;% s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation>Limita tamanho do cache de assinaturas em &lt;n&gt; entradas (padrão: 50000)</translation>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation>Registra log da prioridade de transação e taxa por kB quando minerando blocos (padrão: 0)</translation>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Manter índice completo de transações (padrão: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Buffer máximo de recebimento por conexão, &lt;n&gt;*1000 bytes (padrão: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Buffer máximo de envio por conexão, &lt;n&gt;*1000 bytes (padrão: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Apenas aceitar cadeia de blocos correspondente a marcas de verificação internas (padrão: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Apenas conectar em nós na rede &lt;net&gt; (IPv4, IPv6, ou Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation>Imprime bloco ao iniciar, se encontrado no índice de blocos</translation>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation>Imprime árvore de blocos ao iniciar (padrão: 0)</translation>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>Opções RPC SSL: (veja o Bitcoin Wiki para instruções de configuração SSL)</translation>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>Opções do servidor RPC:</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation>Aleatoriamente descarta 1 em cada &lt;n&gt; mensagens da rede</translation>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation>Aleatoriamente embaralha 1 em cada &lt;n&gt; mensagens da rede</translation>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation>Executa uma thread para limpar a carteira periodicamente (padrão: 1)</translation>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Opções SSL: (veja a Wiki do Bitcoin para instruções de configuração SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation>Enviar comando ao Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Mandar informação de trace/debug para o console em vez de para o arquivo debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Determinar tamanho mínimo de bloco em bytes (padrão: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation>Define a flag DB_PRIVATE no ambiente de banco de dados da carteira (padrão: 1)</translation>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>Exibir todas opções de debug (uso: --help -help-debug)</translation>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation>Exibir informação de benchmark (padrão: 0)</translation>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Encolher arquivo debug.log ao iniciar o cliente (padrão 1 se opção -debug não estiver presente)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Assinatura de transação falhou</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Especifique o tempo limite (timeout) da conexão em milissegundos (padrão: 5000) </translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation>Inicializar serviço Bitcoin Core</translation>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Erro de sistema:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Quantidade da transação muito pequena.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>As quantidades das transações devem ser positivas.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transação muito larga</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Usar UPnP para mapear porta de escuta (padrão: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Usar UPnP para mapear porta de escuta (padrão: 1 quando estiver escutando)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nome de usuário para conexões JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
-        <translation>Cuidado</translation>
+        <translation>Atenção</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
-        <translation>Cuidado: Esta versão está obsoleta, atualização exigida!</translation>
+        <translation>Atenção: Esta versão está obsoleta, atualização exigida!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Aniquilando todas as transações da carteira...</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>ao iniciar</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>versão</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corrompido, recuperação falhou</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Senha para conexões JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permitir conexões JSON-RPC de endereços IP específicos</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
-        <translation>Enviar comando para nó rodando em &lt;ip&gt; (pardão: 127.0.0.1)</translation>
+        <translation>Enviar comando para nó rodando em &lt;ip&gt; (padrão: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Executar comando quando o melhor bloco mudar (%s no comando será substituído pelo hash do bloco)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Atualizar carteira para o formato mais recente</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Determinar tamanho do pool de endereços para &lt;n&gt; (padrão: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Re-escanear blocos procurando por transações perdidas da carteira</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Usar OpenSSL (https) para conexões JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Arquivo de certificado do servidor (padrão: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Chave privada do servidor (padrão: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Esta mensagem de ajuda</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Impossível vincular a %s neste computador (bind retornou erro %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permitir consultas DNS para -addnode, -seednode e -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Carregando endereços...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Erro ao carregar wallet.dat: Carteira corrompida</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Erro ao carregar wallet.dat: Carteira requer uma versão mais nova do Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>A Carteira precisou ser reescrita: reinicie o Bitcoin para completar</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Erro ao carregar wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Endereço -proxy inválido: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Rede desconhecida especificada em -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Versão desconhecida do proxy -socks requisitada: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Impossível encontrar o endereço -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Impossível encontrar endereço -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantidade inválida para -paytxfee=&lt;quantidade&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Quantidade inválida</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Saldo insuficiente</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Carregando índice de blocos...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Adicionar um nó com o qual se conectar e tentar manter a conexão ativa</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Impossível vincular a %s neste computador. O Bitcoin provavelmente já está rodando.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Carregando carteira...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Não é possível fazer downgrade da carteira</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Não foi possível escrever no endereço padrão</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Re-escaneando...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Carregamento terminado</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Para usar a opção %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_pt_PT.ts
+++ b/src/qt/locale/bitcoin_pt_PT.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
-        <translation>Sobre o Núcleo Bitcoin</translation>
+        <translation>Sobre o Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
-        <translation>&lt;b&gt;Bitcoin Core&lt;/b&gt; versão</translation>
+        <translation>versão do &lt;b&gt;Bitcoin Core&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Distribuído sob uma licença de software MIT/X11, por favor verifique o ficheir
 Este produto inclui software desenvolvido pelo Projecto OpenSSL para uso no OpenSSL Toolkit (http://www.openssl.org/), software criptográfico escrito por Eric Young (eay@cryptsoft.com) e software UPnP escrito por Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
-        <translation>Os programadores Bitcoin</translation>
+        <translation>Os programadores Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Clique duas vezes para editar o endereço ou o rótulo</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Criar um novo endereço</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Novo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
-        <translation>Copie o endereço selecionado para a área de transferência</translation>
+        <translation>Copiar o endereço selecionado para a área de transferência</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiar</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>F&amp;echar</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copiar Endereço</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Apagar o endereço selecionado da lista</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar os dados no separador actual para um ficheiro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
-        <translation>E&amp;liminar</translation>
+        <translation>E&amp;liminar\</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
-        <translation>Escolha o endereço com que pretende enviar</translation>
+        <translation>Escolha o endereço para o qual pretende enviar moedas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
-        <translation>Escolha o endereço com que pretende receber</translation>
+        <translation>Escolha o endereço com o qual pretende receber moedas</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>Escol&amp;her</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Endereços de envio</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Endereços de depósito</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
-        <translation>Estes são os seus endereços Bitcoin para enviar pagamentos. Verifique sempre o valor e a morada de envio antes de enviar moedas.</translation>
+        <translation>Estes são os seus endereços Bitcoin para enviar pagamentos. Verifique sempre o valor e o endereço de envio antes de enviar moedas.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Estes são os seus endereços Bitcoin para receber pagamentos. É recomendado que utilize um endereço novo para cada transacção.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copiar &amp;Rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exportar Lista de Endereços</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Ficheiro separado por vírgulas (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
-        <translation>Exportação falhada</translation>
+        <translation>A Exportação Falhou</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Ocorreu um erro ao tentar guardar a lista de endereços em %1.</translation>
     </message>
@@ -169,17 +138,14 @@ Este produto inclui software desenvolvido pelo Projecto OpenSSL para uso no Open
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Rótulo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(sem rótulo)</translation>
     </message>
@@ -187,140 +153,106 @@ Este produto inclui software desenvolvido pelo Projecto OpenSSL para uso no Open
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
-        <translation>Diálogo de Frase-Passe</translation>
+        <translation>Diálogo de frase de segurança</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
-        <translation>Escreva a frase de segurança</translation>
+        <translation>Insira a frase de segurança</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nova frase de segurança</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repita a nova frase de segurança</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
-        <translation>Escreva a nova frase de seguraça da sua carteira. &lt;br/&gt; Por favor, use uma frase de &lt;b&gt;10 ou mais caracteres aleatórios,&lt;/b&gt; ou &lt;b&gt;oito ou mais palavras&lt;/b&gt;.</translation>
+        <translation>Insira a nova frase de segurança da sua carteira.&lt;br/&gt;Por favor, use uma frase de &lt;b&gt;10 ou mais caracteres aleatórios,&lt;/b&gt; ou &lt;b&gt;oito ou mais palavras&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Encriptar carteira</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>A sua frase de segurança é necessária para desbloquear a carteira.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Desbloquear carteira</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>A sua frase de segurança é necessária para desencriptar a carteira.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Desencriptar carteira</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Alterar frase de segurança</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
-        <translation>Escreva a frase de segurança antiga seguida da nova para a carteira.</translation>
+        <translation>Escreva a antiga frase de segurança da carteira, seguida da nova.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmar encriptação da carteira</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Atenção: Se encriptar a carteira e perder a sua senha irá &lt;b&gt;PERDER TODOS OS SEUS BITCOINS&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Tem a certeza que deseja encriptar a carteira?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
-        <translation>IMPORTANTE: Qualquer cópia de segurança anterior da carteira deverá ser substituída com o novo, actualmente encriptado, ficheiro de carteira. Por razões de segurança, cópias de segurança não encriptadas efectuadas anteriormente do ficheiro da carteira tornar-se-ão inúteis assim que começar a usar a nova carteira encriptada.</translation>
+        <translation>IMPORTANTE: Qualquer cópia de segurança da carteira anterior deverá ser substituída com o novo ficheiro de carteira, agora encriptado. Por razões de segurança, cópias de segurança não encriptadas tornar-se-ão inúteis assim que começar a usar a nova carteira encriptada.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Atenção: A tecla Caps Lock está activa!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Carteira encriptada</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>O cliente Bitcoin irá agora ser fechado para terminar o processo de encriptação. Recorde que a encriptação da sua carteira não protegerá totalmente os seus bitcoins de serem roubados por programas maliciosos que infectem o seu computador.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>A encriptação da carteira falhou</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>A encriptação da carteira falhou devido a um erro interno. A carteira não foi encriptada.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>As frases de segurança fornecidas não coincidem.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>O desbloqueio da carteira falhou</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>A frase de segurança introduzida para a desencriptação da carteira estava incorreta.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>A desencriptação da carteira falhou</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>A frase de segurança da carteira foi alterada com êxito.</translation>
     </message>
@@ -328,362 +260,286 @@ Este produto inclui software desenvolvido pelo Projecto OpenSSL para uso no Open
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Assinar &amp;mensagem...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
-        <translation>Sincronizando com a rede...</translation>
+        <translation>A sincronizar com a rede...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>Visã&amp;o geral</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation>Nó</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Mostrar visão geral da carteira</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transações</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Navegar pelo histórico de transações</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>Fec&amp;har</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Sair da aplicação</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
-        <translation>Mostrar informação sobre Bitcoin</translation>
+        <translation>Mostrar informação sobre o Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Sobre &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Mostrar informação sobre Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opções...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>E&amp;ncriptar Carteira...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Guardar Carteira...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>Mudar &amp;Palavra-passe...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>A &amp;enviar endereços...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>A &amp;receber endereços...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Abrir &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
-        <translation>Importando blocos do disco...</translation>
+        <translation>A importar blocos do disco...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
-        <translation>Reindexando blocos no disco...</translation>
+        <translation>A reindexar blocos no disco...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Enviar moedas para um endereço bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modificar opções de configuração para bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Faça uma cópia de segurança da carteira para outra localização</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Mudar a frase de segurança utilizada na encriptação da carteira</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Janela de &amp;depuração</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Abrir consola de diagnóstico e depuração</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verificar mensagem...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Carteira</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Receber</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>Mo&amp;strar / Ocultar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
-        <translation>Mostrar ou esconder a Janela principal</translation>
+        <translation>Mostrar ou esconder a janela principal</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Encriptar as chaves privadas que pertencem à sua carteira</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Assine mensagens com os seus endereços Bitcoin para provar que os controla</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verifique mensagens para assegurar que foram assinadas com o endereço Bitcoin especificado</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Ficheiro</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>Con&amp;figurações</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>A&amp;juda</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Barra de separadores</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[rede de testes]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
-        <translation>Núcleo Bitcoin</translation>
+        <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation>Solicitar pagamentos (gera códigos QR)</translation>
+        <translation>Solicitar pagamentos (gera códigos QR e URIs bitcoin:)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
-        <translation>&amp;Sobre o Núcleo Bitcoin</translation>
+        <translation>&amp;Sobre o Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
-        <translation>Mostrar a lista de endereços de envio e rótulos usados</translation>
+        <translation>Mostrar a lista de rótulos e endereços de envio usados</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation>Mostrar a lista de endereços para receber pagamentos e rótulos usados</translation>
+        <translation>Mostrar a lista de rótulos e endereços de receção usados</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
-        <translation>Abrir bitcoin: link ou pedido de pagamento</translation>
+        <translation>Abrir URI bitcoin: ou pedido de pagamento</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>Opções da linha de &amp;comandos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
-        <translation>Mostrar a mensagem de ajuda do Bitcoin Core para obter uma lista com possíveis opções para a linha de comandos</translation>
+        <translation>Mostrar a mensagem de ajuda do Bitcoin Core para obter uma lista com possíveis opções de linha de comandos</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Cliente Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n ligação ativa à rede Bitcoin</numerusform><numerusform>%n ligações ativas à rede Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
-        <translation>Nenhum bloco fonto disponível</translation>
+        <translation>Nenhuma fonte de blocos disponível...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
-        <translation>Processados %1 dos %2 blocos (estimados) do histórico de transacções.</translation>
+        <translation>Processados %1 de %2 blocos (estimados) do histórico de transacções.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Processados %1 blocos do histórico de transações.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hora</numerusform><numerusform>%n horas</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n dia</numerusform><numerusform>%n dias</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n semana</numerusform><numerusform>%n semanas</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
-        <translation type="unfinished"/>
+        <translation>%1 e %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>%n ano</numerusform><numerusform>%n anos</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 em atraso</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
-        <translation>Último bloco recebido foi gerado há %1 atrás.</translation>
+        <translation>O último bloco recebido foi gerado %1 atrás.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
-        <translation>Transações posteriores poderão não ser imediatamente visíveis.</translation>
+        <translation>Transações posteriores não serão visíveis por enquanto.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informação</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Atualizado</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
-        <translation>Recuperando...</translation>
+        <translation>Recuperando o atraso...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transação enviada</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transação recebida</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -692,21 +548,17 @@ Address: %4
         <translation>Data: %1
 Quantia: %2
 Tipo: %3
-Endereço: %4
-</translation>
+Endereço: %4</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>A carteira está &lt;b&gt;encriptada&lt;/b&gt; e atualmente &lt;b&gt;desbloqueada&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>A carteira está &lt;b&gt;encriptada&lt;/b&gt; e atualmente &lt;b&gt;bloqueada&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Ocorreu um erro fatal. O Bitcoin não pode continuar com segurança e irá fechar.</translation>
     </message>
@@ -714,7 +566,6 @@ Endereço: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Alerta da Rede</translation>
     </message>
@@ -722,359 +573,285 @@ Endereço: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Seleção de Endereço Coin Control</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Quantidade:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Quantia:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioridade:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Saída Baixa:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
-        <translation>Depois de taxas:</translation>
+        <translation>Depois da Taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Troco:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(des)seleccionar todos</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
-        <translation>Modo de árvore</translation>
+        <translation>Modo árvore</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Modo lista</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Quantia</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Confirmados</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmada</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioridade</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Copiar endereço</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
-        <translation>Copiar ID da Transação</translation>
+        <translation>Copiar ID da transação</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Bloquear não gastos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Desbloquear não gastos</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Copiar quantidade</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
-        <translation>Taxa de cópia</translation>
+        <translation>Copiar taxa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation>Taxa depois de cópia</translation>
+        <translation>Copiar valor após taxa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
-        <translation>Prioridade de Cópia</translation>
+        <translation>Copiar prioridade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copiar output baixo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiar alteração</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
-        <translation>o maior</translation>
+        <translation>muito alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
-        <translation>maior</translation>
+        <translation>mais alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
-        <translation>alto</translation>
+        <translation>alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
-        <translation>médio-alto</translation>
+        <translation>média-alta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
-        <translation>médio</translation>
+        <translation>média</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
-        <translation>baixo-médio</translation>
+        <translation>média-baixa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
-        <translation>baixo</translation>
+        <translation>baixa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
-        <translation>mais baixo</translation>
+        <translation>mais baixa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
-        <translation>O mais baixo</translation>
+        <translation>muito alta</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
-        <translation>(%1 bloqueado)</translation>
+        <translation>(%1 bloqueados)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>nenhum</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
-        <translation>Lixo</translation>
+        <translation>Pó</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>sim</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>não</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation>Esta legenda fica vermelha se o tamanho de transacção exceder os 1000 bytes.</translation>
+        <translation>Este rótulo fica vermelha se o tamanho da transacção exceder os 1000 bytes.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Isto significa que uma taxa de pelo menos %1 por kB é necessária.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Pode variar +/- 1 byte por input.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
-        <translation>Transacções com prioridade mais alta estão mais sujeitas a serem incluídas num &quot;bloco&quot;.</translation>
+        <translation>Transacções com uma prioridade mais alta têm uma maior probabilidade de serem incluídas num bloco.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
-        <translation>Esta legenda fica vermelha se a prioridade for menor que &quot;médio&quot;.</translation>
+        <translation>Esta legenda fica vermelha, se a prioridade for menor que &quot;média&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
-        <translation>Esta legenda fica vermelho se algum recipiente receber uma quantidade menor que %1.</translation>
+        <translation>Este rótulo fica vermelho se algum recipiente receber uma quantia menor que %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Isto significa que uma taxa de pelo menos %1 é necessária.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
-        <translation>Quantias menores que 0.546 vezes a mínima taxa de retransmissão são mostradas como &quot;lixo&quot;.</translation>
+        <translation>Quantias abaixo de 0.546 vezes a taxa mínima de retransmissão são mostradas como &quot;pó&quot;.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
-        <translation>Esta legenda fica vermelha, se a mudança for menor do que %1.</translation>
+        <translation>Esta legenda fica vermelha, se o troco for menor do que %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
-        <translation>(Sem rótulo)</translation>
+        <translation>(sem rótulo)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
-        <translation>Alteração de %1 (%2)</translation>
+        <translation>troco de %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation>(Alteração)</translation>
+        <translation>(troco)</translation>
     </message>
 </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editar Endereço</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Rótulo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>O rótulo associado com esta entrada no livro de endereços</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation>O endereço associado com o rótulo desta entrada. Isto só pode ser modificado para endereços de saída.</translation>
+        <translation>O endereço associado com o esta entrada no livro de endereços. Isto só pode ser modificado para endereços de saída.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>E&amp;ndereço</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Novo endereço de entrada</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Novo endereço de saída</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editar endereço de entrada</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editar endereço de saída</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>O endereço introduzido &quot;%1&quot; já se encontra no livro de endereços.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>O endereço introduzido &quot;%1&quot; não é um endereço bitcoin válido.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Impossível desbloquear carteira.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Falha ao gerar nova chave.</translation>
     </message>
@@ -1082,80 +859,69 @@ Endereço: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Uma nova pasta de dados será criada.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nome</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>A pasta já existe. Adicione %1 se pretender criar aqui uma nova pasta.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Caminho já existe, e não é uma pasta.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
-        <translation>Não pode criar pasta de dados aqui.</translation>
+        <translation>Não pode ser criada uma pasta de dados aqui.</translation>
     </message>
 </context>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
-        <translation>Bitcoin Core - Opções da linha de comandos</translation>
+        <translation>Bitcoin Core - Opções de linha de comandos</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
-        <translation>Núcleo Bitcoin</translation>
+        <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versão</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Utilização:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>opções da linha de comandos</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
-        <translation>Opções de UI</translation>
+        <translation>Opções de Interface</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Definir linguagem, por exemplo &quot;pt_PT&quot; (por defeito: linguagem do sistema)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Iniciar minimizado</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Show splash screen on startup (default: 1)</source>
-        <translation>Mostrar animação ao iniciar (por defeito: 1)</translation>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Show splash screen on startup (default: 1)</source>
+        <translation>Mostrar imagem ao iniciar (por defeito: 1)</translation>
+    </message>
+    <message>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Escolha a pasta de dados ao iniciar (por defeito: 0)</translation>
     </message>
@@ -1163,58 +929,46 @@ Endereço: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Bem-vindo</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Bem-vindo ao Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
-        <translation>Sendo isto a primeira vez que o programa é iniciado, você pode escolher onde Bitcoin Core vai guardar os seus dados.</translation>
+        <translation>Sendo esta a primeira vez que o programa é iniciado, poderá escolher onde o Bitcoin Core irá guardar os seus dados.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
-        <translation>Bitcoin Core vai transferir e guardar uma cópia do Bitcoin &quot;block chain&quot; (cadeia de bloco). Pelo menos %1GB de dados será guardado neste directório, e vai crescer consoante o tempo.
-A sua &quot;carteira&quot; também irá ser guardada neste directório.</translation>
+        <translation>O Bitcoin Core vai transferir e armazenar uma cópia do &quot;block chain&quot; (cadeia de blocos). Pelo menos %1GB de dados serão armazenados nesta pasta, e vão crescer ao longo do tempo. A sua carteira também irá ser armazenada nesta pasta.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
-        <translation>Use a pasta de dados por defeito</translation>
+        <translation>Utilizar a pasta de dados padrão</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
-        <translation>Use uma pasta de dados personalizada</translation>
+        <translation>Utilizar uma pasta de dados personalizada:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
-        <translation>Erro: Pasta de dados especificada &quot;%1&quot; não pode ser criada.</translation>
+        <translation>Erro: Pasta de dados especificada &quot;%1&quot; não pôde ser criada.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
-        <translation>GB de espaço livre</translation>
+        <translation>GB de espaço livre disponível</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(de %1GB necessários)</translation>
     </message>
@@ -1222,281 +976,229 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
-        <translation>URI Aberto</translation>
+        <translation>Abir URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
-        <translation>Pedido de pagamento aberto de um URI or file</translation>
+        <translation>Abrir pedido de pagamento de um URI ou ficheiro</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
-        <translation>Seleccione o ficheiro do pedido de pagamento</translation>
+        <translation>Seleccione o ficheiro de pedido de pagamento</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
-        <translation>Seleccione o ficheiro de pedido de pagamento para abrir</translation>
+        <translation>Seleccione o ficheiro de pedido de pagamento a abrir</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opções</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Principal</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Taxa de transação opcional por KB que ajuda a assegurar que as suas transações serão processadas rapidamente. A maioria das transações tem 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Pagar &amp;taxa de transação</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Começar o Bitcoin automaticamente ao iniciar sessão no sistema.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Começar o Bitcoin ao iniciar o sistema</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
-        <translation>Tamanho dos temporários da &amp;base de dados</translation>
+        <translation>Tamanho da cache da base de &amp;dados</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
-        <translation>Número de processos de script e &amp;verificação</translation>
+        <translation>Número de processos de &amp;verificação de scripts</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Defina o número de processos de verificação (até 16, 0 = automático, &lt;0 = disponibiliza esse número de núcleos livres, por defeito: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Ligar à rede Bitcoin através de um proxy SOCKS.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>Ligar através de um proxy SO&amp;CKS (proxy por defeito):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>Endereço IP do proxy (p.ex. IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
-        <translation type="unfinished"/>
+        <translation>Opções de linha de comandos ativas que se sobrepõem ás opções anteriores:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
-        <translation>Repôr todas as opções.</translation>
+        <translation>Repor todas as opções do cliente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
-        <translation>&amp;Repôr Opções</translation>
+        <translation>&amp;Repor Opções</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Rede</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
-        <translation type="unfinished"/>
+        <translation>C&amp;arteira</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation>Especialista</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>Ativar funcionalidades de controlo de transação.</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished"/>
+        <translation>No caso de desativar o gasto de troco não confirmado, o troco de uma transação não poderá ser utilizado até que essa transação tenha pelo menos uma confirmação. Isto também afeta o cálculo do seu saldo.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>&amp;Gastar troco não confirmado</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
-        <translation>Abrir a porta do cliente bitcoin automaticamente no seu router. Isto penas funciona se o seu router suportar UPnP e este se encontrar ligado.</translation>
+        <translation>Abrir a porta do cliente bitcoin automaticamente no seu router. Isto apenas funciona se o seu router suportar UPnP e este se encontrar ligado.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapear porta usando &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP do proxy:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Porta:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Porta do proxy (p.ex. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Versão SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Versão do proxy SOCKS (p.ex. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Janela</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
-        <translation>Apenas mostrar o ícone da bandeja após minimizar a janela.</translation>
+        <translation>Apenas mostrar o ícone da bandeja de sistema após minimizar a janela.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
-        <translation>&amp;Minimizar para a bandeja e não para a barra de ferramentas</translation>
+        <translation>&amp;Minimizar para a bandeja de sistema e não para a barra de ferramentas</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
-        <translation>Minimize ao invés de sair da aplicação quando a janela é fechada. Com esta  opção selecionada, a aplicação apenas será encerrada quando escolher Sair da aplicação no menú.</translation>
+        <translation>Minimize ao invés de sair da aplicação quando a janela é fechada. Com esta opção selecionada, a aplicação apenas será encerrada só quando escolher Sair da aplicação no menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimizar ao fechar</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>Vis&amp;ualização</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Linguagem da interface de utilizador:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>A linguagem da interface do utilizador pode ser definida aqui. Esta definição entrará em efeito após reiniciar o Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
-        <translation>&amp;Unidade a usar em quantias:</translation>
+        <translation>&amp;Unidade para mostrar quantias:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Escolha a subdivisão unitária a ser mostrada por defeito na aplicação e ao enviar moedas.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Se mostrar, ou não, os endereços Bitcoin na lista de transações.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>Mostrar en&amp;dereços na lista de transações</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
-        <translation>Escolha para mostrar funcionalidades de controlo &quot;coin&quot; ou não.</translation>
+        <translation>Escolha para mostrar funcionalidades de Coin Control ou não.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation>Mostrar coin &amp; funcionalidades de controlo (apenas para utilizadores experientes)</translation>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>padrão</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>nenhum</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Confirme a reposição de opções</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
-        <translation>Precisa reiniciar o cliente para ativar as mudanças.</translation>
+        <translation>É necessário reiniciar o cliente para ativar as alterações.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
-        <translation>O cliente será desligado, deseja proceder?</translation>
+        <translation>O cliente será desligado, deseja continuar?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
-        <translation>Esta mudança requer um reinício do cliente.</translation>
+        <translation>Esta alteração requer um reinício do cliente.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>O endereço de proxy introduzido é inválido. </translation>
     </message>
@@ -1504,69 +1206,54 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulário</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>A informação mostrada poderá estar desatualizada. A sua carteira sincroniza automaticamente com a rede Bitcoin depois de estabelecer ligação, mas este processo ainda não está completo.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Carteira</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
-        <translation type="unfinished"/>
+        <translation>Disponível:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
-        <translation>O seu saldo disponível para gastar</translation>
+        <translation>O seu saldo (gastável) disponível</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
-        <translation type="unfinished"/>
+        <translation>Pendente:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
-        <translation>Total de transações ainda não confirmadas, e que não estão contabilizadas ainda no seu saldo actual</translation>
+        <translation>Total de transações por confirmar, que ainda não estão contabilizadas no seu saldo gastável</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Imaturo:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
-        <translation>O saldo minado ainda não maturou</translation>
+        <translation>O saldo minado ainda não amadureceu</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>O seu saldo total actual</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transações recentes&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>fora de sincronia</translation>
     </message>
@@ -1574,93 +1261,70 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
-        <translation>Manuseamento URI</translation>
+        <translation>Manuseamento de URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation>URI não foi lido correctamente! Isto pode ser causado por um endereço Bitcoin inválido ou por parâmetros URI malformados.</translation>
+        <translation>O URI não foi lido correctamente! Isto pode ser causado por um endereço Bitcoin inválido ou por parâmetros URI malformados.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation>Quantia requisitada para pagamento de %1 é muito pequena (considerada pó).</translation>
+        <translation>Quantia solicitada para pagamento de %1 é muito pequena (considerada &quot;pó&quot;).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
-        <translation>Erro no pedido de pagamento</translation>
+        <translation>Erro de pedido de pagamento</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
-        <translation>Impossível começar o modo clicar-para-pagar com bitcoin:</translation>
+        <translation>Impossível iniciar o controlador de bitcoin: click-to-pay</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Aviso do gestor de rede</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
-        <translation type="unfinished"/>
+        <translation>O seu proxy ativo não suporta SOCKS5, que é necessário para efectuar pedidos de pagemento via proxy.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
-        <translation type="unfinished"/>
+        <translation>O URL de pedido de pagamento é inválido: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
-        <translation type="unfinished"/>
+        <translation>Controlo de pedidos de pagamento.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
-        <translation type="unfinished"/>
+        <translation>O ficheiro de pedido de pagamento não pôde ser lido ou processado! Isto pode ter sido causado por um ficheiro de pedido de pagamento inválido.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
-        <translation>Pedidos de pagamento não-verificados para scripts de pagamento personalizadas não é suportado.</translation>
+        <translation>Pedidos de pagamento não-verificados para scripts de pagamento personalizados não são suportados.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Reembolsar de %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Erro ao comunicar com %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
-        <translation type="unfinished"/>
+        <translation>O pedido de pagamento não pode ser lido ou processado!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Má resposta do servidor %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Pagamento confirmado</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Erro de pedido de rede</translation>
     </message>
@@ -1668,23 +1332,22 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Erro: Pasta de dados especificada &quot;%1&quot; não existe.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Erro: Combinação inválida de -regtest e -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduza um endereço Bitcoin (p.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1692,22 +1355,18 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Salvar Imagem...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Copiar Imagem</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Guardar Código QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>Imagem PNG (*.png)</translation>
     </message>
@@ -1715,192 +1374,146 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nome do Cliente</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>N/D</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versão do Cliente</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informação</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Janela de depuração</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Geral</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Usando versão OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
-        <translation>Tempo de início</translation>
+        <translation>Hora de inicialização</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Rede</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Nome</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Número de ligações</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Cadeia de blocos</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Número actual de blocos</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Total estimado de blocos</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
-        <translation>Tempo do último bloco</translation>
+        <translation>Data do último bloco</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Abrir</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Consola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Tráfego de Rede</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Limpar</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totais</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>Entrada:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
-        <translation>Saída</translation>
+        <translation>Saída:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
-        <translation>Data de construção</translation>
+        <translation>Data de compilação</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Ficheiro de registo de depuração</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Abrir o ficheiro de registo de depuração da pasta de dados actual. Isto pode demorar alguns segundos para ficheiros de registo maiores.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Limpar consola</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bem-vindo à consola RPC Bitcoin.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Use as setas para cima e para baixo para navegar no histórico e &lt;b&gt;Ctrl-L&lt;/b&gt; para limpar o ecrã.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
-        <translation>Digite &lt;b&gt;help&lt;/b&gt; para visualizar os comandos disponíveis.</translation>
+        <translation>Insira &lt;b&gt;help&lt;/b&gt; para visualizar os comandos disponíveis.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1908,105 +1521,82 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Quantia:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>Rótu&amp;lo:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Mensagem:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
-        <translation>Reutilize uns dos anteriores endereços de entrada. Reutilizar endereços pode levar a um risco de segurança e de privacidade. Não use isto a não ser que esteja a repetir uma requisição de pagamento feita anteriormente.</translation>
+        <translation>Reutilize um dos endereços de entrada usados anteriormente. Reutilizar endereços pode levar a riscos de segurança e de privacidade. Não use esta função a não ser que esteja a gerar novamente uma requisição de pagamento feita anteriormente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
-        <translation>Reutilizar um endereço de recebimento existente (não recomendado)</translation>
+        <translation>Reutilizar um endereço de receção existente (não recomendado)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished"/>
+        <translation>Uma mensagem opcional para anexar ao pedido de pagamento, que será exibida quando o pedido for aberto. Nota: A mensagem não será enviada com o pagamento através da rede Bitcoin.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation>Um rótulo opcional a associar ao novo endereço de recebimento.</translation>
+        <translation>Um rótulo opcional a associar ao novo endereço de receção.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Utilize este formulário para solicitar pagamentos. Todos os campos são &lt;b&gt;opcionais&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished"/>
+        <translation>Uma quantia opcional a solicitar. Deixe em branco ou zero para não solicitar uma quantidade específica.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Limpar todos os campos do formulário.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Limpar</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
-        <translation>Histórico de pagamentos requisitados</translation>
+        <translation>Histórico de pagamentos solicitados</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Requisitar Pagamento</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation>Mostrar o pedido seleccionado (Faz o mesmo que clicar 2 vezes numa entrada)</translation>
+        <translation>Mostrar o pedido seleccionado (faz o mesmo que clicar 2 vezes numa entrada)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Mostrar</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
-        <translation>Remover a entrada seleccionada da lista</translation>
+        <translation>Remover as entradas seleccionadas da lista</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Remover</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Copiar rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Copiar mensagem</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
@@ -2014,67 +1604,54 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Copiar &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Copi&amp;ar Endereço</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Salvar Imagem...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Requisitar Pagamento para %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Informação de Pagamento</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Quantia</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Rótulo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mensagem</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI resultante muito longo. Tente reduzir o texto do rótulo / mensagem.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Erro ao codificar URI em Código QR.</translation>
     </message>
@@ -2082,37 +1659,30 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Rótulo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mensagem</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Quantia</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
-        <translation>(Sem rótulo)</translation>
+        <translation>(sem rótulo)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
-        <translation>(Sem mensagem)</translation>
+        <translation>(sem mensagem)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(sem quantia)</translation>
     </message>
@@ -2120,247 +1690,194 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Enviar Moedas</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
-        <translation>Funcionalidades de Coin Controlo:</translation>
+        <translation>Funcionalidades de Coin Control:</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
-        <translation>Entradas</translation>
+        <translation>Entradas...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
-        <translation>Selecção automática</translation>
+        <translation>selecionadas automáticamente</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Fundos insuficientes!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Quantidade:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bytes:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Quantia:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioridade:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Output Baixo:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
-        <translation>Depois de taxas:</translation>
+        <translation>Depois da taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
-        <translation>Alteração:</translation>
+        <translation>Troco:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation>Se activar isto, mas o endereço de alteração estiver vazio ou for inválido, a alteração irá ser enviada para um novo endereço gerado.</translation>
+        <translation>Se isto estiver ativo, mas o endereço de troco estiver vazio ou for inválido, o troco irá ser enviado para um novo endereço.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
-        <translation>Personalização de endereço de alteração</translation>
+        <translation>Endereço de troco personalizado</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Enviar para múltiplos destinatários de uma vez</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Adicionar &amp;Destinatário</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Limpar todos os campos do formulário.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>&amp;Limpar Tudo</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Saldo:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Confirme ação de envio</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Enviar</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirme envio de moedas</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 para %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Copiar quantidade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
-        <translation>Taxa de cópia</translation>
+        <translation>Copiar taxa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation>Taxa depois de cópia</translation>
+        <translation>Copiar valor após taxa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiar bytes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
-        <translation>Prioridade de Cópia</translation>
+        <translation>Copiar prioridade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copiar output baixo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiar alteração</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Quantia Total %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>ou</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>O endereço de destino não é válido, por favor verifique.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>A quantia a pagar deverá ser maior que 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>A quantia excede o seu saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>O total excede o seu saldo quando a taxa de transação de %1 for incluída.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Endereço duplicado encontrado, apenas poderá enviar uma vez para cada endereço por cada operação de envio.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
-        <translation>Erro: A criação da transacção falhou! </translation>
+        <translation>Erro: A criação da transação falhou! </translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
-        <translation>Erro: A transação foi rejeitada.  Isso poderá acontecer se algumas das moedas na sua carteira já tiverem sido gastas, se por exemplo tiver usado uma cópia do ficheiro wallet.dat e as moedas foram gastas na cópia mas não foram marcadas como gastas aqui.</translation>
+        <translation>A transação foi rejeitada! Isto poderá acontecer se algumas das moedas na sua carteira já tiverem sido gastas, se por exemplo tiver usado uma cópia do ficheiro wallet.dat e as moedas tiverem sido gastas na cópia mas não tiverem sido marcadas como gastas aqui.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Aviso: Endereço Bitcoin inválido</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
-        <translation>(Sem rótulo)</translation>
+        <translation>(sem rótulo)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
-        <translation>Aviso: Endereço de alteração desconhecido</translation>
+        <translation>Aviso: Endereço de troco desconhecido</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Tem a certeza que deseja enviar?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>adicionados como taxa de transação</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Pedido de pagamento expirou</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Endereço de pagamento inválido %1</translation>
     </message>
@@ -2368,111 +1885,85 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Qu&amp;antia:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Pagar A:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>O endereço para onde enviar o pagamento  (p.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Escreva um rótulo para este endereço para o adicionar ao seu livro de endereços</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>Rótu&amp;lo:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Escolher endereço usado previamente</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Este é um pagamento normal.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Cole endereço da área de transferência</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
-        <translation>Remover esta inscrição</translation>
+        <translation>Remover esta entrada</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Mensagem:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
-        <translation>Este é um pedido de verificação de pagamento.</translation>
+        <translation>Este é um pedido de pagamento verificado.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation>Escreva um rótulo para este endereço para o adicionar à sua lista de endereços usados</translation>
+        <translation>Introduza um rótulo para este endereço para o adicionar à sua lista de endereços usados</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished"/>
+        <translation>Uma mensagem que estava anexada ao URI bitcoin: que será armazenada com a transação para sua referência. Nota: Esta mensagem não será enviada através da rede Bitcoin.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Este é um pedido de pagamento não-verificado.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
-        <translation>&amp;Pagar A:</translation>
+        <translation>Pagar A:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
-        <translation>Memo:</translation>
+        <translation>Memorando:</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>O Bitcoin Core está a encerrar...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Não desligue o computador enquanto esta janela não desaparecer.</translation>
     </message>
@@ -2480,186 +1971,142 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Assinaturas - Assinar / Verificar uma Mensagem</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>A&amp;ssinar Mensagem</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
-        <translation>Pode assinar mensagens com os seus endereços para provar que são seus. Tenha atenção ao assinar mensagens ambíguas, pois ataques de phishing podem tentar enganá-lo, de modo a assinar a sua identidade para os atacantes. Apenas assine declarações completamente detalhadas com as quais concorde.</translation>
+        <translation>Pode assinar mensagens com os seus endereços para provar que são seus. Tenha atenção ao assinar mensagens ambíguas, pois ataques de phishing podem tentar enganá-lo de modo a assinar a sua identidade para os atacantes. Apenas assine declarações detalhadas com as quais concorde.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>O endereço a utilizar para assinar a mensagem (p.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Escolher endereço usado previamente</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
-        <translation>Cole endereço da área de transferência</translation>
+        <translation>Colar endereço da área de transferência</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Escreva aqui a mensagem que deseja assinar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Assinatura</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copiar a assinatura actual para a área de transferência</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Assine uma mensagem para provar que é dono deste endereço Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Assinar &amp;Mensagem</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
-        <translation>Repôr todos os campos de assinatura de mensagem</translation>
+        <translation>Repor todos os campos de assinatura de mensagem</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Limpar &amp;Tudo</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verificar Mensagem</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
-        <translation>Introduza o endereço de assinatura, mensagem (assegure-se de copiar quebras de linha, espaços, tabuladores, etc. exactamente) e assinatura abaixo para verificar a mensagem. Tenha atenção para não ler mais na assinatura do que o que estiver na mensagem assinada, para evitar ser enganado por um atacante que se encontre entre si e quem assinou a mensagem.</translation>
+        <translation>Introduza o endereço de assinatura, mensagem (assegure-se que copia quebras de linha, espaços, tabulações, etc. exactamente) e assinatura abaixo para verificar a mensagem. Tenha atenção para não ler mais na assinatura do que o que estiver na mensagem assinada, para evitar ser enganado por um atacante que se encontre entre si e quem assinou a mensagem.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>O endereço utilizado para assinar a mensagem (p.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verifique a mensagem para assegurar que foi assinada com o endereço Bitcoin especificado</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verificar &amp;Mensagem</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
-        <translation>Repôr todos os campos de verificação de mensagem</translation>
+        <translation>Repor todos os campos de verificação de mensagem</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduza um endereço Bitcoin (p.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Clique &quot;Assinar mensagem&quot; para gerar a assinatura</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
-        <translation>O endereço introduzido é inválido. </translation>
+        <translation>O endereço introduzido é inválido.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Por favor verifique o endereço e tente de novo.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
-        <translation>O endereço introduzido não refere a chave alguma.</translation>
+        <translation>O endereço introduzido não refere a nenhuma chave.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>O desbloqueio da carteira foi cancelado.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>A chave privada para o endereço introduzido não está disponível.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Assinatura de mensagem falhou.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Mensagem assinada.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>A assinatura não pôde ser descodificada.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Por favor verifique a assinatura e tente de novo.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>A assinatura não condiz com o conteúdo da mensagem.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Verificação da mensagem falhou.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Mensagem verificada.</translation>
     </message>
@@ -2667,17 +2114,14 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
-        <translation>Núcleo Bitcoin</translation>
+        <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
-        <translation>Os programadores Bitcoin</translation>
+        <translation>Os programadores do Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[rede de testes]</translation>
     </message>
@@ -2685,7 +2129,6 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2693,184 +2136,138 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Aberto até %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
-        <translation type="unfinished"/>
+        <translation>em conflito:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/desligado</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/não confirmada</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmações</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Estado</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, transmitida através de %n nó</numerusform><numerusform>, transmitida através de %n nós</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Origem</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Gerado</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>De</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Para</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>endereço próprio</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>rótulo</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Crédito</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
-        <translation><numerusform>matura daqui por %n bloco</numerusform><numerusform>matura daqui por %n blocos</numerusform></translation>
+        <translation><numerusform>matura em %n bloco</numerusform><numerusform>matura em %n blocos</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>não aceite</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Débito</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Taxa de transação</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Valor líquido</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mensagem</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Comentário</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID da Transação</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Comerciante</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation>Moedas geradas deverão maturar por %1 blocos antes de poderem ser gastas. Quando gerou este bloco, ele foi transmitido para a rede para ser incluído na cadeia de blocos. Se a inclusão na cadeia de blocos falhar, irá mudar o estado para &quot;não aceite&quot; e as moedas não poderão ser gastas.  Isto poderá acontecer ocasionalmente se outro nó da rede gerar um bloco a poucos segundos de diferença do seu.</translation>
+        <translation>Moedas geradas deverão maturar por %1 blocos antes de poderem ser gastas. Quando gerou este bloco, ele foi transmitido para a rede para ser incluído na cadeia de blocos. Se a inclusão na cadeia de blocos falhar, o seu estado irá ser alterado para &quot;não aceite&quot; e as moedas não poderão ser gastas. Isto poderá acontecer ocasionalmente se outro nó da rede gerar um bloco a poucos segundos de diferença do seu.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Informação de depuração</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transação</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Entradas</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Quantia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>verdadeiro</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falso</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, ainda não foi transmitida com sucesso</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Aberta por mais %n bloco</numerusform><numerusform>Aberta por mais %n blocos</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>desconhecido</translation>
     </message>
@@ -2878,12 +2275,10 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detalhes da transação</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Esta janela mostra uma descrição detalhada da transação</translation>
     </message>
@@ -2891,127 +2286,102 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Quantia</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished"/>
+        <translation>Imaturo (%1 confirmações, estará disponível após %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Aberta por mais %n bloco</numerusform><numerusform>Aberta por mais %n blocos</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Aberto até %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmada (%1 confirmações)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Este bloco não foi recebido por outros nós e provavelmente não será aceite pela rede!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Gerado mas não aceite</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
-        <translation type="unfinished"/>
+        <translation>Offline</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
-        <translation type="unfinished"/>
+        <translation>Não confirmado:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation type="unfinished"/>
+        <translation>A confirmar (%1 de %2 confirmações recomendadas)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
-        <translation type="unfinished"/>
+        <translation>Em Conflito:</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Recebido com</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Recebido de</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Enviado para</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
-        <translation>Pagamento ao próprio</translation>
+        <translation>Pagamento a si mesmo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minadas</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/d)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
-        <translation>Estado da transação. Pairar por cima deste campo para mostrar o número de confirmações.</translation>
+        <translation>Estado da transação. Passar o cursor por cima deste campo para mostrar o número de confirmações.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
-        <translation>Data e hora a que esta transação foi recebida.</translation>
+        <translation>Data e hora em que a transação foi recebida.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipo de transação.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Endereço de destino da transação.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Quantia retirada ou adicionada ao saldo.</translation>
     </message>
@@ -3019,178 +2389,142 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Todas</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Hoje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Esta semana</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Este mês</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Mês passado</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Este ano</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Período...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Recebida com</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Enviada para</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
-        <translation>Para si</translation>
+        <translation>Para si mesmo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minadas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Outras</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Escreva endereço ou rótulo a procurar</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Quantia mínima</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copiar endereço</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiar rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiar quantia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copiar ID da Transação</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Editar rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Mostrar detalhes da transação</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
-        <translation>Exportar histórico de transacções</translation>
+        <translation>Exportar Histórico de Transacções</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
-        <translation>Exportação falhada</translation>
+        <translation>A Exportação Falhou</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
-        <translation>Ocorreu um erro ao tentar guardar o histórico de dados para %1.</translation>
+        <translation>Ocorreu um erro ao tentar guardar o histórico de transações em %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
-        <translation>Exportação bem sucedida</translation>
+        <translation>Exportação Bem Sucedida</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation>O histórico de transacções foi com sucesso salvo para %1.</translation>
+        <translation>O histórico de transacções foi com guardado com sucesso em %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
-        <translation>Ficheiro separado por vírgula (*.csv)</translation>
+        <translation>Ficheiro separado por vírgulas (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmada</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Rótulo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Endereço</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Quantia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Período:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>até</translation>
     </message>
@@ -3198,7 +2532,6 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Nenhuma carteira foi carregada.</translation>
     </message>
@@ -3206,7 +2539,6 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Enviar Moedas</translation>
     </message>
@@ -3214,42 +2546,34 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportar os dados no separador actual para um ficheiro</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Cópia de Segurança da Carteira</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Dados da Carteira (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Cópia de Segurança Falhou</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation>Ocorreu um erro ao tentar guardar os dados da carteira na nova localização.</translation>
+        <translation>Ocorreu um erro ao tentar guardar os dados da carteira em %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation>Os dados da carteira foram salvos com sucesso para %1.</translation>
+        <translation>Os dados da carteira foram guardados com sucesso em %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Cópia de Segurança Bem Sucedida</translation>
     </message>
@@ -3257,107 +2581,86 @@ A sua &quot;carteira&quot; também irá ser guardada neste directório.</transla
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Utilização:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Listar comandos</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Obter ajuda para um comando</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Opções:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Especificar ficheiro de configuração (por defeito: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Especificar ficheiro pid (por defeito: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Especificar pasta de dados</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Definir o tamanho da cache de base de dados em megabytes (por defeito: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
-        <translation>Escute por ligações em &lt;port&gt; (por defeito: 8333 ou testnet: 18333)</translation>
+        <translation>Escute ligações na porta &lt;n&gt; (por defeito: 8333 ou testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Manter no máximo &lt;n&gt; ligações a outros nós da rede (por defeito: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Ligar a um nó para recuperar endereços de pares, e desligar</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Especifique o seu endereço público</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
-        <translation>Tolerância para desligar nós mal-formados (por defeito: 100)</translation>
+        <translation>Tolerância para desligar nós com comportamento indesejável (por defeito: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
-        <translation>Número de segundos a impedir que nós mal-formados se liguem de novo (por defeito: 86400)</translation>
+        <translation>Número de segundos a impedir que nós com comportamento indesejado se liguem de novo (por defeito: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Ocorreu um erro ao definir a porta %u do serviço RPC a escutar em IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
-        <translation>Escutar por ligações JSON-RPC em &lt;port&gt; (por defeito: 8332 ou rede de testes: 18332)</translation>
+        <translation>Escutar por ligações JSON-RPC na porta &lt;n&gt; (por defeito: 8332 ou rede de testes: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
-        <translation>Aceitar comandos da consola e JSON-RPC</translation>
+        <translation>Aceitar comandos de linha de comandos e JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
-        <translation>Correr o processo como um daemon e aceitar comandos</translation>
+        <translation>Correr o processo em segundo plano e aceitar comandos</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
-        <translation>Utilizar a rede de testes - testnet</translation>
+        <translation>Utilizar a rede de testes</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Aceitar ligações externas (padrão: 1 sem -proxy ou -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3369,735 +2672,694 @@ If the file does not exist, create it with owner-readable-only file permissions.
 It is also recommended to set alertnotify so you are notified of problems;
 for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.com
 </source>
-        <translation>%s, deverá definir rpcpassword no ficheiro de configuração :
- %s
+        <translation>%s, deverá definir uma rpcpassword no ficheiro de configuração:
+%s
 É recomendado que use a seguinte palavra-passe aleatória:
 rpcuser=bitcoinrpc
 rpcpassword=%s
-(não precisa recordar esta palavra-passe)
-O nome de utilizador e password NÃO DEVEM ser iguais.
+(não é necessário lembrar esta palavra-passe)
+O nome de utilizador e palavra-passe NÃO PODEM ser iguais.
 Se o ficheiro não existir, crie-o com permissões de leitura apenas para o dono.
-Também é recomendado definir alertnotify para que seja alertado sobre problemas;
-por exemplo: alertnotify=echo %%s | mail -s &quot;Alerta Bitcoin&quot; admin@foo.com
-</translation>
+Também é recomendado definir um alertnotify para que seja alertado sobre problemas;
+por exemplo: alertnotify=echo %%s | mail -s &quot;Alerta Bitcoin&quot; admin@foo.com</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
-        <translation>Cifras aceitáveis (por defeito:  TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
+        <translation>Cifras aceitáveis (por defeito: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ocorreu um erro ao definir a porta %u do serviço RPC a escutar em IPv6, a usar IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
-        <translation>Trancar a endereço específio e sempre escutar nele. Use a notação [anfitrião]:porta para IPv6</translation>
+        <translation>Associar a endereço específico e escutar sempre nele. Use a notação [anfitrião]:porta para IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Impossível trancar a pasta de dados %s.  Provavelmente o Bitcoin já está a ser executado.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
-        <translation>Entre no modo de retrocesso, que usa uma cadeia especial cujos bloqueios podem ser resolvidos instantâneamente. Isto têm como fim para as ferramentas de retrocesso e desenvolvimento de aplicações.</translation>
+        <translation>Entre no modo de teste de regressão, que usa uma cadeia especial cujos blocos podem ser resolvidos instantaneamente. Isto têm como fim a realização de testes de regressão para pools e desenvolvimento de aplicações.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
-        <translation>Entre no modo de regressão, que usa uma cadeia especial cujos blocos podem ser resolvidos instantaneamente.</translation>
+        <translation>Entre no modo de teste de regressão, que usa uma cadeia especial cujos blocos podem ser resolvidos instantaneamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation>Erro: A Escuta de ligações de entrada falhou (retornou erro %d)</translation>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
-        <translation>Erro: A transação foi rejeitada.  Isso poderá acontecer se algumas das moedas na sua carteira já tiverem sido gastas, se por exemplo tiver usado uma cópia do ficheiro wallet.dat e as moedas foram gastas na cópia mas não foram marcadas como gastas aqui.</translation>
+        <translation>Erro: A transação foi rejeitada! Isso poderá acontecer se algumas das moedas na sua carteira já tiverem sido gastas, se por exemplo tiver usado uma cópia do ficheiro wallet.dat e as moedas tiverem sido gastas na cópia mas não tiverem sido marcadas como gastas aqui.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
-        <translation>Erro: Esta transação requer uma taxa de transação mínima de %s devido á sua quantia, complexidade, ou uso de fundos recebidos recentemente!  </translation>
+        <translation>Erro: Esta transação requer uma taxa de transação mínima de %s devido á sua quantia, complexidade, ou uso de fundos recebidos recentemente!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Executar comando quando uma das transações na carteira mudar (no comando, %s é substituído pelo ID da Transação)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
-        <translation>Esta é uma versão de pré-lançamento - use à sua responsabilidade - não usar para minar ou aplicações comerciais</translation>
+        <translation>Esta é uma versão de testes pré-lançamento - use à sua responsabilidade - não usar para minar ou aplicações comerciais</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation>Incapaz de vincular à porta %s neste computador. O Bitcoin Core provavelmente já está a correr.</translation>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
-        <translation>Usar proxy SOCKS5 separado para aceder a pares P2P via rede Tor (Por defeito:-proxy)</translation>
+        <translation>Usar um proxy SOCKS5 separado para aceder a pares através de Tor hidden services (por defeito: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Atenção: -paytxfee está definida com um valor muito alto! Esta é a taxa que irá pagar se enviar uma transação.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Atenção: Por favor verifique que a data e hora do seu computador estão correctas! Se o seu relógio não estiver certo o Bitcoin não irá funcionar correctamente.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Aviso: A rede não parece estar completamente de acordo! Parece que alguns mineiros estão com dificuldades técnicas.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
-        <translation>Atenção: Parecemos não estar de acordo com os nossos pares! Poderá ter que atualizar ou outros nós poderão ter que atualizar.</translation>
+        <translation>Atenção: Parecemos não estar de acordo com os nossos pares! Poderá ter que atualizar o seu cliente, ou outros nós poderão ter que atualizar os seus clientes.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Atenção: erro ao ler wallet.dat! Todas as chaves foram lidas correctamente, mas dados de transação ou do livro de endereços podem estar em falta ou incorrectos.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
-        <translation>Atenção: wallet.dat corrupto, dados recuperados! wallet.dat original salvo como wallet.{timestamp}.bak em %s; se o seu saldo ou transações estiverem incorrectos deverá recuperar de uma cópia de segurança.</translation>
+        <translation>Atenção: wallet.dat corrompido, dados recuperados! wallet.dat original salvo como wallet.{timestamp}.bak em %s; se o seu saldo ou transações estiverem incorrectos deverá recuperar uma cópia de segurança.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
-        <translation>&lt;category&gt; pode ser:</translation>
+        <translation>&lt;categoria&gt; pode ser:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Tentar recuperar chaves privadas de um wallet.dat corrupto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
-        <translation>Bitcoin Core Daemon</translation>
+        <translation>Servidor Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Versão do cliente Bitcoin RPC</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Opções de criação de bloco:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
-        <translation type="unfinished"/>
+        <translation>Limpar lista de transações (ferramenta de diagnóstico; implica -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Apenas ligar ao(s) nó(s) especificado(s)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Ligar através de proxy SOCKS:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
-        <translation>Ligar ao JSON-RPC em &lt;port&gt; (por defeito: 8332 ou rede de testes: 18332)</translation>
+        <translation>Ligar ao JSON-RPC na porta &lt;n&gt; (por defeito: 8332 ou rede de testes: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Cadeia de blocos corrompida detectada</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
-        <translation>Descobrir endereço IP próprio (padrão: 1 ao escutar e sem -externalip)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
-        <source>Do not load the wallet and disable wallet RPC calls</source>
+        <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Do you want to rebuild the block database now?</source>
-        <translation>Deseja reconstruir agora a cadeia de blocos?</translation>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
+        <translation>Descobrir endereço IP próprio (padrão: 1 ao escutar sem -externalip)</translation>
+    </message>
+    <message>
+        <source>Do not load the wallet and disable wallet RPC calls</source>
+        <translation>Não carregar a carteira e desativar chamadas RPC de carteira.</translation>
+    </message>
+    <message>
+        <source>Do you want to rebuild the block database now?</source>
+        <translation>Deseja reconstruir agora a base de dados de blocos.</translation>
+    </message>
+    <message>
         <source>Error initializing block database</source>
         <translation>Erro ao inicializar a cadeia de blocos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
-        <translation>Erro ao inicializar o ambiente de base de dados da carteira %s!</translation>
+        <translation>Erro ao inicializar o ambiente %s da base de dados da carteira</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
-        <translation>Erro ao carregar cadeia de blocos</translation>
+        <translation>Erro ao carregar base de dados de blocos</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
-        <translation>Erro ao abrir a cadeia de blocos</translation>
+        <translation>Erro ao abrir a base de dados de blocos</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Erro: Pouco espaço em disco!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Erro: Carteira bloqueada, incapaz de criar transação!  </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Erro: erro do sistema:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
-        <translation>Falhou a escutar em qualquer porta. Use -listen=0 se quer isto.</translation>
+        <translation>Falhou a escutar em qualquer porta. Use -listen=0 se quiser isto.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
-        <translation>Falha ao ler info do bloco</translation>
+        <translation>Falha ao ler informação do bloco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Falha ao ler bloco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
-        <translation>Falha ao sincronizar índice do bloco</translation>
+        <translation>Falha ao sincronizar índice de blocos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
-        <translation>Falha ao escrever índice do bloco</translation>
+        <translation>Falha ao escrever índice de blocos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
-        <translation>Falha ao escrever info do bloco</translation>
+        <translation>Falha ao escrever informação do bloco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
-        <translation>Falha ao escrever o bloco</translation>
+        <translation>Falha ao escrever bloco</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
-        <translation>Falha ao escrever info do ficheiro</translation>
+        <translation>Falha ao escrever informação do ficheiro</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Falha ao escrever na base de dados de moedas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Falha ao escrever índice de transações</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Falha ao escrever histórico de modificações</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Taxa por KB a adicionar a transações enviadas</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Encontrar pares usando procura DNS (por defeito: 1 excepto -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Gerar moedas (por defeito: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
-        <translation>Quantos blocos verificar ao começar (por defeito: 288, 0 = todos)</translation>
+        <translation>Quantos blocos verificar ao inicializar (por defeito: 288, 0 = todos)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Qual a minúcia na verificação de blocos (0-4, por defeito: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
-        <translation>Se &lt;category&gt; não é fornecida, toda a informação debug é &quot;output&quot;.</translation>
+        <translation>Se uma &lt;categoria&gt; não é fornecida, imprimir toda a informação de depuração.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
-        <translation>Incorrecto ou nenhum bloco génesis encontrado. Pasta de dados errada para a rede?</translation>
+        <translation>Bloco génese incorreto ou nenhum bloco génese encontrado. Pasta de dados errada para a rede?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Endereço -onion inválido: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
-        <translation>Descritores de ficheiros disponíveis são insuficientes.</translation>
+        <translation>Os descritores de ficheiros disponíveis são insuficientes.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
-        <translation>Preceder informação de depuração com selo temporal (por defeito: 1)</translation>
+        <translation>Adicionar data e hora à informação de depuração (por defeito: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
-        <translation>RPC opções de cliente:</translation>
+        <translation>Opções de cliente RPC:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
-        <translation>Reconstruir a cadeia de blocos dos ficheiros blk000??.dat actuais</translation>
+        <translation>Reconstruir a cadeia de blocos a partir dos ficheiros blk000??.dat atuais</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
-        <translation>Selecione a versão do proxy socks a usar (4-5, padrão: 5)</translation>
+        <translation>Selecione a versão do proxy socks a usar (4 ou 5, por defeito: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Enviar comando para servidor Bitcoin</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation>Definir o tamanho da cache de base de dados em megabytes (%d a %s, padrão: %d)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
-        <translation>Definir tamanho máximo de um bloco em bytes (por defeito: 250000)</translation>
+        <translation>Definir tamanho máximo por bloco em bytes (por defeito: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Defina o número de processos para servir as chamadas RPC (por defeito: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Especifique ficheiro de carteira (dentro da pasta de dados)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
-        <translation type="unfinished"/>
+        <translation>Gastar saldo não confirmado ao enviar transações (padrão: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Começar servidor Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
-        <translation type="unfinished"/>
+        <translation>Isto têm como fim a realização de testes de regressão para pools e desenvolvimento de aplicações.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
-        <translation>Utilização (deprecado, use bitcoin-cli)</translation>
+        <translation>Utilização (obsoleto, usar bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
-        <translation>Verificando blocos...</translation>
+        <translation>A verificar blocos...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
-        <translation>Verificando a carteira...</translation>
+        <translation>A verificar carteira...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Esperar pelo ínicio do servidor RPC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>A carteira %s reside fora da pasta de dados %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Opções da carteira:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
-        <translation>Aviso: Argumento obsolote -debugnet ignorado, usar -debug=net</translation>
+        <translation>Atenção: Argumento obsoleto -debugnet ignorado, usar -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
-        <translation>Necessita reconstruir as bases de dados usando -reindex para mudar -txindex</translation>
+        <translation>É necessário reconstruir as bases de dados usando -reindex para mudar o -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importar blocos de um ficheiro blk000??.dat externo</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation>Impossível trancar a pasta de dados %s. Provavelmente o Bitcoin Core já está a ser executado.</translation>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Executar comando quando um alerta relevante for recebido ou em caso de uma divisão longa da cadeia de blocos (no comando, %s é substituído pela mensagem)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
-        <translation>Informação de depuração (default: 0, fornecer &lt;category&gt; é opcional)</translation>
+        <translation>Informação de depuração (por defeito: 0, fornecer uma &lt;categoria&gt; é opcional)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
-        <translation>Definir tamanho máximo de transações de alta-/baixa-prioridade em bytes (por defeito: 27000)</translation>
+        <translation>Definir tamanho máximo de transações com alta-prioridade/baixa-taxa em bytes (por defeito: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Defina o número de processos de verificação (até 16, 0 = automático, &lt;0 = disponibiliza esse número de núcleos livres, por defeito: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informação</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
-        <translation>Quantia inválida para -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
+        <translation>Quantia inválida para -minrelaytxfee=&lt;quantidade&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
-        <translation>Quantia inválida para -mintxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
+        <translation>Quantia inválida para -mintxfee=&lt;quantidade&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Manter índice de transações completo (por defeito: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
-        <translation>Armazenamento intermédio de recepção por ligação, &lt;n&gt;*1000 bytes (por defeito: 5000)</translation>
+        <translation>Maximo armazenamento intermédio de recepção por ligação, &lt;n&gt;*1000 bytes (por defeito: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
-        <translation>Armazenamento intermédio de envio por ligação, &lt;n&gt;*1000 bytes (por defeito: 1000)</translation>
+        <translation>Maximo armazenamento intermédio de envio por ligação, &lt;n&gt;*1000 bytes (por defeito: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
-        <translation>Apenas aceitar cadeia de blocos coincidente com marcas de verificação internas (por defeito: 1)</translation>
+        <translation>Apenas aceitar cadeia de blocos coincidente com pontos de controle internos (por defeito: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Apenas ligar a nós na rede &lt;net&gt; (IPv4, IPv6 ou Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
-        <translation>Opções SSL: (ver a Wiki Bitcoin para instruções de configuração SSL)</translation>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>Opções SSL: (ver a Bitcoin Wiki para instruções de configuração SSL)</translation>
+    </message>
+    <message>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Enviar informação de rastreio/depuração para a consola e não para o ficheiro debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Definir tamanho minímo de um bloco em bytes (por defeito: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Encolher ficheiro debug.log ao iniciar o cliente (por defeito: 1 sem -debug definido)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Falhou assinatura da transação</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Especificar tempo de espera da ligação em millisegundos (por defeito: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Erro de sistema:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Quantia da transação é muito baixa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Quantia da transação deverá ser positiva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transação grande demais</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Usar UPnP para mapear a porta de escuta (padrão: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Usar UPnP para mapear a porta de escuta (padrão: 1 ao escutar)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Nome de utilizador para ligações JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Aviso</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Atenção: Esta versão está obsoleta, é necessário actualizar!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
+        <translation>A limpar todas as transações da carteira...</translation>
+    </message>
+    <message>
+        <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>versão</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
-        <translation>wallet.dat corrupta, recuperação falhou</translation>
+        <translation>wallet.dat corrompido, recuperação falhou</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Palavra-passe para ligações JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permitir ligações JSON-RPC do endereço IP especificado</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Enviar comandos para o nó a correr em &lt;ip&gt; (por defeito: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
-        <translation>Executar comando quando mudar o melhor bloco (no comando, %s é substituído pela hash do bloco)</translation>
+        <translation>Executar comando quando o melhor bloco mudar (no comando, %s é substituído pela hash do bloco)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Atualize a carteira para o formato mais recente</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Definir o tamanho da memória de chaves para &lt;n&gt; (por defeito: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
-        <translation>Reexaminar a cadeia de blocos para transações em falta na carteira</translation>
+        <translation>Procurar transações em falta na cadeia de blocos</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Usar OpenSSL (https) para ligações JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Ficheiro de certificado do servidor (por defeito: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Chave privada do servidor (por defeito: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Esta mensagem de ajuda</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
-        <translation>Incapaz de vincular a %s neste computador (vínculo retornou erro %d, %s)</translation>
+        <translation>Incapaz de vincular à porta %s neste computador (vínculo retornou erro %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permitir procuras DNS para -addnode, -seednode e -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
-        <translation>Carregar endereços...</translation>
+        <translation>A carregar endereços...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Erro ao carregar wallet.dat: Carteira danificada</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Erro ao carregar wallet.dat: A Carteira requer uma versão mais recente do Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
-        <translation>A Carteira precisou ser reescrita: reinicie o Bitcoin para completar</translation>
+        <translation>A Carteira precisou de ser reescrita: reinicie o Bitcoin para completar o processo</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Erro ao carregar wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Endereço -proxy inválido: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Rede desconhecida especificada em -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
-        <translation>Versão desconhecida de proxy -socks requisitada: %i</translation>
+        <translation>Versão de proxy -socks requisitada desconhecida: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
-        <translation>Não conseguiu resolver endereço -bind: &apos;%s&apos;</translation>
+        <translation>Não foi possível resolver o endereço -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
-        <translation>Não conseguiu resolver endereço -externalip: &apos;%s&apos;</translation>
+        <translation>Não foi possível resolver o endereço -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Quantia inválida para -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Quantia inválida</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Fundos insuficientes</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
-        <translation>Carregar índice de blocos...</translation>
+        <translation>A carregar índice de blocos...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
-        <translation>Adicione um nó ao qual se ligar e tentar manter a ligação aberta</translation>
+        <translation>Adicionar um nó para se ligar e tentar manter a ligação aberta</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Incapaz de vincular à porta %s neste computador.  Provavelmente o Bitcoin já está a funcionar.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
-        <translation>Carregar carteira...</translation>
+        <translation>A carregar carteira...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Impossível mudar a carteira para uma versão anterior</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Impossível escrever endereço por defeito</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Reexaminando...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Carregamento completo</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Para usar a opção %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ro_RO.ts
+++ b/src/qt/locale/bitcoin_ro_RO.ts
@@ -1,18 +1,15 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS language="ro_RO" version="2.1">
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="ro_RO" version="2.0">
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Despre Nucleul Bitcoin</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;Nucleul Bitcoin &lt;/b&gt; versiune</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ Distribuit sub licența de programe MIT/X11, vezi fișierul însoțitor COPYING 
 Acest produs include programe dezvoltate de către OpenSSL Project pentru a fi folosite în OpenSSL Toolkit (http://www.openssl.org/) și programe criptografice scrise de către Eric Young (eay@cryptsoft.com) și programe UPnP scrise de către Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Drepturi de autor</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Dezvoltatorii Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dublu-click pentru a edita adresa sau eticheta</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Creează o adresă nouă</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nou</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Copiază adresa selectată în clipboard</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Copiere</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>&amp;Inchidere</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Copiază adresa</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Sterge adresele curent selectate din lista</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exporta datele din tab-ul curent într-un fișier</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportă</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>Ște&amp;rge</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Alegeti adresa unde vreti sa trimiteti monezile</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Alegeti adresa unde vreti sa primiti monezile</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Alege</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Adresa Destinatarului</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Adresa pe care primiti</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Acestea sunt adresele dumneavoastra Bitcoin care pot fi folosite la trimiterea platilor. Verificati totdeauna cantitatea si adresa de primire inainte de a trimite monezi.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Acestea sunt adresele dumneavoastra Bitcoin folosite pentru a primi plati. Este recomandat sa folositi cate o adresa noua de primire pentru fiecare tranzactie in parte.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Copiază &amp;eticheta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editează</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exportati Agenda</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Valori separate prin virgulă (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Exportare esuata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>A apărut o eroare încercând să se salveze lista de adrese la %1.</translation>
     </message>
@@ -169,17 +138,14 @@ Acest produs include programe dezvoltate de către OpenSSL Project pentru a fi f
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etichetă</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresă</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(fără etichetă)</translation>
     </message>
@@ -187,140 +153,106 @@ Acest produs include programe dezvoltate de către OpenSSL Project pentru a fi f
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Dialogul pentru fraza de acces</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Introdu fraza de acces</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Frază de acces nouă</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Repetă noua frază de acces</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Introdu noua parolă a portofelului electronic.&lt;br/&gt;Te rog folosește &lt;b&gt;minim 10 caractere aleatoare&lt;/b&gt;, sau &lt;b&gt;minim 8 cuvinte&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Criptează portofelul</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Această acțiune necesită fraza ta de acces pentru deblocarea portofelului.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Deblochează portofelul</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Această acțiune necesită fraza ta de acces pentru decriptarea portofelului.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Decriptează portofelul.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Schimbă fraza de acces</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Introdu vechea și noua parolă pentru portofel.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Confirmă criptarea portofelului</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Atenție: Dacă pierdeţi parola portofelului electronic dupa criptare, &lt;b&gt;VEŢI PIERDE ÎNTREAGA SUMĂ DE BITCOIN ACUMULATĂ&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Sunteţi sigur că doriţi să criptaţi portofelul electronic?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>IMPORTANT: Orice copie de siguranta facuta in prealabil portofelului dumneavoastra ar trebui inlocuita cu cea generata cel mai recent fisier criptat al portofelului. Pentru siguranta, copiile de siguranta vechi ale portofelului ne-criptat vor deveni inutile de indata ce veti incepe folosirea noului fisier criptat al portofelului.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Atentie! Caps Lock este pornit</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Portofel criptat</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin se va închide acum pentru a termina procesul de criptare. Ține minte că criptarea portofelului nu te poate proteja în totalitate de furtul monedelor de către programe dăunătoare care îți infectează calculatorul.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Criptarea portofelului a eșuat</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Criptarea portofelului a eșuat din cauza unei erori interne. Portofelul tău nu a fost criptat.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Frazele de acces introduse nu se potrivesc.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Deblocarea portofelului a eșuat</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Fraza de acces introdusă pentru decriptarea portofelului a fost incorectă.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Decriptarea portofelului a eșuat</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Parola portofelului electronic a fost schimbată.</translation>
     </message>
@@ -328,363 +260,286 @@ Acest produs include programe dezvoltate de către OpenSSL Project pentru a fi f
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>Semnează &amp;mesaj...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Se sincronizează cu rețeaua...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Imagine de ansamblu</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>Nod</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Arată o stare generală de ansamblu a portofelului</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Tranzacții</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Răsfoiește istoricul tranzacțiilor</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Ieșire</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Închide aplicația</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Arată informații despre Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Despre &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Arată informații despre Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Setări...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>Criptează portofelul electronic...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Fă o copie de siguranță a  portofelului...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>S&amp;chimbă parola...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Vizitaţi &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importare blocks de pe disk...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Se reindexează blocurile pe disc...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Trimite monede către o adresă Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Modifică opțiunile de configurare pentru Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Creează o copie de rezervă a portofelului într-o locație diferită</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Schimbă fraza de acces folosită pentru criptarea portofelului</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Fereastră &amp;debug</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Deschide consola de debug și diagnosticare</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verifică mesajul...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Portofelul</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;Trimite</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Primește</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>Arata/Ascunde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Arată sau ascunde fereastra principală</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Criptează cheile private ale portofelului tău</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Semnează mesaje cu adresa ta Bitcoin pentru a dovedi că îți aparțin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verifică mesaje pentru a te asigura că au fost semnate cu adresa Bitcoin specificată</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Fișier</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Setări</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>A&amp;jutor</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Bara de file</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Cereti plati (genereaza coduri QR si bitcoin-uri: URls)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;Despre Nucleul Bitcoin</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Aratati lista de adrese trimise si etichete folosite.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Aratati lista de adrese pentru primire si etichete </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Deschideti un bitcoin: o adresa URI sau o cerere de plata</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>Command-line setări</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Client Bitcoin</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n conexiune activă către rețeaua Bitcoin</numerusform><numerusform>%n conexiuni active către rețeaua Bitcoin</numerusform><numerusform>%n de conexiuni active către rețeaua Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Nici o sursă de bloc disponibil ...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>S-a procesat %1 din %2 block-uri (estimate) din istoria tranzactiei.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>S-au procesat %1 blocuri din istoricul tranzacțiilor.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n oră</numerusform><numerusform>%n ore</numerusform><numerusform>%n ore</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n zi</numerusform><numerusform>%n zile</numerusform><numerusform>%n zile</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n săptămână</numerusform><numerusform>%n săptămâni</numerusform><numerusform>%n de săptămâni</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 si %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 în urmă</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Ultimul bloc recepționat a fost generat acum %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Tranzacții după aceasta nu va fi încă disponibile.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Avertizare</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informație</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Actualizat</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Se actualizează...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Tranzacție expediată</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Tranzacție recepționată</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +552,14 @@ Adresa: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Portofelul este &lt;b&gt;criptat&lt;/b&gt; iar în momentul de față este &lt;b&gt;deblocat&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Portofelul este &lt;b&gt;criptat&lt;/b&gt; iar în momentul de față este &lt;b&gt;blocat&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+441"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>A survenit o eroare fatala. Bitcoin nu mai poate continua in siguranta si se va opri.</translation>
     </message>
@@ -715,7 +567,6 @@ Adresa: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Alertă rețea</translation>
     </message>
@@ -723,291 +574,230 @@ Adresa: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Selectare Adresă de Comandă Monedă</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Cantitate:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Octeţi:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Sumă:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prioritate:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Ieşire minimă: </translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>După taxe:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Schimb:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(de)selectaţi tot</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Modul arborescent</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Modul lista</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Sumă</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresă</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Confirmări</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Confirmat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prioritate</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Copiază adresa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiază eticheta</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Copiază suma</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Copiază ID tranzacție</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Blocaţi necheltuite</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Deblocaţi necheltuite</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Copiaţi quantitea</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Copiaţi taxele</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copiaţi după taxe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiaţi octeţi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copiaţi prioritatea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copiaţi ieşire minimă:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiaţi schimb</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>cel mai mare</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>mai mare</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>mare</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>marime medie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>mediu</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>mediu-scazut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>scazut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>mai scazut</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>cel mai scazut</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(1% blocat)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>nimic</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Praf</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>da</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>nu</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Această etichetă devine roşie, în cazul în care dimensiunea tranzacţiei este mai mare de 1000 de octeţi. </translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Aceasta înseamnă o taxă de cel puţin 1% pe kB necesar.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Poate varia +/- 1 octet pentru fiecare intrare. </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Tranzacţiile cu prioritate mai mare sunt mai susceptibile de fi incluse într-un bloc. </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Aceasta eticheta se face rosie daca prioritatea e mai mica decat media</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Această etichetă devine roşie, dacă orice beneficiar primeşte o sumă mai mică decât 1. </translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Aceasta înseamnă că o taxă de cel puţin 1% este necesară. </translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Sume sub 0,546 ori taxa minima sunt indicate ca ignorate. </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Această etichetă devine roşie, dacă schimbul e mai mic de 1%.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+63"/>
         <source>(no label)</source>
         <translation>(fără etichetă)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(schimb)</translation>
     </message>
@@ -1015,67 +805,54 @@ Adresa: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Editează adresa</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etichetă</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>Etichetele asociate cu aceasta intrare din lista.</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Adresa asociata cu aceasta adresa din lista. Aceasta poate fi modificata doar pentru Destinatari.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adresă</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Noua adresă de primire</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Noua adresă de trimitere</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Editează adresa de primire</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Editează adresa de trimitere</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Adresa introdusă &quot;%1&quot; se află deja în lista de adrese.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Adresa introdusă &quot;%1&quot; nu este o adresă bitcoin validă.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Portofelul nu a putut fi deblocat.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Generarea noii chei a eșuat.</translation>
     </message>
@@ -1083,27 +860,22 @@ Adresa: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Va fi creat un nou dosar de date.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>nume</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Dosarul deja există. Adaugă %1 dacă intenționezi să creezi un nou dosar aici.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Calea deja există și nu este un dosar.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Nu se poate crea un dosar de date aici.</translation>
     </message>
@@ -1111,52 +883,46 @@ Adresa: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - Opţiuni Linie de comandă</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>versiunea</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Uz:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>command-line setări</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI setări</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Seteaza limba, de exemplu: &quot;de_DE&quot; (initialt: system locale)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Incepe miniaturizare</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Afișează pe ecran splash la pornire (implicit: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Alege dosarul de date la pornire (implicit: 0)</translation>
     </message>
@@ -1164,57 +930,46 @@ Adresa: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Bun venit</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Bine Aţi Venit la Nucleul Bitcoin.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Dacă aceasta este prima dată când programul este lansat, puteţi alege unde Nucleul Bitcoin va stoca datele. </translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Nucleul Bitcoin Core se va descărca şi va stoca o copie a lanţului blocului Bitcoin. Cel puţin 1GB de date vor fi stocate in acest dosar şi se va dezvolta în timp. Portofelul va fi, de asemenea, stocat în acest dosar.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Folosește dosarul de date implicit</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Folosește un dosar de date personalizat:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Eroare: Directorul datelor specificate &quot;%1&quot; nu poate fi creat.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB de spațiu liber disponibil</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(din %1GB necesari)</translation>
     </message>
@@ -1222,27 +977,22 @@ Adresa: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Deschideti adresa URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Deschideţi cerere de plată prin intermediul adresei URI sau a fişierului</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>adresa URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Selectaţi fişierul de cerere de plată</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Selectaţi fişierul de cerere de plată de deschis</translation>
     </message>
@@ -1250,258 +1000,206 @@ Adresa: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Principal</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Taxa optionala de tranzactie per kB care ajuta ca tranzactiile dumneavoastra sa fie procesate rapid. Majoritatea tranzactiilor sunt 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Plăteşte comision pentru tranzacţie &amp;f</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Porneşte automat programul Bitcoin la pornirea computerului.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;S Porneşte Bitcoin la pornirea sistemului</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+153"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Conecteaza-te la reteaua Bitcoin printr-un proxy SOCKS</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Resetează toate setările clientului la valorile implicite.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Resetează opțiunile</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>&amp;Retea</translation>
     </message>
     <message>
-        <location line="-95"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>expert</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Deschide automat în router portul aferent clientului Bitcoin. Funcţionează doar în cazul în care routerul e compatibil UPnP şi opţiunea e activată.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapeaza portul folosind &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Portul pe care se concetează proxy serverul (de exemplu: 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Versiune:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Versiunea SOCKS a proxiului (ex. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Fereastra</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Afişează doar un icon in tray la ascunderea ferestrei</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;M Ascunde în tray în loc de taskbar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Ascunde fereastra în locul părăsirii programului în momentul închiderii ferestrei. Când acestă opţiune e activă, aplicaţia se va opri doar în momentul selectării comenzii Quit din menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>&amp;i Ascunde fereastra în locul închiderii programului</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Afişare</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Interfata &amp; limba userului</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Limba interfeței utilizatorului poate fi setat aici. Această setare va avea efect după repornirea Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Unitatea de măsură pentru afişarea sumelor:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Alege subdiviziunea folosită la afişarea interfeţei şi la trimiterea de bitcoin.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Vezi dacă adresele Bitcoin sunt în lista de tranzacție sau nu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Afişează adresele în lista de tranzacţii</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Dacă să se afişeze controlul caracteristicilor monedei sau nu.</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp; OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp; Renunta</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>Initial</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>nimic</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Confirmă resetarea opțiunilor</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Este necesar un restart al clientului pentru a activa schimbările.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>Clientul va fi închis, doriţi să continuaţi?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Această schimbare va necesita un restart al clientului.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Adresa bitcoin pe care a-ti specificat-o este invalida</translation>
     </message>
@@ -1509,69 +1207,54 @@ Adresa: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Informațiile afișate pot neactualizate. Portofelul tău se sincronizează automat cu rețeaua Bitcoin după ce o conexiune este stabilită, dar acest proces nu a fost finalizat încă.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Portofel</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Disponibil:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Balanța ta curentă de cheltuieli</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>În aşteptare:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Totalul tranzacțiilor care nu sunt confirmate încă și care nu sunt încă adunate la balanța de cheltuieli</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Nematurizat:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Balanta minata care nu s-a maturizat inca</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Total:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Balanța totală curentă</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Tranzacții recente&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>Nu este sincronizat</translation>
     </message>
@@ -1579,93 +1262,70 @@ Adresa: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Gestionare URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI nu poate fi analizat! Acest lucru poate fi cauzat de o adresa Bitcoin invalida sau parametri deformati URI.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Cereti plata cu suma de %1 este prea mica (considerata praf)</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Eroare la cererea de plată</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Nu poate porni bitcoin: regula clic-pentru-plata</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Cereri de plată neverificate prin script-uri personalizate de plată nu sunt suportate.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>rambursare de la %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Eroare la comunicarea cu %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Răspuns greșit de la server %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Plată acceptată</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Eroare în cererea de rețea</translation>
     </message>
@@ -1673,23 +1333,22 @@ Adresa: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+14"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-13"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Eroare: Directorul datelor specificate &quot;%1&quot; nu exista.</translation>
     </message>
     <message>
-        <location line="+13"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Eroare: combinație nevalidă de -regtest și -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introdu o adresă Bitcoin (de exemplu: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1697,22 +1356,18 @@ Adresa: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>Salvarea imaginii ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>Copierea imaginii</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Salvează codul QR</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>Imagine de tip PNG (*.png)</translation>
     </message>
@@ -1720,194 +1375,146 @@ Adresa: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Nume client</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>N/A</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Versiune client</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informație</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Fereastra de depanare</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Foloseste versiunea OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Durata pornirii</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Rețea</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Numele</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Numărul de conexiuni</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Lanț de blocuri</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Numărul curent de blocuri</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Blocurile totale estimate</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Data ultimului bloc</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Deschide</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Consolă</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>Traficul in rețea</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Ştergeţi</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Totaluri</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>în:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>Ieșire.</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Construit la data</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Loguri debug</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Deschide logurile debug din directorul curent. Aceasta poate dura cateva secunde pentru fisierele mai mari</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Curăță consola</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bun venit la consola bitcoin RPC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Foloseste sagetile sus si jos pentru a naviga in istoric si &lt;b&gt;Ctrl-L&lt;/b&gt; pentru a curata.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Scrie &lt;b&gt;help&lt;/b&gt; pentru a vedea comenzile disponibile</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 ora %2 minute</translation>
     </message>
@@ -1915,105 +1522,82 @@ Adresa: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp; suma:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etichetă:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp; mesaj:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Refolositi una din adresele de primire folosite in prealabil. Refolosirea adreselor poate crea probleme de securitate si confidentialitate. Nu folositi aceasta optiune decat daca o cerere de regenerare a platii a fost facuta in prealabil.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>&amp;Refolosirea unei adrese de primire (nu este recomandat)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Folosește acest formular pentru a solicita plăți. Toate câmpurile sunt &lt;b&gt;opționale&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Stergeti toate campurile formularului</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Stergeti</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Istoricul platilor a fost cerut</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Cereti plata</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Arată</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Elimină</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Copiază eticheta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Copiaţi mesajul</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiază suma</translation>
     </message>
@@ -2021,67 +1605,54 @@ Adresa: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Copiati &amp;URl</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Copiati &amp;Adresa</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>Salvarea imaginii ...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Cereti plata pentru %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Informatiile platii</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>Identificator uniform de resurse</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresă</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Sumă</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etichetă</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI rezultat este prea lung, încearcă să reduci textul pentru etichetă / mesaj.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Eroare la codarea URl-ului în cod QR.</translation>
     </message>
@@ -2089,285 +1660,225 @@ Adresa: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etichetă</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Sumă</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(fără etichetă)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(nici un mesaj)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
-        <translation type="unfinished"/>
+        <translation>(suma nulă)</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Trimite monede</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Intrări</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>Selectie automatică</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Fonduri insuficiente!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Cantitate:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Octeţi:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Sumă:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prioritate:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Taxa:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Ieşire minimă: </translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>După taxe:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Schimbaţi:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Trimite simultan către mai mulți destinatari</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;Adaugă destinatar</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Stergeti toate campurile formularului</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Șterge &amp;tot</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Balanță:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Confirmă operațiunea de trimitere</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;S Trimite</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Confirmă trimiterea de monede</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 la %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Copiaţi quantitea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiază suma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Copiaţi taxele</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Copiaţi după taxe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Copiaţi octeţi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Copiaţi prioritatea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Copiaţi ieşire minimă:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Copiaţi schimb</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Suma totală %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>sau</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresa destinatarului nu este validă, vă rugăm să o verificaţi.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Suma de plată trebuie să fie mai mare decât 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Suma depășește soldul contului.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Totalul depășește soldul contului dacă se include și plata comisionului de %1.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>S-a descoperit o adresă care figurează de două ori. Expedierea se poate realiza către fiecare adresă doar o singură dată pe operațiune.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Creare de tranzactie nereusita!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Tranzactia a fost respinsa! Acest lucru se poate intampla daca o parte din monedele tale din portofel au fost deja cheltuite, la fel ca si cum ai fi folosit o copie a wallet.dat si monedele au fost cheltuite in copie, dar nu au fost marcate si si cheltuite si aici.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Atentie: Adresa Bitcoin invalida!</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(fără etichetă)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Atentie: Schimbare de adresa necunoscuta</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Ești sigur că vrei să trimiți?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>adăugat ca taxă de tranzacție</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Cererea de plată a expirat</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Adresă pentru plată nevalidă %1</translation>
     </message>
@@ -2375,98 +1886,74 @@ Adresa: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Su&amp;mă:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Plătește că&amp;tre:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adresa către care se va face plata  (de exemplu: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Introdu o etichetă pentru această adresă pentru a fi adăugată în lista ta de adrese</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etichetă:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Alegeti adrese folosite in prealabil.</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Aceasta este o tranzacţie normală.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Lipește adresa din clipboard</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Scoate aceasta introducere</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Mesaj:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Aceasta este o cerere de plata verificata</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Introduceti eticheta pentru ca aceasta adresa sa fie introdusa in lista de adrese folosite</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Aceasta este o cerere de plata neverificata</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Plateste catre:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Memo:</translation>
     </message>
@@ -2474,12 +1961,10 @@ Adresa: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Core se închide...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Nu închide calculatorul până ce această fereastră nu dispare.</translation>
     </message>
@@ -2487,186 +1972,142 @@ Adresa: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Semnatura- Semneaza/verifica un mesaj</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>Semneaza Mesajul</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Puteti semna mesaje cu adresa dumneavoastra pentru a demostra ca sunteti proprietarul lor. Aveti grija sa nu semnati nimic vag, deoarece atacurile de tip phishing va pot pacali sa le transferati identitatea. Semnati numai declaratiile detaliate cu care sunteti deacord.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduceţi o adresă Bitcoin (de exemplu: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Alegeti adrese folosite in prealabil</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Lipiţi adresa copiată in clipboard.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Introduce mesajul pe care vrei sa il semnezi, aici.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Semnătură</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Copiaza semnatura curenta in clipboard-ul sistemului</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Semneaza mesajul pentru a dovedi ca detii acesta adresa Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Semnează &amp;Message</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Reseteaza toate spatiile mesajelor semnate.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Şterge &amp;tot</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>Verifica mesajul</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Introduceti adresa de semnatura, mesajul (asigurati-va ca ati copiat spatiile, taburile etc. exact) si semnatura dedesubt pentru a verifica mesajul. Aveti grija sa nu cititi mai mult in semnatura decat mesajul in sine, pentru a evita sa fiti pacaliti de un atac de tip man-in-the-middle.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduceţi o adresă Bitcoin (de exemplu: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verifica mesajul pentru a fi sigur ca a fost semnat cu adresa Bitcoin specifica</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verifică &amp;Message</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Reseteaza toate spatiile mesajelor semnate.</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Introduceţi o adresă Bitcoin (de exemplu: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Click &quot;Semneaza msajul&quot; pentru a genera semnatura</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Adresa introdusa nu este valida</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Te rugam verifica adresa si introduce-o din nou</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Adresa introdusa nu se refera la o cheie.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Blocarea portofelului a fost intrerupta</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Cheia privata pentru adresa introdusa nu este valida.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Semnarea mesajului a esuat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Mesaj Semnat!</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Aceasta semnatura nu a putut fi decodata</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Verifica semnatura si incearca din nou</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Semnatura nu seamana!</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Verificarea mesajului a esuat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Mesaj verificat</translation>
     </message>
@@ -2674,17 +2115,14 @@ Adresa: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Dezvoltatorii Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2692,7 +2130,6 @@ Adresa: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2700,184 +2137,138 @@ Adresa: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Deschis până la %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/deconectat</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/neconfirmat</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 confirmări</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Stare</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, distribuit prin %n nod</numerusform><numerusform>, distribuit prin %n noduri</numerusform><numerusform>, distribuit prin %n de noduri</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Sursa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generat</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>De la</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Către</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>Adresa posedata</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etichetă</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Credit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>se maturizează în încă %n bloc</numerusform><numerusform>se maturizează în încă %n blocuri</numerusform><numerusform>se maturizează în încă %n de blocuri</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>nu este acceptat</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debit</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Comisionul tranzacţiei</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Suma netă</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Comentarii</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID-ul tranzactiei</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Comerciant</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Monezile generate trebuie sa creasca %1 block-uri inainte sa poata fi cheltuite. Cand ati generat acest block, a fost transmis retelei pentru a fi adaugat la lantul de block-uri. Aceasta  se poate intampla ocazional daca alt nod genereaza un block la numai cateva secunde de al tau.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Informatii pentru debug</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Tranzacţie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Intrari</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Sumă</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>Adevarat!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>Fals!</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, nu s-a propagat încă</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Deschis pentru încă %1 bloc</numerusform><numerusform>Deschis pentru încă %1 blocuri</numerusform><numerusform>Deschis pentru încă %1 de blocuri</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>necunoscut</translation>
     </message>
@@ -2885,12 +2276,10 @@ Adresa: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detaliile tranzacției</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Acest panou afișează o descriere detaliată a tranzacției</translation>
     </message>
@@ -2898,127 +2287,102 @@ Adresa: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tipul</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Cantitate</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Deschis pentru încă %1 bloc</numerusform><numerusform>Deschis pentru încă %1 blocuri</numerusform><numerusform>Deschis pentru încă %1 de blocuri</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Deschis până la %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Confirmat (%1 confirmări)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Acest bloc nu a fost recepționat de niciun alt nod și probabil nu va fi acceptat!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generat dar neacceptat</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Deconectat</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Neconfirmat</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Confirmare (%1 dintre %2 confirmări recomandate)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Recepționat cu</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Primit de la</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Trimis către</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Plată către tine</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Produs</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Starea tranzacției. Treci cu mausul peste acest câmp pentru afișarea numărului de confirmări.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Data și ora la care a fost recepționată tranzacția.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tipul tranzacției.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Adresa de destinație a tranzacției.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Suma extrasă sau adăugată la sold.</translation>
     </message>
@@ -3026,178 +2390,142 @@ Adresa: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Toate</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Astăzi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Săptămâna aceasta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Luna aceasta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Luna trecută</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Anul acesta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Între...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Recepționat cu</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Trimis către</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Către tine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Produs</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Altele</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Introdu adresa sau eticheta pentru căutare</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Cantitatea minimă</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Copiază adresa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Copiază eticheta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Copiază suma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Copiază ID tranzacție</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Editează eticheta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Arată detaliile tranzacției</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Exportare Istoric Tranzacţii</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Exportare Eşuată</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>S-a produs o eroare încercând să se salveze istoricul tranzacţiilor la %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Exportare Reuşită</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>Istoricul tranzacţiilor a fost salvat cu succes la %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Fișier text cu valori separate prin virgulă (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Confirmat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tipul</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etichetă</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresă</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Sumă</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Interval:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>către</translation>
     </message>
@@ -3205,7 +2533,6 @@ Adresa: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Nu a fost încărcat niciun portofel.</translation>
     </message>
@@ -3213,7 +2540,6 @@ Adresa: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Trimite Bitcoin</translation>
     </message>
@@ -3221,42 +2547,34 @@ Adresa: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportă</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exporta datele din tab-ul curent într-un fișier</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Fă o copie de siguranță a portofelului</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Date portofel (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Copia de rezerva a esuat</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>S-a produs o eroare încercând să se salveze datele portofelului la %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Datele portofelului s-au salvat cu succes la %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Copia de siguranță efectuată cu succes</translation>
     </message>
@@ -3264,102 +2582,86 @@ Adresa: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+226"/>
         <source>Usage:</source>
         <translation>Uz:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Listă de comenzi</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Ajutor pentru o comandă</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Setări:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Specifică fișierul de configurare (implicit: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Specifică fișierul pid (implicit bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Specifică dosarul de date</translation>
     </message>
     <message>
-        <location line="-35"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Ascultă pentru conectări pe &lt;port&gt; (implicit:  8333 sau testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Menține cel mult &lt;n&gt; conexiuni cu partenerii (implicit: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Conectează-te la nod pentru a obține adresele partenerilor, și apoi deconectează-te</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Specifică adresa ta publică</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Prag pentru deconectarea partenerilor care nu funcționează corect (implicit: 100)</translation>
     </message>
     <message>
-        <location line="-151"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Numărul de secunde pentru a preveni reconectarea partenerilor care nu funcționează corect (implicit: 86400)</translation>
     </message>
     <message>
-        <location line="-38"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>A intervenit o eroare in timp ce se seta portul RPC %u pentru ascultare pe IPv4: %s</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Ascultă pentru conexiuni JSON-RPC pe &lt;port&gt; (implicit:8332 sau testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Se acceptă comenzi din linia de comandă și comenzi JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Rulează în fundal ca un demon și acceptă comenzi</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Utilizează rețeaua de test</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Acceptă conexiuni din afară (implicit: 1  dacă nu se folosește -proxy sau -connect)</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3385,732 +2687,682 @@ spre exemplu: alertnotify=echo %%s | mail -s &quot;Alerta Bitcoin&quot; admin@fo
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Cifruri acceptabile (implicit: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>A intervenit o eroare in timp ce se seta portul RPC %u pentru ascultare pe IPv6, reintoarcere la IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Atasati adresei date si ascultati totdeauna pe ea. Folositi [host]:port notatia pentru IPv6</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Initiati modul de test al regresie, care foloseste un lant special in care block-urile pot fi rezolvate instantaneu. Acest lucru este facut pentru utilitare si aplicatii de dezvoltare pentru testarea regresiei.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Eroare: Tranzactia a fost respinsa! Acest lucru se poate intampla daca anumite monezi din portofelul dumneavoastra au fost deja cheltuite, deasemenea daca ati folosit o copie a fisierului wallet.dat si monezile au fost folosite in acea copie dar nu au fost marcate ca fiind folosite acolo.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Eroare: Aceasta tranzactie necesita o taxa de cel putin %s din cauza sumei, complexitatii sau folosirii fondurilor recent primite!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Executati comanda cand o tranzactie a portofelului se schimba (%s in cmd este inlocuit de TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation>Taxe mai mici decat aceasta suma sunt considerate taxe nule (pentru crearea tranzactiilor) (pentru nespecificare:</translation>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Aceasta este o versiune de test preliminara - va asumati riscul folosind-o - nu folositi pentru minerit sau aplicatiile comerciantilor.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Utilizare proxy SOCKS5 separat pentru a ajunge la servicii ascunse TOR (implicit: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Atentie: setarea -paytxfee este foarte ridicata! Aceasta este taxa tranzactiei pe care o vei plati daca trimiti o tranzactie.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Atentie: Va rugam verificati daca data/timpul computerului dumneavoastra sunt corecte! Daca ceasul computerului este decalat, Bitcoin nu va functiona corect.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Atentie: Reteaua nu pare sa fie deacord in totalitate! Aparent niste mineri au probleme. </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Atentie: Aparent, nu suntem deacord cu toti membrii nostri! Va trebui sa faci un upgrade, sau alte noduri ar necesita upgrade. </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Atentie: eroare la citirea fisierului wallet.dat! Toate cheile sunt citite corect, dar datele tranzactiei sau anumite intrari din agenda sunt incorecte sau lipsesc.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Atentie: fisierul wallet.dat este corupt, date salvate! Fisierul original wallet.dat a fost salvat ca wallet.{timestamp}.bak in %s; daca balansul sau tranzactiile sunt incorecte ar trebui sa restaurati dintr-o copie de siguranta. </translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; poate fi:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Încearcă recuperarea cheilor private dintr-un wallet.dat corupt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Daemon-ul Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Versiunea clientului Bitcoin RPC</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Optiuni creare block</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Conecteaza-te doar la nod(urile) specifice</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Conectare prin proxy SOCKS</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Conectat la JSON-RPC pe &lt;portul&gt; (implicit: 8332 sau testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Baza de date &apos;bloc&apos; defectată a fost detectată</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Descopera propria ta adresa IP (intial: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Doriți să reconstruiți baza de date &apos;bloc&apos; acum?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Eroare la inițializarea bazei de date de blocuri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Eroare la initializarea mediului de baza de date a portofelului %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Eroare la încărcarea bazei de date de blocuri</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Eroare la deschiderea bazei de date de blocuri</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Eroare: Spațiu pe disc redus!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Eroare: Portofel blocat, nu se poate crea o tranzacție!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Eroare: eroare de sistem:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Am esuat ascultarea pe orice port. Folositi -listen=0 daca vreti asta.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Citirea informațiilor despre bloc a eșuat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Citirea blocului a eșuat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>A eșuat sincronizarea indexului de blocuri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>A eșuat scrierea indexului de blocuri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Scrierea informațiilor despre bloc a eșuat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Scrierea blocului a eșuat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Nu a reușit scrierea informației în fișier</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Eșuarea scrierii în baza de date de monede</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Nu a reușit scrierea indexului de tranzacție</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Esuare in scrierea datelor anulate</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Găsește parteneri folosind căutarea DNS (implicit: 1 doar dacă nu s-a folosit -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation>Pornire fortata a modului safe mode (prestabilit: 0)</translation>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generează monede (implicit: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Cate block-uri se verifica la initializare (implicit: 288, 0=toate)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Cât de </translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Incorect sau nici un bloc de Geneza găsite. Directorul de retea greşit?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Adresa -onion invalidă: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Nu sunt destule descriptoare disponibile.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>Opţiuni client RPC:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Reconstruirea indexului lantului de block-uri din fisierele actuale blk000???.dat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Selectaţi versiunea SOCKS pentru -proxy (4 din 5; iniţial: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Trimite comanda la serverul Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+5"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Setaţi dimensiunea maximă a unui block în bytes (implicit: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Specifică fișierul wallet (în dosarul de date)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>A porni serverul Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
-        <translation type="unfinished"/>
+        <translation>Este folosita pentru programe de testare a regresiei in algoritmi si  dezvoltare de alte aplicatii. </translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Utilizare (învechită, folositi bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Se verifică blocurile...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Se verifică portofelul...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Aşteptaţi serverul RPC să pornească</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Portofelul %s se află în afara dosarului de date %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Optiuni de portofel</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Trebuie să reconstruiești baza de date folosind -reindex pentru a schimba -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importă blocuri dintr-un fișier extern blk000??.dat</translation>
     </message>
     <message>
-        <location line="-126"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Executati comanda cand o alerta relevanta este primita sau vedem o bifurcatie foarte lunga (%s in cmd este inlocuti de mesaj)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+91"/>
         <source>Information</source>
         <translation>Informație</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Suma invalida pentru -minrelaytxfee=&lt;suma&gt;:&apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Suma invalida pentru -mintxfee=&lt;suma&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Păstrează un index complet al tranzacțiilor (implicit: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Tampon maxim pentru recepție per conexiune, &lt;n&gt;*1000 baiți (implicit: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Tampon maxim pentru transmitere per conexiune, &lt;n&gt;*1000 baiți (implicit: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Se accepta decat lantul de block care se potriveste punctului de control implementat (implicit: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Efectuează conexiuni doar către nodurile din rețeaua &lt;net&gt; (IPv4, IPv6 sau Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation>Publica bloc la pornire daca exista in index-ul de blocuri. </translation>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation>Publicare arbore blocuri la pornire (prestabilit: 0)</translation>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Optiuni SSl (vezi Bitcoin wiki pentru intructiunile de instalare)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation>Trimitere comenzi catre Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Trimite informațiile trace/debug la consolă în locul fișierului debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Setează mărimea minimă a blocului în baiți (implicit: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Micsorati fisierul debug.log la inceperea clientului (implicit: 1 cand nu -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Semnarea tranzacției a eșuat</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Specifică intervalul maxim de conectare în milisecunde (implicit: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Eroare de sistem:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Suma tranzacționată este prea mică</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Sumele tranzacționate trebuie să fie pozitive</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Tranzacția este prea mare</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Foloseste UPnP pentru a vedea porturile (initial: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Foloseste UPnP pentru a vedea porturile (initial: 1 cand listezi)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Utilizator pentru conexiunile JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Avertizare</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Atenție: această versiune este depășită, este necesară actualizarea!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>in timpul pornirii</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>versiunea</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat corupt, recuperare eșuată</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Parola pentru conexiunile JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Permite conexiuni JSON-RPC de la adresa IP specificată</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Trimite comenzi la nodul care rulează la &lt;ip&gt; (implicit: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-134"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Execută comanda când cel mai bun bloc se modifică (%s în cmd este înlocuit cu hash-ul blocului)</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Actualizează portofelul la ultimul format</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Setează mărimea bazinului de chei la &lt;n&gt; (implicit: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Rescanează lanțul de bloc pentru tranzacțiile portofel lipsă</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Folosește OpenSSL (https) pentru conexiunile JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Certificatul serverului (implicit: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Cheia privată a serverului (implicit: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Acest mesaj de ajutor</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Nu se poate folosi %s pe acest calculator (eroarea returnată este %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Permite căutări DNS pentru -addnode, -seednode și -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Încarc adrese...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Eroare la încărcarea wallet.dat: Portofel corupt</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Eroare la încărcarea wallet.dat: Portofelul are nevoie de o versiune Bitcoin mai nouă</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Portofelul trebuie rescris: repornește Bitcoin pentru finalizare</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Eroare la încărcarea wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Adresa -proxy nevalidă: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Rețeaua specificată în -onlynet este necunoscută: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>S-a cerut o versiune necunoscută de proxy -socks: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Nu se poate rezolva adresa -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Nu se poate rezolva adresa -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Suma nevalidă pentru -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Sumă nevalidă</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Fonduri insuficiente</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Încarc indice bloc...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Adaugă un nod la care te poți conecta pentru a menține conexiunea deschisă</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>Loading wallet...</source>
         <translation>Încarc portofel...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Nu se poate retrograda portofelul</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Nu se poate scrie adresa implicită</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Rescanez...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Încărcare terminată</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Pentru a folosi opțiunea %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Eroare</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ru.ts
+++ b/src/qt/locale/bitcoin_ru.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>О Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>версия &lt;b&gt;Bitcoin Core&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ This product includes software developed by the OpenSSL Project for use in the O
 Этот продукт включает ПО, разработанное OpenSSL Project для использования в OpenSSL Toolkit (http://www.openssl.org/) и криптографическое ПО, написанное Eric Young (eay@cryptsoft.com) и ПО для работы с UPnP, написанное Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Все права защищены</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Разработчики Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
-        <translation>(%1-bit)</translation>
+        <source>(%1-bit)</source>
+        <translation>(%1-бит)</translation>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Для того, чтобы изменить адрес или метку, дважды кликните по изменяемому объекту</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Создать новый адрес</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Новый</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Копировать текущий выделенный адрес в буфер обмена</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Копировать</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>&amp;Закрыть</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Копировать адрес</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Удалить выбранный адрес из списка</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Экспортировать данные из вкладки в файл</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Экспорт</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Удалить</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Выберите адрес для отправки на него монет</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Выберите адрес для получения монет</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Выбрать</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Адреса отправки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Адреса получения</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Это ваши адреса Bitcoin для отправки платежей. Всегда проверяйте количество и адрес получателя перед отправкой перевода.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Это ваши адреса Bitcoin для приёма платежей. Рекомендуется использовать новый адрес получения для каждой транзакции.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Копировать &amp;метку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Правка</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Экспортировать список адресов</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Текст, разделённый запятыми (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Экспорт не удался</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Произошла ошибка при сохранении списка адресов в %1.</translation>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Метка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>[нет метки]</translation>
     </message>
@@ -187,140 +153,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Диалог ввода пароля</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Введите пароль</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Новый пароль</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Повторите новый пароль</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Введите новый пароль для бумажника. &lt;br/&gt; Пожалуйста, используйте фразы из &lt;b&gt;10 или более случайных символов,&lt;/b&gt; или &lt;b&gt;восьми и более слов.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Зашифровать бумажник</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Для выполнения операции требуется пароль вашего бумажника.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Разблокировать бумажник</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Для выполнения операции требуется пароль вашего бумажника.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Расшифровать бумажник</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Сменить пароль</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Введите старый и новый пароль для бумажника.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Подтвердите шифрование бумажника</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Внимание: если вы зашифруете бумажник и потеряете пароль, вы &lt;b&gt;ПОТЕРЯЕТЕ ВСЕ ВАШИ БИТКОЙНЫ&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Вы уверены, что хотите зашифровать ваш бумажник?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>ВАЖНО: все предыдущие резервные копии вашего бумажника должны быть заменены новым зашифрованным файлом. В целях безопасности предыдущие резервные копии незашифрованного бумажника станут бесполезны, как только вы начнёте использовать новый зашифрованный бумажник.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Внимание: Caps Lock включен!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Бумажник зашифрован</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Сейчас программа закроется для завершения процесса шифрования. Помните, что шифрование вашего бумажника не может полностью защитить ваши биткойны от кражи с помощью инфицирования вашего компьютера вредоносным ПО.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Не удалось зашифровать бумажник</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Шифрование бумажника не удалось из-за внутренней ошибки. Ваш бумажник не был зашифрован.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Введённые пароли не совпадают.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Разблокировка бумажника не удалась</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Указанный пароль не подходит.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Расшифрование бумажника не удалось</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Пароль бумажника успешно изменён.</translation>
     </message>
@@ -328,362 +260,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;Подписать сообщение...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Синхронизация с сетью...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Обзор</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation>Узел</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Показать общий обзор действий с бумажником</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Транзакции</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Показать историю транзакций</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>В&amp;ыход</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Закрыть приложение</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Показать информацию о Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>О &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Показать информацию о Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Зашифровать бумажник...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Сделать резервную копию бумажника...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Изменить пароль...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;Адреса отправки...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>Адреса &amp;получения...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Открыть &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Импортируются блоки с диска...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Идёт переиндексация блоков на диске...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Отправить монеты на указанный адрес Bitcoin</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Изменить параметры конфигурации Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Сделать резервную копию бумажника в другом месте</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Изменить пароль шифрования бумажника</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Окно отладки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Открыть консоль отладки и диагностики</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Проверить сообщение...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Бумажник</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Отправить</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Получить</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Показать / Скрыть</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Показать или скрыть главное окно</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Зашифровать приватные ключи, принадлежащие вашему бумажнику</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Подписать сообщения вашим адресом Bitcoin, чтобы доказать, что вы им владеете</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Проверить сообщения, чтобы удостовериться, что они были подписаны определённым адресом Bitcoin</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Настройки</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Помощь</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Панель вкладок</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[тестовая сеть]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Запросить платежи (создаёт QR-коды и bitcoin: ссылки)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;О Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Показать список использованных адресов и меток отправки</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Показать список использованных адресов и меток получения</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Открыть bitcoin: URI или запрос платежа</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Опции командной строки</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Показать помощь по Bitcoin Core и получить список доступных опций командной строки.</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin клиент</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n активное соединение с сетью</numerusform><numerusform>%n активных соединений с сетью</numerusform><numerusform>%n активных соединений с сетью Bitcoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Источник блоков недоступен...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Обработано %1 из %2 (примерно) блоков истории транзакций.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Обработано %1 блоков истории транзакций.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n час</numerusform><numerusform>%n часа</numerusform><numerusform>%n часов</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n день</numerusform><numerusform>%n дня</numerusform><numerusform>%n дней</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n неделя</numerusform><numerusform>%n недели</numerusform><numerusform>%n недель</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 и %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n год</numerusform><numerusform>%n лет</numerusform><numerusform>%n года</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 позади</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Последний полученный блок был сгенерирован %1 назад.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Транзакции после него пока не будут видны.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Внимание</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Синхронизировано</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Синхронизируется...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Исходящая транзакция</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Входящая транзакция</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +552,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Бумажник &lt;b&gt;зашифрован&lt;/b&gt; и в настоящее время &lt;b&gt;разблокирован&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Бумажник &lt;b&gt;зашифрован&lt;/b&gt; и в настоящее время &lt;b&gt;заблокирован&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Произошла неисправимая ошибка. Bitcoin не может безопасно продолжать работу и будет закрыт.</translation>
     </message>
@@ -714,7 +567,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Сетевая Тревога</translation>
     </message>
@@ -722,291 +574,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Выбор адреса контроля монет</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Количество:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Байт:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Сумма:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Приоритет:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Комиссия:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Малый выход:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>После комиссии:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Сдача:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>Отменить выбор всего</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Режим дерева</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Режим списка</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Сумма</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Подтверждений</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Подтверждено</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Приоритет</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Копировать адрес</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Копировать метку</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Скопировать сумму</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Скопировать ID транзакции</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Заблокировать непотраченное</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Разблокировать непотраченное</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Копировать количество</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Копировать комиссию</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Копировать после комиссии</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Копировать байты</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Копировать приоритет</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Копировать малый выход</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Копировать сдачу</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation>самый высокий</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>выше</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>высокий</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>выше среднего</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>средний</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>ниже среднего</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>низкий</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>ниже</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>самый низкий</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 заблокировано)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>ничего</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Пыль</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>да</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>нет</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Эта пометка становится красной, если размер транзакции больше 1000 байт.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Это значит, что требуется комиссия как минимум %1 на КБ.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Может отличаться на +/- 1 байт на вход.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Транзакции с более высоким приоритетом будут вероятнее других включены в блок.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Эта пометка становится красной, если приоритет ниже, чем &quot;средний&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Эта пометка становится красной, если какой-либо из адресатов получает сумму менее %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Это значит, что требуется комиссия как минимум %1.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Суммы ниже, чем 0.546 минимальных комиссий ретрансляции, показаны как пыль.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Эта пометка становится красной, если сдача меньше %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>[нет метки]</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>сдача с %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(размен)</translation>
     </message>
@@ -1014,67 +805,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Изменить адрес</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Метка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>Метка, связанная с этой записью списка адресов</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Адрес, связанный с этой записью списка адресов. Он может быть изменён только для адресов отправки.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Адрес</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Новый адрес для получения</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Новый адрес для отправки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Изменение адреса для получения</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Изменение адреса для отправки</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Введённый адрес «%1» уже находится в адресной книге.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Введённый адрес &quot;%1&quot; не является правильным Bitcoin-адресом.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Не удается разблокировать бумажник.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Генерация нового ключа не удалась.</translation>
     </message>
@@ -1082,27 +860,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Будет создан новый каталог данных.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>имя</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Каталог уже существует. Добавьте %1, если вы хотите создать здесь новый каталог.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Путь уже существует и не является каталогом.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Не удаётся создать здесь каталог данных.</translation>
     </message>
@@ -1110,52 +883,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Core - опции командной строки</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>версия</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Использование:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>опции командной строки</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Опции интерфейса</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Выберите язык, например &quot;de_DE&quot; (по умолчанию: как в системе)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Запускать свёрнутым</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>Указать корневые SSL-сертификаты для запроса платежа (по умолчанию: -system-)</translation>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Показывать сплэш при запуске (по умолчанию: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Выбрать каталог данных при запуске (по умолчанию: 0)</translation>
     </message>
@@ -1163,57 +930,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Добро пожаловать</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Добро пожаловать в Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Так как вы впервые запустили программу, вы можете выбрать, где Bitcoin Core будет хранить данные.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin Core скачает и сохранит копию цепи блоков. Как минимум, %1ГБ данных будет храниться в этом каталоге, и со временем он будет расти. Бумажник будет также сохранён в этом каталоге.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Использовать каталог данных по умолчанию</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Использовать другой каталог данных:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Ошибка: не удалось создать указанный каталог данных &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>ГБ свободного места доступно</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(из необходимых %1ГБ)</translation>
     </message>
@@ -1221,27 +977,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Открыть URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Открыть запрос платежа из URI или файла</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Выбрать файл запроса платежа</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Выберите файл запроса платежа</translation>
     </message>
@@ -1249,253 +1000,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Опции</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Главная</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Необязательная комиссия за каждый КБ транзакции, которая ускоряет обработку Ваших транзакций.  Большинство транзакций занимают 1КБ.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Заплатить ко&amp;миссию</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Автоматически запускать Bitcoin после входа в систему</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Запускать Bitcoin при входе в систему</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>Размер кэша &amp;БД</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>МБ</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>Число потоков проверки &amp;сценария</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Задать число потоков проверки сценария (вплоть до 16, 0=авто, &lt;0 = оставить столько ядер свободными, по умолчанию: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation>&amp;Тратить неподтвержденную сдачу(Только для продвинутых пользователей!)</translation>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Подключаться к сети Bitcoin через прокси SOCKS.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>&amp;Подключаться через SOCKS прокси (прокси по умолчанию):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>IP-адрес прокси (например IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation>Активные опции командной строки, которые перекрывают вышеуказанные опции:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Сбросить все опции клиента на значения по умолчанию.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Сбросить опции</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Сеть</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation>(0 = автоматически, &lt;0 = оставить столько незагруженных ядер)</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation>Б&amp;умажник</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation>Эксперт</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>Включить управление входами</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>При отключении траты неподтверждённой сдачи, сдача от транзакции не может быть использована до тех пор пока у этой транзакции не будет хотя бы одно подтверждение. Это также влияет как ваш баланс рассчитывается.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>&amp;Тратить неподтверждённую сдачу</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Автоматически открыть порт для Bitcoin-клиента на роутере. Работает только если Ваш роутер поддерживает UPnP, и данная функция включена.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Пробросить порт через &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP Прокси: </translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>По&amp;рт: </translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Порт прокси-сервера (например, 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>&amp;Версия SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Версия SOCKS-прокси (например, 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Окно</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Показывать только иконку в системном лотке после сворачивания окна.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Cворачивать в системный лоток вместо панели задач</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Сворачивать вместо закрытия. Если данная опция будет выбрана — приложение закроется только после выбора соответствующего пункта в меню.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>С&amp;ворачивать при закрытии</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>О&amp;тображение</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>&amp;Язык интерфейса:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Здесь можно выбрать язык интерфейса. Настройки вступят в силу после перезапуска Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Отображать суммы в единицах: </translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Выберите единицу измерения монет при отображении и отправке.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Показывать ли адреса Bitcoin в списке транзакций.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Показывать адреса в списке транзакций</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Показывать ли функции контроля монет или нет.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation>Показать функции &amp;контроля монет (только для экспертов)</translation>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Отмена</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>по умолчанию</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>ничего</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Подтвердите сброс опций</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Для применения изменений требуется перезапуск клиента.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>Клиент будет выключен, желаете продолжить?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Это изменение потребует перезапуска клиента.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Адрес прокси неверен.</translation>
     </message>
@@ -1503,69 +1207,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Отображаемая информация может быть устаревшей. Ваш бумажник автоматически синхронизируется с сетью Bitcoin после подключения, но этот процесс пока не завершён.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Бумажник</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Доступно:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Ваш текущий расходный баланс</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>В ожидании:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Общая сумма всех транзакций, которые до сих пор не подтверждены, и до сих пор не учитываются в расходном балансе</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Незрелые:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Баланс добытых монет, который ещё не созрел</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Итого:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Ваш текущий общий баланс</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Последние транзакции&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Недавние транзакции&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>не синхронизировано</translation>
     </message>
@@ -1573,93 +1262,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Обработка URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
-        <translation>Не удалось обработать URI! Это может быть связано с неверным адресом Bitcoin или неправильными параметрами URI.</translation>
+        <translation>Не удалось разобрать URI! Это может быть связано с неверным адресом Bitcoin или неправильными параметрами URI.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Запрошенная сумма платежа %1 слишком мала (считается пылью).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Ошибка запроса платежа</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Не удаётся запустить bitcoin: обработчик click-to-pay</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Предупреждение менеджера сети</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>Активный прокси не поддерживает SOCKS5, который необходим для запроса платежей через прокси.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>Неверный URL запроса платежа: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Обработка файла запроса платежа</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>Файл запроса платежа не может быть прочитан или обработан! Обычно это происходит из-за неверного файла запроса платежа.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Непроверенные запросы платежей с нестандартными платёжными сценариями не поддерживаются.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>Возврат от %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Ошибка связи с %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>Запрос платежа не может быть разобран или обработан!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Плохой ответ от сервера %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Платёж принят</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Ошибка сетевого запроса</translation>
     </message>
@@ -1667,23 +1333,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Ошибка: указанный каталог &quot;%1&quot; не существует.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Ошибка: не удалось разобрать конфигурационный файл: %1. Используйте синтаксис вида ключ=значение.</translation>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Ошибка: неверная комбинация -regtest и -testnet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Введите Bitcoin-адрес (например 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1691,22 +1356,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Сохранить изображение...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Копировать изображение</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Сохранить QR-код</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>Изображение PNG (*.png)</translation>
     </message>
@@ -1714,192 +1375,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Имя клиента</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>Н/Д</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Версия клиента</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Информация</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Окно отладки</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Общие</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Используется версия OpenSSL</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Время запуска</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Сеть</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Имя</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Число подключений</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Цепь блоков</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Текущее число блоков</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Расчётное число блоков</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Время последнего блока</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Открыть</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>Консоль</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>Сетевой &amp;трафик</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Очистить</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Всего</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>Вход:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>Выход:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Дата сборки</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Отладочный лог-файл</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Открыть отладочный лог-файл Bitcoin из текущего каталога данных. Это может занять несколько секунд для больших лог-файлов.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Очистить консоль</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Добро пожаловать в RPC-консоль Bitcoin.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Используйте стрелки вверх и вниз для просмотра истории и &lt;b&gt;Ctrl-L&lt;/b&gt; для очистки экрана.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Напишите &lt;b&gt;help&lt;/b&gt; для просмотра доступных команд.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 Б</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 КБ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 МБ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 ГБ</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 мин</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 ч</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 ч %2 мин</translation>
     </message>
@@ -1907,105 +1522,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Сумма:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Метка:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Сообщение</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Повторно использовать один из ранее использованных адресов. Повторное использование адресов несёт риски безопасности и приватности. Не используйте эту опцию, если вы не создаёте повторно ранее сделанный запрос платежа.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>&amp;Повторно использовать существующий адрес получения (не рекомендуется)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>Необязательное сообщение для запроса платежа, которое будет показано при открытии запроса. Заметьте: сообщение не будет отправлено вместе с платежом через сеть Bitcoin.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Необязательная метка для нового адреса получения.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Заполните форму для запроса платежей. Все поля &lt;b&gt;необязательны&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Необязательная сумма для запроса. Оставьте пустым или укажите ноль, чтобы запросить неопределённую сумму.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Очистить все поля формы.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Очистить</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>История запрошенных платежей</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Запросить платёж</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>Показать выбранный запрос (то же самое, что и двойной клик по записи)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Показать</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation>Удалить выбранные записи из списка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Копировать метку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Копировать сообщение</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Скопировать сумму</translation>
     </message>
@@ -2013,67 +1605,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR код</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Копировать &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Копировать &amp;адрес</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Сохранить изображение...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Запросить платёж на %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Информация платежа</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Сумма</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Метка</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Сообщение</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Получившийся URI слишком длинный, попробуйте сократить текст метки / сообщения.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Ошибка кодирования URI в QR-код</translation>
     </message>
@@ -2081,37 +1660,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Метка</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Сообщение</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Сумма</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>[нет метки]</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(нет сообщения)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(нет суммы)</translation>
     </message>
@@ -2119,247 +1691,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Отправка</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Функции Контроля Монет</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Входы...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>автоматически выбрано</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Недостаточно средств!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Количество:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Байт:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Сумма:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Приоритет:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Комиссия:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Малый выход:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>После комиссии:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Размен:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Если это выбрано, но адрес сдачи пустой или неверный, сдача будет отправлена на новый сгенерированный адрес.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Свой адрес для сдачи</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Отправить нескольким получателям одновременно</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;Добавить получателя</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Очистить все поля формы</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Очистить &amp;всё</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Баланс:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Подтвердить отправку</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Отправить</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Подтвердите отправку монет</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>С %1 на %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Копировать количество</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Скопировать сумму</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Копировать комиссию</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Копировать после комиссии</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Копировать байты</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Копировать приоритет</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Копировать малый выход</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Копировать размен</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Общая сумма %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>или</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Адрес получателя неверный, пожалуйста, перепроверьте.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Сумма для отправки должно быть больше 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Сумма превышает Ваш баланс</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Сумма превысит Ваш баланс, если комиссия в размере %1 будет добавлена к транзакции</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Обнаружен дублирующийся адрес. Отправка на один и тот же адрес возможна только один раз за одну операцию отправки</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Не удалось создать транзакцию!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Транзакция была отклонена! Такое может произойти, если некоторые монеты уже были потрачены, например, если Вы используете одну копию бумажника (wallet.dat), а монеты были потрачены из другой копии, но не были отмечены как потраченные в этой.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Внимание: неверный адрес Bitcoin</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>[нет метки]</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Внимание: неизвестный адрес для сдачи</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Вы уверены, что хотите отправить?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>добавлено как комиссия</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Запрос платежа просрочен</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Неверный адрес платежа %1</translation>
     </message>
@@ -2367,111 +1886,85 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Ко&amp;личество:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Полу&amp;чатель:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Адрес, на который будет выслан платёж (например 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Введите метку для данного адреса (для добавления в адресную книгу)</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Метка:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Выберите ранее использованный адрес</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Это нормальный платёж.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Вставить адрес из буфера обмена</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Удалить эту запись</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Сообщение:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Это проверенный запрос платежа.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Введите метку для этого адреса, чтобы добавить его в список использованных</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>К bitcoin: URI было прикреплено сообщение, которое будет сохранено вместе с транзакцией для вашего сведения. Заметьте: сообщение не будет отправлено через сеть Bitcoin.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Это непроверенный запрос платежа.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Получатель:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
-        <translation>Заметка:</translation>
+        <translation>Примечание:</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Core выключается...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Не выключайте компьютер, пока это окно не исчезнет.</translation>
     </message>
@@ -2479,186 +1972,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Подписи - подписать/проверить сообщение</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Подписать сообщение</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Вы можете подписывать сообщения своими адресами, чтобы доказать владение ими. Будьте осторожны, не подписывайте что-то неопределённое, так как фишинговые атаки могут обманным путём заставить вас подписать нежелательные сообщения. Подписывайте только те сообщения, с которыми вы согласны вплоть до мелочей.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Адрес, которым вы хотите подписать сообщение  (напр. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Выберите ранее использованный адрес</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Вставить адрес из буфера обмена</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Введите сообщение для подписи</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Подпись</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Скопировать текущую подпись в системный буфер обмена</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Подписать сообщение, чтобы доказать владение адресом Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Подписать &amp;Сообщение</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Сбросить значения всех полей подписывания сообщений</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Очистить &amp;всё</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Проверить сообщение</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Введите ниже адрес для подписи, сообщение (убедитесь, что переводы строк, пробелы, табы и т.п. в точности скопированы) и подпись, чтобы проверить сообщение. Убедитесь, что не скопировали лишнего в подпись, по сравнению с самим подписываемым сообщением, чтобы не стать жертвой атаки &quot;man-in-the-middle&quot;.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Адрес, которым было подписано сообщение (напр. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Проверить сообщение, чтобы убедиться, что оно было подписано указанным адресом Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Проверить &amp;Сообщение</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Сбросить все поля проверки сообщения</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Введите адрес Bitcoin (напр. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Нажмите &quot;Подписать сообщение&quot; для создания подписи</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Введённый адрес неверен</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Пожалуйста, проверьте адрес и попробуйте ещё раз.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Введённый адрес не связан с ключом</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Разблокировка бумажника была отменена.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Для введённого адреса недоступен закрытый ключ</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Не удалось подписать сообщение</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Сообщение подписано</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Подпись не может быть раскодирована.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Пожалуйста, проверьте подпись и попробуйте ещё раз.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Подпись не соответствует отпечатку сообщения.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Проверка сообщения не удалась.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Сообщение проверено.</translation>
     </message>
@@ -2666,17 +2115,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Разработчики Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[тестовая сеть]</translation>
     </message>
@@ -2684,7 +2130,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>КБ/сек</translation>
     </message>
@@ -2692,184 +2137,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Открыто до %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>в противоречии</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/отключен</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/не подтверждено</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 подтверждений</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Статус</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, разослано через %n узел</numerusform><numerusform>, разослано через %n узла</numerusform><numerusform>, разослано через %n узлов</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Источник</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Сгенерированно</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>От</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Для</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>свой адрес</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>метка</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Кредит</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>будет доступно через %n блок</numerusform><numerusform>будет доступно через %n блока</numerusform><numerusform>будет доступно через %n блоков</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>не принято</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Дебет</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Комиссия</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Чистая сумма</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Сообщение</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Комментарий:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID транзакции</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Продавец</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Сгенерированные монеты должны подождать %1 блоков, прежде чем они могут быть потрачены. Когда Вы сгенерировали этот блок, он был отправлен в сеть для добавления в цепочку блоков. Если он не попадёт в цепь, его статус изменится на &quot;не принят&quot;, и монеты будут недействительны. Это иногда происходит в случае, если другой узел сгенерирует блок на несколько секунд раньше вас.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Отладочная информация</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Транзакция</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Входы</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Сумма</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>истина</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>ложь</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, ещё не было успешно разослано</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Открыто для ещё %n блока</numerusform><numerusform>Открыто для ещё %n блоков</numerusform><numerusform>Открыто для ещё %n блоков</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>неизвестно</translation>
     </message>
@@ -2877,140 +2276,113 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Детали транзакции</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
-        <translation>Данный диалог показывает детализированную статистику по выбранной транзакции</translation>
+        <translation>Эта панель отображает детальное описание транзакции.</translation>
     </message>
 </context>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Сумма</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>Незрелый (%1 подтверждений, будет доступен после %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Открыто для ещё %n блока</numerusform><numerusform>Открыто для ещё %n блоков</numerusform><numerusform>Открыто для ещё %n блоков</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Открыто до %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Подтверждено (%1 подтверждений)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Этот блок не был получен другими узлами и, возможно, не будет принят!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Сгенерированно, но не подтверждено</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Нет активных соединений с сетью</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Неподтверждено</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Подтверждено(%1 подтверждений, рекомендуется 2% подтверждений)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>В противоречии</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Получено</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Получено от</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Отправлено</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Отправлено себе</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Добыто</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>[не доступно]</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Статус транзакции. Подведите курсор к нужному полю для того, чтобы увидеть количество подтверждений.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Дата и время, когда транзакция была получена.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Тип транзакции.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Адрес назначения транзакции.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Сумма, добавленная, или снятая с баланса.</translation>
     </message>
@@ -3018,178 +2390,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Все</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Сегодня</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>На этой неделе</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>В этом месяце</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>В прошлом месяце</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>В этом году</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Промежуток...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Получено на</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Отправлено на</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Отправленные себе</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Добытые</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Другое</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Введите адрес или метку для поиска</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Мин. сумма</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Копировать адрес</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Копировать метку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Скопировать сумму</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Скопировать ID транзакции</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Изменить метку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Показать подробности транзакции</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation>Экспортировать историю транзакций</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Экспорт не удался</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Произошла ошибка при сохранении истории транзакций в %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Экспорт успешно завершён</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>История транзакций была успешно сохранена в %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Текст, разделённый запятыми (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Подтверждено</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Метка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Адрес</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Сумма</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Промежуток от:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>до</translation>
     </message>
@@ -3197,7 +2533,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Не был загружен ни один бумажник.</translation>
     </message>
@@ -3205,7 +2540,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Отправка</translation>
     </message>
@@ -3213,42 +2547,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Экспорт</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Экспортировать данные из вкладки в файл</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Сделать резервную копию бумажника</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Данные бумажника (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Резервное копирование не удалось</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Произошла ошибка при сохранении данных бумажника в %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Данные бумажника были успешно сохранены в %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Резервное копирование успешно завершено</translation>
     </message>
@@ -3256,108 +2582,87 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Использование:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Список команд
 </translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Получить помощь по команде</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Опции:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Указать конфигурационный файл (по умолчанию: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Задать pid-файл (по умолчанию: bitcoin.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Задать каталог данных</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Установить размер кэша базы данных в мегабайтах (по умолчанию: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Принимать входящие подключения на &lt;port&gt; (по умолчанию: 8333 или 18333 в тестовой сети)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Поддерживать не более &lt;n&gt; подключений к узлам (по умолчанию: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Подключиться к узлу, чтобы получить список адресов других участников и отключиться</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Укажите ваш собственный публичный адрес</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Порог для отключения неправильно ведущих себя узлов (по умолчанию: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Число секунд блокирования неправильно ведущих себя узлов (по умолчанию: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Произошла ошибка при открытии RPC-порта %u для прослушивания на IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Прослушивать подключения JSON-RPC на &lt;порту&gt; (по умолчанию: 8332 или для testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Принимать командную строку и команды JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation>Версия RPC-клиента Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Запускаться в фоне как демон и принимать команды</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Использовать тестовую сеть</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Принимать подключения извне (по умолчанию: 1, если не используется -proxy или -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3382,723 +2687,683 @@ rpcpassword=%s
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Разрешённые алгоритмы(по умолчанию: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Произошла ошибка при открытии на прослушивание IPv6 RCP-порта %u, возвращаемся к IPv4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Привязаться к указанному адресу и всегда прослушивать только его. Используйте [хост]:порт для IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Не удаётся установить блокировку на каталог данных %s.  Возможно, Bitcoin уже работает.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation>Ограничить скорость передачи бесплатных транзакций до &lt;n&gt;*1000 байт в минуту (по умолчанию: 15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Войти в режим тестирования на регрессии, в котором используется специальная цепь, где блоки находятся мгновенно. Этот режим рассчитан на инструменты регрессионного тестирования и разработку приложений.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>Войти в режим тестирования на регрессии, в котором используется специальная цепь, где блоки находятся мгновенно.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation>Ошибка: не удалось начать прослушивание входящих подключений (прослушивание вернуло ошибку %d)</translation>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Ошибка: транзакция была отклонена! Это могло произойти в случае, если некоторые монеты в вашем бумажнике уже были потрачены, например, если вы используете копию wallet.dat, и монеты были использованы в копии, но не отмечены как потраченные здесь.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Ошибка: эта транзакция требует комиссию как минимум %s из-за суммы, сложности или использования недавно полученных средств!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Выполнить команду, когда меняется транзакция в бумажнике (%s в команде заменяется на TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation>Комиссии меньшие этого значения считаются нулевыми (для создания транзакции) (по умолчанию:</translation>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation>Сбрасывать активность базы данных из памяти на диск каждые &lt;n&gt; мегабайт (по умолчанию: 100)</translation>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation>Насколько тщательна проверка контрольных блоков -checkblocks (0-4, по умолчанию: 3)</translation>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation>В этом режиме -genproclimit определяет, сколько блоков генерируется немедленно.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation>Задать число потоков проверки скрипта (от %u до %d, 0=авто, &lt;0 = оставить столько ядер свободными, по умолчанию: %d)</translation>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation>Задать лимит процессора, когда генерация работает (-1 = безлимитно, по умолчанию: -1)</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Это пре-релизная тестовая сборка - используйте на свой страх и риск - не используйте для добычи или торговых приложений</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation>Не удалось забиндиться на %s на этом компьютере. Возможно, Bitcoin Core уже запущен.</translation>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Использовать отдельный прокси SOCKS5 для соединения с участниками через скрытые сервисы Tor (по умолчанию: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Внимание: установлено очень большое значение -paytxfee. Это комиссия, которую вы заплатите при проведении транзакции.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Внимание: убедитесь, что дата и время на Вашем компьютере выставлены верно. Если Ваши часы идут неправильно, Bitcoin будет работать некорректно.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Внимание: похоже, в сети нет полного согласия! Некоторый майнеры, возможно, испытывают проблемы.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Внимание: мы не полностью согласны с подключенными участниками! Вам или другим узлам, возможно, следует обновиться.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Внимание: ошибка чтения wallet.dat! Все ключи прочитаны верно, но данные транзакций или записи адресной книги могут отсутствовать или быть неправильными.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Внимание: wallet.dat повреждён, данные спасены! Оригинальный wallet.dat сохранён как wallet.{timestamp}.bak в %s; если ваш баланс или транзакции некорректны, вы должны восстановить файл из резервной копии.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation>(по умолчанию: 1)</translation>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation>(по умолчанию: wallet.dat)</translation>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; может быть:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Попытаться восстановить приватные ключи из повреждённого wallet.dat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Демон Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Версия RPC клиента Bitcoin</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Параметры создания блоков:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Очистить список транзакций кошелька (диагностический инструмент; включает в себя -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Подключаться только к указанному узлу(ам)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>Подключаться через SOCKS прокси</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Подключаться к JSON-RPC на &lt;порт&gt; (по умолчанию: 8332 или testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>Параметры подключения:</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>БД блоков повреждена</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation>Параметры отладки/тестирования:</translation>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation>Отключить безопасный режим, отклонить реальное событие безопасного режима (по умолчанию: 0)</translation>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Определить свой IP (по умолчанию: 1 при прослушивании и если не используется -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Не загружать бумажник и запретить обращения к нему через RPC</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Пересобрать БД блоков прямо сейчас?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Ошибка инициализации БД блоков</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Ошибка инициализации окружения БД бумажника %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Ошибка чтения базы данных блоков</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Не удалось открыть БД блоков</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Ошибка: мало места на диске!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Ошибка: бумажник заблокирован, невозможно создать транзакцию!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Ошибка: системная ошибка:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Не удалось начать прослушивание на порту. Используйте -listen=0 если вас это устраивает.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Не удалось прочитать информацию блока</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Не удалось прочитать блок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Не удалось синхронизировать индекс блоков</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Не удалось записать индекс блоков</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Не удалось записать информацию блока</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Не удалось записать блок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Не удалось записать информацию файла</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Не удалось записать БД монет</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Не удалось записать индекс транзакций</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Не удалось записать данные для отмены</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Комиссия на КБ, добавляемая к вашим переводам</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation>Комиссии меньшие этого значения считаются нулевыми (для ретрансляции) (по умолчанию:</translation>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Искать узлы с помощью DNS (по умолчанию: 1, если не указан -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation>Принудительный безопасный режим (по умолчанию: 0)</translation>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Включить добычу монет (по умолчанию: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Сколько блоков проверять при запуске (по умолчанию: 288, 0 = все)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Насколько тщательно проверять блок (0-4, по умолчанию: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>Если &lt;category&gt; не предоставлена, выводить всю отладочную информацию.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Неверный или отсутствующий начальный блок. Неправильный каталог данных для сети?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Неверный -onion адрес: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Недостаточно файловых дескрипторов.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>Дописывать отметки времени к отладочному выводу (по умолчанию: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>Параметры RPC клиента:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Перестроить индекс цепи блоков из текущих файлов blk000??.dat</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>Выбрать версию SOCKS для -proxy (4 или 5, по умолчанию: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Отправлить команды на сервер Bitcoin</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation>Установить размер кэша БД в мегабайтах(от %d до %d, по умолчанию: %d)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Задать максимальный размер блока в байтах (по умолчанию: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Задать число потоков выполнения(по умолчанию: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Укажите файл бумажника (внутри каталога данных)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Тратить неподтвержденную сдачу при отправке транзакций (по умолчанию: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Запустить Bitcoin сервер</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>Это рассчитано на инструменты регрессионного тестирования и разработку приложений.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Использование (устарело, используйте bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Проверка блоков...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Проверка бумажника...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Ожидание запуска RPC сервера</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Бумажник %s располагается вне каталога данных %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Опции бумажника:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Внимание: устаревший аргумент -debugnet проигнорирован, используйте -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Вам необходимо пересобрать базы данных с помощью -reindex, чтобы изменить -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Импортировать блоки из внешнего файла blk000??.dat</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation>Не удалось установить блокировку на каталог данных %s. Возможно, Bitcoin Core уже запущен.</translation>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Выполнить команду, когда приходит соответствующее сообщение о тревоге или наблюдается очень длинное расщепление цепи (%s в команде заменяется на сообщение)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Выводить отладочную информацию (по умолчанию: 0, указание &lt;category&gt; необязательно)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Задать максимальный размер высокоприоритетных/низкокомиссионных транзакций в байтах (по умолчанию: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Задать число потоков проверки сценария (вплоть до 16, 0=авто, &lt;0 = оставить столько ядер свободными, по умолчанию: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Информация</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Неверная сумма в параметре -minrelaytxfee=&lt;кол-во&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Неверная сумма в параметре -mintxfee=&lt;кол-во&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation>Ограничить размер кэша подписей &lt;n&gt; записями (по умолчанию: 50000)</translation>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation>Записывать в лог приоритет транзакции и комиссию на килобайт во время добычи блоков (по умолчанию: 0)</translation>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Держать полный индекс транзакций (по умолчанию: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Максимальный размер буфера приёма на соединение, &lt;n&gt;*1000 байт (по умолчанию: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Максимальный размер буфера отправки на соединение, &lt;n&gt;*1000 байт (по умолчанию: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Принимать цепь блоков, только если она соответствует встроенным контрольным точкам (по умолчанию: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Подключаться только к узлам из сети &lt;net&gt; (IPv4, IPv6 или Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation>Печатать блок при запуске, если он найден в индексе блоков</translation>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation>Печатать дерево блоков при запуске (по умолчанию: 0)</translation>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>Параметры RPC SSL: (см. Bitcoin вики для инструкций по настройке SSL)</translation>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>Параметры сервера RPC:</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation>Случайно отбрасывать 1 из каждых &lt;n&gt; сетевых сообщений</translation>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation>Случайно разбрасывать 1 из каждых &lt;n&gt; сетевых сообщений</translation>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation>Запустить поток для периодического сохранения бумажника (по умолчанию: 1)</translation>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>
 Параметры SSL: (см. Bitcoin Wiki для инструкций по настройке SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation>Отправить команду Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Выводить информацию трассировки/отладки на консоль вместо файла debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Минимальный размер блока в байтах (по умолчанию: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation>Установить флаг DB_PRIVATE в окружении базы данных бумажника (по умолчанию: 1)</translation>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>Показать все отладочные параметры (использование: --help -help-debug)</translation>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation>Показать информацию нагрузочного тестирования (по умолчанию: 0)</translation>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Сжимать файл debug.log при запуске клиента (по умолчанию: 1, если нет -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Не удалось подписать транзакцию</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Тайм-аут соединения в миллисекундах (по умолчанию: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation>Запустить Bitcoin Core демон</translation>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Системная ошибка:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Сумма транзакции слишком мала</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Сумма транзакции должна быть положительна</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Транзакция слишком большая</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Использовать UPnP для проброса порта (по умолчанию: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Использовать UPnP для проброса порта (по умолчанию: 1, если используется прослушивание)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Имя для подключений JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Внимание</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Внимание: эта версия устарела, требуется обновление!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Стираем все транзакции из кошелька...</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>при запуске</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>версия</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat повреждён, спасение данных не удалось</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Пароль для подключений JSON-RPC</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Разрешить подключения JSON-RPC с указанного IP</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Посылать команды узлу, запущенному на &lt;ip&gt; (по умолчанию: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Выполнить команду, когда появляется новый блок (%s в команде заменяется на хэш блока)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Обновить бумажник до последнего формата</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Установить размер запаса ключей в &lt;n&gt; (по умолчанию: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Перепроверить цепь блоков на предмет отсутствующих в бумажнике транзакций</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Использовать OpenSSL (https) для подключений JSON-RPC</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Файл серверного сертификата (по умолчанию: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Приватный ключ сервера (по умолчанию: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Эта справка</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Невозможно привязаться к %s на этом компьютере (bind вернул ошибку %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Разрешить поиск в DNS для -addnode, -seednode и -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Загрузка адресов...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Ошибка загрузки wallet.dat: Бумажник поврежден</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Ошибка загрузки wallet.dat: бумажник требует более новую версию Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Необходимо перезаписать бумажник, перезапустите Bitcoin для завершения операции.</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Ошибка при загрузке wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Неверный адрес -proxy: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>В параметре -onlynet указана неизвестная сеть: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>В параметре -socks запрошена неизвестная версия: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Не удаётся разрешить адрес в параметре -bind: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Не удаётся разрешить адрес в параметре -externalip: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Неверная сумма в параметре -paytxfee=&lt;кол-во&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Неверная сумма</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Недостаточно монет</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Загрузка индекса блоков...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Добавить узел для подключения и пытаться поддерживать соединение открытым</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Невозможно привязаться к %s на этом компьютере.  Возможно, Bitcoin уже работает.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Загрузка бумажника...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Не удаётся понизить версию бумажника</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Не удаётся записать адрес по умолчанию</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Сканирование...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Загрузка завершена</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Чтобы использовать опцию %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_sah.ts
+++ b/src/qt/locale/bitcoin_sah.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,18 +19,14 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -41,122 +34,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Аадырыскын уларытаргар иккитэ баттаа</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,363 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -688,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -706,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -714,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1006,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1074,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1102,57 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1160,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1218,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1246,258 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1505,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1575,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1669,29 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1699,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1722,194 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1917,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2023,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2091,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2129,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2377,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2476,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2489,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2676,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2694,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2702,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2887,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2900,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3028,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3207,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3215,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3223,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3266,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,852 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_sk.ts
+++ b/src/qt/locale/bitcoin_sk.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>O jadre Bitcoin</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>Verzia &lt;b&gt;Bitcoin jadra&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,18 +19,14 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Autorské práva</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Vývojári jadra Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -41,122 +34,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dvojklikom editovať adresu alebo popis</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Vytvoriť novú adresu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Nové</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopírovať práve zvolenú adresu do systémového klipbordu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopírovať</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>Zatvoriť</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopírovať adresu</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportovať tento náhľad do súboru</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportovať...</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Zmazať</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Adresa odoslania</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Adresa prijatia</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopírovať &amp;popis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Upraviť</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exportovať zoznam adries</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Čiarkou oddelený súbor (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Export zlyhal</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Dialóg hesla</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Zadajte heslo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nové heslo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Zopakujte nové heslo</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Zadajte nové heslo k peňaženke.&lt;br/&gt;Prosím použite heslo s dĺžkou aspon &lt;b&gt;10 alebo viac náhodných znakov&lt;/b&gt;, alebo &lt;b&gt;8 alebo viac slov&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Zašifrovať peňaženku</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Táto operácia potrebuje heslo k vašej peňaženke aby ju mohla dešifrovať.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Odomknúť peňaženku</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Táto operácia potrebuje heslo k vašej peňaženke na dešifrovanie peňaženky.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dešifrovať peňaženku</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Zmena hesla</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Zadajte staré a nové heslo k peňaženke.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Potvrďte šifrovanie peňaženky</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Varovanie: Ak zašifrujete peňaženku a stratíte heslo, &lt;b&gt;STRATÍTE VŠETKY VAŠE BITCOINY&lt;/b&gt;!⏎</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Ste si istí, že si želáte zašifrovať peňaženku?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Varovanie: Caps Lock je zapnutý</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Peňaženka zašifrovaná</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin sa teraz ukončí pre dokončenie procesu šifrovania. Pamätaj že šifrovanie peňaženky Ťa nemôže úplne ochrániť pred kráďežou bitcoinov pomocou škodlivého software.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Šifrovanie peňaženky zlyhalo</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Šifrovanie peňaženky zlyhalo kôli internej chybe. Vaša peňaženka nebola zašifrovaná.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Zadané heslá nesúhlasia.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Odomykanie peňaženky zlyhalo</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Zadané heslo pre dešifrovanie peňaženky bolo nesprávne.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Zlyhalo šifrovanie peňaženky.</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Heslo k peňaženke bolo úspešne zmenené.</translation>
     </message>
@@ -323,363 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>Podpísať &amp;správu...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synchronizácia so sieťou...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Prehľad</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>Uzol</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>Zobraziť celkový prehľad o peňaženke</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transakcie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Prechádzať históriu transakcií</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>U&amp;končiť</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Ukončiť program</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Zobraziť informácie o Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Zobrazit informácie o Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Možnosti...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Zašifrovať Peňaženku...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Backup peňaženku...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Zmena Hesla...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Otvoriť &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importujem bloky z disku...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Preindexúvam bloky na disku...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Poslať bitcoins na adresu</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Upraviť možnosti nastavenia pre bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Zálohovať peňaženku na iné miesto</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Zmeniť heslo použité na šifrovanie peňaženky</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Okno pre ladenie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Otvor konzolu pre ladenie a diagnostiku</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>Overiť správu</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>Peňaženka</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>&amp;Odoslať</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Prijať</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>Zobraziť / skryť</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Zobraziť alebo skryť hlavné okno</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Súbor</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Nastavenia</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Pomoc</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Lišta záložiek</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testovacia sieť]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>Jadro Bitcoin</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>O jadre Bitcoin</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>Voľby príkazového riadku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin klient</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktívne spojenie v Bitcoin sieti</numerusform><numerusform>%n aktívne spojenia v Bitcoin sieti</numerusform><numerusform>%n aktívnych spojení v Bitconi sieti</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Nedostupný zdroj blokov...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Spracovaných %1 z %2 (odhadovaných) blokov transakčnej histórie.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Spracovaných %1 blokov transakčnej histórie.</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n hodina</numerusform><numerusform>%n hodiny</numerusform><numerusform>%n hodín</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n deň</numerusform><numerusform>%n dni</numerusform><numerusform>%n dní</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n týždeň</numerusform><numerusform>%n týždne</numerusform><numerusform>%n týždňov</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 za</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Posledný prijatý blok bol vygenerovaný pred %1.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transakcie potom nebudú ešte viditeľné.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Upozornenie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informácia</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>Aktualizovaný</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>Sťahujem...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Odoslané transakcie</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Prijaté transakcie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -691,17 +546,14 @@ Typ: %3
 Adresa: %4</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Peňaženka je &lt;b&gt;zašifrovaná&lt;/b&gt; a momentálne &lt;b&gt;odomknutá&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Peňaženka je &lt;b&gt;zašifrovaná&lt;/b&gt; a momentálne &lt;b&gt;zamknutá&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -709,7 +561,6 @@ Adresa: %4</translation>
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>Výstraha siete</translation>
     </message>
@@ -717,291 +568,230 @@ Adresa: %4</translation>
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Množstvo:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bajtov:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Suma:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Priorita:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Poplatok:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Zmena:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Stromový režim</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Zoznamový režim</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Potvrdenia</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Potvrdené</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Priorita</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>Kopírovať adresu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopírovať popis</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopírovať sumu</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopírovať ID transakcie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Kopírovať množstvo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Kopírovať poplatok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopírovať bajty</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopírovať prioritu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopírovať zmenu</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>najvyššie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>vyššie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>vysoké</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>stredne vysoké</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>stredné</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>stredne nízke</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>nízke</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>nižšie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>najnižšie</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation>žiadne</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Prach</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>áno</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>nie</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation>zmena od %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(zmena)</translation>
     </message>
@@ -1009,67 +799,54 @@ Adresa: %4</translation>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Upraviť adresu</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Popis</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adresa</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nová adresa pre prijímanie</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nová adresa pre odoslanie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Upraviť prijímacie adresy</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Upraviť odosielaciu adresu</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Vložená adresa &quot;%1&quot; sa už nachádza v adresári.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Vložená adresa &quot;%1&quot; nieje platnou adresou bitcoin.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Nepodarilo sa odomknúť peňaženku.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Generovanie nového kľúča zlyhalo.</translation>
     </message>
@@ -1077,27 +854,22 @@ Adresa: %4</translation>
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation>Bude vytvorený nový dátový adresár.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>názov</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Cesta už existuje a nie je to adresár.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Tu nemôžem vytvoriť dátový adresár.</translation>
     </message>
@@ -1105,57 +877,46 @@ Adresa: %4</translation>
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Jadro Bitcoin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>verzia</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Použitie:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>voľby príkazového riadku</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI možnosti</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Nastaviť jazyk, napríklad &quot;sk_SK&quot; (predvolené: systémový)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Spustiť minimalizované</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Zobraziť splash screen pri spustení (predvolené: 1)</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1163,57 +924,46 @@ Adresa: %4</translation>
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Vitajte</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Vitajte v jadre Bitcoin.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Použiť predvolený dátový adresár</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Použiť vlastný dátový adresár:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB dostupného voľného miesta</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(z %1GB potrebných)</translation>
     </message>
@@ -1221,27 +971,22 @@ Adresa: %4</translation>
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Otvoriť URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1249,258 +994,206 @@ Adresa: %4</translation>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Hlavné</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Zaplatiť transakčné &amp;poplatky</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Automaticky spustiť Bitcoin po zapnutí počítača</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Spustiť Bitcoin pri spustení systému správy okien</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Vynulovať všetky voľby klienta na predvolené.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>Vynulovať voľby</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>Sieť</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Automaticky otvorit port pre Bitcoin na routeri. Toto funguje len ak router podporuje UPnP a je táto podpora aktivovaná.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Mapovať port pomocou &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy &amp;IP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Port proxy (napr. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>Verzia SOCKS:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS verzia proxy (napr. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>Okno</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Zobraziť len ikonu na lište po minimalizovaní okna.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>Zobraziť len ikonu na lište po minimalizovaní okna.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimalizovat namiesto ukončenia aplikácie keď sa okno zavrie. Keď je zvolená táto možnosť, aplikácia sa zavrie len po zvolení Ukončiť v menu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimalizovať pri zavretí</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Displej</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Jazyk užívateľského rozhrania:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Zobrazovať hodnoty v jednotkách:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Zobraziť adresy zo zoznamu transakcií</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>predvolené</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>žiadne</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Zadaná proxy adresa je neplatná.</translation>
     </message>
@@ -1508,69 +1201,54 @@ Adresa: %4</translation>
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Forma</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Peňaženka</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Nezrelé:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Celkovo:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Váš súčasný celkový zostatok</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Nedávne transakcie&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>nesynchronizované</translation>
     </message>
@@ -1578,93 +1256,70 @@ Adresa: %4</translation>
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Spracovanie URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Zlá odpoveď zo servera %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1672,29 +1327,22 @@ Adresa: %4</translation>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Zadajte Bitcoin adresu (napr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1702,22 +1350,18 @@ Adresa: %4</translation>
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>Uložiť obrázok...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>Kopírovať obrázok</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Ukladanie QR kódu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG obrázok (*.png)</translation>
     </message>
@@ -1725,194 +1369,146 @@ Adresa: %4</translation>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Meno klienta</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>nie je k dispozícii</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Verzia klienta</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informácia</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Okno pre ladenie</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Všeobecné</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Používa OpenSSL verziu</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Čas spustenia</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Sieť</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Názov</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Počet pripojení</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Reťazec blokov</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Aktuálny počet blokov</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Očakávaných blokov celkovo</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Čas posledného bloku</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Otvoriť</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konzola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>Sieťová prevádzka</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Vyčistiť</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Celkovo</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>Dnu:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>Von:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Dátum zostavenia</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Súbor záznamu ladenia</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Vymazať konzolu</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1920,105 +1516,82 @@ Adresa: %4</translation>
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Suma:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Popis:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Správa:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Vyčistiť všetky polia formulára.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Vyčistiť</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>História vyžiadaných platieb</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>Vyžiadať platbu</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Zobraziť</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Odstrániť</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>Kopírovať popis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Kopírovať správu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopírovať sumu</translation>
     </message>
@@ -2026,67 +1599,54 @@ Adresa: %4</translation>
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Kopírovať &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Kopírovať adresu</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>Uložiť obrázok...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>Vyžiadať platbu pre %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Informácia o platbe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Správa</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Výsledné URI príliš dlhé, skráť text pre názov / správu.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Chyba v zakódovaní URI do QR kódu</translation>
     </message>
@@ -2094,37 +1654,30 @@ Adresa: %4</translation>
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Správa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(žiadna správa)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(žiadna suma)</translation>
     </message>
@@ -2132,247 +1685,194 @@ Adresa: %4</translation>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Poslať Bitcoins</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Vstupy...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>automaticky vybrané</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Nedostatok prostriedkov!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Množstvo:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bajtov:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Suma:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Priorita:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Poplatok:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Zmena:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Vlastná adresa zmeny</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Poslať viacerým príjemcom naraz</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;Pridať príjemcu</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Vyčistiť všetky polia formulára.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Zmazať &amp;všetko</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>Zostatok:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>Potvrďte odoslanie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Odoslať</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Potvrdiť odoslanie bitcoins</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 do %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Kopírovať množstvo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopírovať sumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Kopírovať poplatok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopírovať bajty</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopírovať prioritu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Kopírovať zmenu</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Celková suma %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>alebo</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Adresa príjemcu je neplatná, prosím, overte ju.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Suma na úhradu musí byť väčšia ako 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Suma je vyššia ako Váš zostatok.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Suma celkom prevyšuje Váš zostatok ak sú započítané %1 transakčné poplatky.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Duplikát adresy objavený, je možné poslať na každú adresu len raz v jednej odchádzajúcej transakcii.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Vytvorenie transakcie zlyhalo!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(bez popisu)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Určite to chcete odoslať?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>pridané ako transakčný poplatok</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Neplatná adresa platby %1</translation>
     </message>
@@ -2380,98 +1880,74 @@ Adresa: %4</translation>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Su&amp;ma:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Zapla&amp;tiť:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adresa na odoslanie platby (napr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Vložte popis pre túto adresu aby sa pridala do adresára</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Popis:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Vybrať predtým použitú adresu</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Toto je normálna platba.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Vložiť adresu z klipbordu</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Odstrániť túto položku</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Správa:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Platba pre:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2479,12 +1955,10 @@ Adresa: %4</translation>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Jadro Bitcoin sa ukončuje...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2492,186 +1966,142 @@ Adresa: %4</translation>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Podpísať Správu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Môžete podpísať správy svojou adresou a dokázať, že ju vlastníte. Buďte opatrní a podpíšte len prehlásenia s ktorými plne súhlasíte, nakoľko útoky typu &quot;phishing&quot; Vás môžu lákať k ich podpísaniu.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Zadajte Bitcoin adresu (napr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Vybrať predtým použitú adresu</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Vložte adresu z klipbordu</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Sem vložte správu ktorú chcete podpísať</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Podpis</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Podpíšte správu aby ste dokázali že vlastníte túto adresu</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Podpísať &amp;správu</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Zmazať &amp;všetko</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>Overiť správu...</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Zadajte Bitcoin adresu (napr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Overiť správu</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Zadajte Bitcoin adresu (napr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Kliknite &quot;Podpísať Správu&quot; na získanie podpisu</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Zadaná adresa je neplatná.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Prosím skontrolujte adresu a skúste znova.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Odomknutie peňaženky bolo zrušené.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Podpísanie správy zlyhalo.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Správa podpísaná.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Podpis nie je možné dekódovať.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Prosím skontrolujte podpis a skúste znova.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Overenie správy zlyhalo.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Správa overená.</translation>
     </message>
@@ -2679,17 +2109,14 @@ Adresa: %4</translation>
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation>Jadro Bitcoin</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Vývojári jadra Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testovacia sieť]</translation>
     </message>
@@ -2697,7 +2124,6 @@ Adresa: %4</translation>
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2705,184 +2131,138 @@ Adresa: %4</translation>
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Otvorené do %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/offline</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepotvrdené</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potvrdení</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Stav</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Zdroj</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Vygenerované</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>od</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Pre</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>vlastná adresa</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>popis</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Kredit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>neprijaté</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Debet</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Transakčný poplatok</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Suma netto</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Správa</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Komentár</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID transakcie</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Kupec</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Ladiace informácie</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transakcie</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Vstupy</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>pravda</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>nepravda</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, ešte nebola úspešne odoslaná</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>neznámy</translation>
     </message>
@@ -2890,12 +2270,10 @@ Adresa: %4</translation>
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detaily transakcie</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Táto časť obrazovky zobrazuje detailný popis transakcie</translation>
     </message>
@@ -2903,127 +2281,102 @@ Adresa: %4</translation>
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Hodnota</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Otvorené do %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Potvrdené (%1 potvrdení)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Ten blok nebol prijatý žiadnou inou nódou a pravdepodobne nebude akceptovaný!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Vypočítané ale neakceptované</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Prijaté s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Prijaté od:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Odoslané na</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Platba sebe samému</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Vyfárané</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status transakcie. Pohybujte myšou nad týmto poľom a zjaví sa počet potvrdení.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Dátum a čas prijatia transakcie.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Typ transakcie.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Cieľová adresa transakcie.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Suma pridaná alebo odobraná k zostatku.</translation>
     </message>
@@ -3031,178 +2384,142 @@ Adresa: %4</translation>
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Všetko</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Dnes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Tento týždeň</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Tento mesiac</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Minulý mesiac</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Tento rok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Rozsah...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Prijaté s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Odoslané na</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Samému sebe</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Vyfárané</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Iné</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Vložte adresu alebo popis pre vyhľadávanie</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Min množstvo</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopírovať adresu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopírovať popis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopírovať sumu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopírovať ID transakcie</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Editovať popis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Zobraziť podrobnosti transakcie</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>Exportovať históriu transakcií</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Export zlyhal</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Export úspešný</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Čiarkou oddelovaný súbor (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Potvrdené</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Dátum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Popis</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresa</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Suma</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Rozsah:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>do</translation>
     </message>
@@ -3210,7 +2527,6 @@ Adresa: %4</translation>
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Nie je načítaná peňaženka.</translation>
     </message>
@@ -3218,7 +2534,6 @@ Adresa: %4</translation>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Poslať Bitcoins</translation>
     </message>
@@ -3226,42 +2541,34 @@ Adresa: %4</translation>
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportovať...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportovať tento náhľad do súboru</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation>Zálohovať peňaženku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Údaje peňaženky (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Záloha zlyhala</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Záloha úspešná</translation>
     </message>
@@ -3269,107 +2576,86 @@ Adresa: %4</translation>
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>Použitie:</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>Zoznam príkazov</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Dostať pomoc pre príkaz</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>Možnosti:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Určiť súbor s nastaveniami (predvolené: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Určiť súbor pid (predvolené: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Určiť priečinok s dátami</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Načúvať spojeniam na &lt;port&gt; (prednastavené: 8333 alebo testovacia sieť: 18333)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Udržiavať maximálne &lt;n&gt; spojení (predvolené: 125)</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation>Určite vašu vlastnú verejnú adresu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Hranica pre odpojenie zle sa správajúcich peerov (predvolené: 100)</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Počet sekúnd kedy sa zabráni zle sa správajúcim peerom znovupripojenie (predvolené: 86400)</translation>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Počúvať JSON-RPC spojeniam na &lt;port&gt; (predvolené: 8332 or testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Prijímať príkazy z príkazového riadku a JSON-RPC</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Bežať na pozadí ako démon a prijímať príkazy</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>Použiť testovaciu sieť</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3384,852 +2670,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Varovanie: -paytxfee je nastavené veľmi vysoko. Toto sú transakčné poplatky ktoré zaplatíte ak odošlete transakciu.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; môže byť:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation>Voľby vytvorenia bloku:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Pripojiť sa len k určenej nóde</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation>Zistená poškodená databáza blokov</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Chcete znovu zostaviť databázu blokov?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Chyba inicializácie databázy blokov</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Chyba načítania databázy blokov</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Chyba otvárania databázy blokov</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Chyba: Málo miesta na disku!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Chyba: Peňaženka je zamknutá, nemôžem vytvoriť transakciu!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Chyba: systémová chyba:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Zlyhalo čítanie info o bloku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Zlyhalo čítanie bloku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Zlyhal zápis info o bloku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Zlyhal zápis bloku</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Poplatok za kB ktorý treba pridať k odoslanej transakcii</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Overujem bloky...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Overujem peňaženku...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Voľby peňaženky:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importuje bloky z externého súboru blk000??.dat</translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>Informácia</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL možnosť: (pozrite Bitcoin Wiki pre návod na nastavenie SSL)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Odoslať trace/debug informácie na konzolu namiesto debug.info žurnálu</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Podpísanie správy zlyhalo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Určiť aut spojenia v milisekundách (predvolené: 5000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>Systémová chyba:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Suma transakcie príliš malá</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transakcia príliš veľká</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Skúsiť použiť UPnP pre mapovanie počúvajúceho portu (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Skúsiť použiť UPnP pre mapovanie počúvajúceho portu (default: 1 when listening)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Užívateľské meno pre JSON-RPC spojenia</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Upozornenie</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Upozornenie: Táto verzia je zastaraná, vyžaduje sa aktualizácia!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>verzia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat je poškodený, záchrana zlyhala</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Heslo pre JSON-rPC spojenia</translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Povoliť JSON-RPC spojenia z určenej IP adresy.</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Poslať príkaz nóde bežiacej na &lt;ip&gt; (predvolené: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Vykonaj príkaz, ak zmeny v najlepšom bloku (%s v príkaze nahradí blok hash)</translation>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Aktualizuj peňaženku na najnovší formát.</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Nastaviť zásobu adries na &lt;n&gt; (predvolené: 100)</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Znovu skenovať reťaz blokov pre chýbajúce transakcie</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Použiť OpenSSL (https) pre JSON-RPC spojenia</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Súbor s certifikátom servra (predvolené: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Súkromný kľúč servra (predvolené: server.pem)</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>Táto pomocná správa</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Povoliť vyhľadávanie DNS pre pridanie nódy a spojenie</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>Načítavanie adries...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Chyba načítania wallet.dat: Peňaženka je poškodená</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Chyba načítania wallet.dat: Peňaženka vyžaduje novšiu verziu Bitcoin</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Bolo potrebné prepísať peňaženku: dokončite reštartovaním Bitcoin</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>Chyba načítania wallet.dat</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Neplatná adresa proxy: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Neplatná suma pre -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Neplatná suma</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Nedostatok prostriedkov</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>Načítavanie zoznamu blokov...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Pridať nód na pripojenie a pokus o udržanie pripojenia otvoreného</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>Načítavam peňaženku...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation>Nie je možné prejsť na nižšiu verziu peňaženky</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Nie je možné zapísať predvolenú adresu.</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>Nové prehľadávanie...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>Dokončené načítavanie</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>Použiť %s možnosť.</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_sl_SI.ts
+++ b/src/qt/locale/bitcoin_sl_SI.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>O jedru Bitcoina</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;Jedro Bitcoina&lt;/b&gt; različica</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
-        <translation>(%1-bitov)</translation>
+        <source>(%1-bit)</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Dvakrat klikni za urejanje naslovov ali oznak</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Ustvari nov naslov</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Novo</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopiraj trenutno izbrani naslov v odložišče</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopiraj</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>&amp;Zapri (close)</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopiraj naslov</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Izvozi</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Zbriši</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Izberi naslov prejemnika kovancev</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Izberi naslov pošiljatelja kovancev</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>&amp;Izberi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Pošiljati naslove</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Prejemati naslovi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>To so vaši Bitcoin naslovi za prejemanje plačil. Priporočljivo je uporabljati nov prejemni naslov za vsako izmed transakcij.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopiraj &amp;oznako</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Uredi</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Izvozi seznam naslovov</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Datoteka s podatki, ločenimi z vejico (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Neuspešen izvoz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Naslov</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(ni oznake)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Poziv gesla</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Vnesite geslo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Novo geslo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Ponovite novo geslo</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Vnesite novo geslo za vstop v denarnico.&lt;br/&gt;Prosimo, da geslo sestavite iz &lt;b&gt; 10 ali več naključnih znakov&lt;/b&gt; oz. &lt;b&gt;osem ali več besed&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Šifriraj denarnico</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>To dejanje zahteva geslo za odklepanje vaše denarnice.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Odkleni denarnico</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>To dejanje zahteva geslo za dešifriranje vaše denarnice.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dešifriraj denarnico</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Zamenjaj geslo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Vnesite staro in novo geslo denarnice.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Potrdi šifriranje denarnice</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Ali ste prepričani, da želite šifrirati vašo denarnico?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Opozorilo: imate prižgan Cap Lock</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Denarnica šifrirana</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin se bo zaprl, da bi dokončal proces šifriranja. Zapomnite si, da šifriranje vaše denarnice ne more popolnoma zaščititi pred krajami zlonamernih programov, ki bi lahko bili nameščeni na vašem računalniku.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Šifriranje denarnice spodletelo</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Šifriranje denarnice spodletelo zaradi notranje napake. Vaša denarnica ni šifrirana.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Vnešeno geslo se ne ujema</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Odklep denarnice spodletel</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Geslo za dešifriranje denarnice, ki ste ga vnesli, ni pravilno.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Dešifriranje denarnice spodletelo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Podpiši &amp;sporočilo ...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Sinhroniziranje z omrežjem ...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Pregled</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Pokaži splošen pregled denarnice</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transakcije</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Brskaj po zgodovini transakcij</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>I&amp;zhod</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Izhod iz aplikacije</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Pokaži informacije o Bitcoinu</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>O &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Prikaži informacije o Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Možnosti ...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Šifriraj denarnico ...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Napravi varnostno kopijo denarnice ...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Spremeni geslo ...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;Pošiljanje naslovov...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;Prejemanje naslovov...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>Odpri &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
-        <translation type="unfinished"/>
+        <translation>Uvažam bloke z diska...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
-        <translation type="unfinished"/>
+        <translation>Poustvarjam kazalo blokov na disku...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Pošlji kovance na Bitcoin naslov</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Napravi varnostno kopijo denarnice na drugo lokacijo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Spremeni šifrirno geslo denarnice</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Razhroščevalno okno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Odpri razhroščevalno in diagnostično konzolo</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>%Preveri sporočilo ...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Denarnica</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Pošlji</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Sprejmi</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Prikaži / Skrij</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Prikaži ali skrij glavno okno</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
-        <translation type="unfinished"/>
+        <translation>Šifiraj zasebne ključe v moji denarnici</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Za dokaz, da ste lastniki sporočil, se podpišite z Bitcoin naslovom</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Datoteka</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Nastavitve</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Pomoč</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Orodna vrstica zavihkov</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Jedro Bitcoina</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>&amp;O jedru Bitcoina</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Prikaži seznam uporabljenih naslovov za pošiljanje in oznak</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Prikaži seznam uporabljenih sprejemnih naslovov in oznak</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Odpri Bitcoin: URI ali zahteva o plačilu</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin odjemalec</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktivna povezava v bitcoin omrežje</numerusform><numerusform>%n aktivni povezavi v bitcoin omrežje</numerusform><numerusform>%n aktivnih povezav v bitcoin omrežje</numerusform><numerusform>%n aktivnih povezav v bitcoin omrežje</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n ura</numerusform><numerusform>%n uri</numerusform><numerusform>%n ure</numerusform><numerusform>%n ura</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n dan</numerusform><numerusform>%n dneva</numerusform><numerusform>%n dnevi</numerusform><numerusform>%n dni</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n teden</numerusform><numerusform>%n tedna</numerusform><numerusform>%n tedni</numerusform><numerusform>%n tednov</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n leto</numerusform><numerusform>%n leti</numerusform><numerusform>%n leta</numerusform><numerusform>%n let</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 odzadaj</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transkacija za tem ne bo bila še na voljo.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Napaka</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Opozorilo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Informacije</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Posodobljeno</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Pridobivanje ...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Odlivi</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Prilivi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -691,17 +547,14 @@ Naslov: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Denarnica je &lt;b&gt;šifrirana&lt;/b&gt; in trenutno &lt;b&gt;odklenjena&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Denarnica je &lt;b&gt;šifrirana&lt;/b&gt; in trenutno &lt;b&gt;zaklenjena&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -709,7 +562,6 @@ Naslov: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Omrežno Opozorilo</translation>
     </message>
@@ -717,291 +569,230 @@ Naslov: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Količina:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Biti:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Količina:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Prednostno mesto:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Provizija:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Sprememba:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Količina</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Naslov</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Potrdila</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Potrjeno</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Prednostno mesto</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopiraj naslov</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopiraj oznako</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopiraj količino</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopiraj ID transakcije</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Kopiraj količino</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Kopiraj provizijo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopiraj bite</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopiraj prednostno mesto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation>najvišja</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>višja</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>visoka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>srednje visoka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>srednje</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>srednje nizka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>nizka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>nižja</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>najnižja</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 zaklenjeno)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Prah</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>da</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>ne</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>V primeru, da je velikost transakcije večja od 1000 bitov, se ta oznaka se obarva rdeče.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(ni oznake)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1009,67 +800,54 @@ Naslov: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Uredi naslov</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Oznaka</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>Oznaka je povezana s tem vnosom seznama naslovov</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Naslov</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Nov naslov za prilive</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Nov naslov za odlive</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Uredi naslov za prilive</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Uredi naslov za odlive</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Vnešeni naslov &quot;&amp;1&quot; je že v imeniku.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Vnešeni naslov &quot;%1&quot; ni veljaven Bitcoin naslov.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Ni bilo moč odkleniti denarnice.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Generiranje novega ključa je spodletelo.</translation>
     </message>
@@ -1077,27 +855,22 @@ Naslov: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>ime</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1105,52 +878,46 @@ Naslov: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Jedro Bitcoina</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>različica</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Uporaba:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>možnosti ukazne vrstice</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>možnosti uporabniškega vmesnika</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Nastavi jezik, npr. &quot;sl_SI&quot; (privzeto: jezikovna oznaka sistema)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Zaženi pomanjšano</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1158,57 +925,46 @@ Naslov: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Dobrodošli</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Dobrodošli v jedru Bitcoina</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Napaka</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB prostora na voljo</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1216,27 +972,22 @@ Naslov: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>Odpri URl</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Odpri zahtevo o plačilo od ORI ali datoteke</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1244,253 +995,206 @@ Naslov: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Glavno</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Nakazilo plačila &amp; provizija</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Po prijavi v sistem samodejno zaženite Bitcoin.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Zaženi Bitcoin ob prijavi v sistem</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>megabite</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Omrežje</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation>&amp;Denarnica</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>IP posredniškega strežnika:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Vrata:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Vrata strežnika (npr.: 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;različica:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS različica posredniškega strežnika (npr.: 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Okno</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Prikaz</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;Potrdi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Prekini</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>privzeto</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1498,69 +1202,54 @@ Naslov: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Oblika</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Prikazanim podatkom je lahko potekel rok. Vaša denarnica bo po vzpostavitvi povezave samodejno sinhronizirana z Bitcoin omrežjem, ampak ta proces še ni bil zaključen.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Denarnica</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Razpoložljivost:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Vaše trenutno razpoložljivo stanje</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Skupno število potrjenih transakcij, ki sicer niso bile prištete k razpoložljivem stanju</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Skupaj:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Vaše trenutno skupno stanje</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
-        <translation>&lt;b&gt;Pogoste transakcije&lt;/&gt;</translation>
+        <translation>&lt;b&gt;Nedavne transakcije&lt;/&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1568,93 +1257,70 @@ Naslov: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Rokovanje z URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Napaka pri zahtevi plačila</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>Napaka pri povezavi z  %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>Slab odziv strežnika %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Plačilo priznano</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Napaka omrežne zahteve</translation>
     </message>
@@ -1662,23 +1328,22 @@ Naslov: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Napaka: Želena nahajališče datoteke &quot;%1&quot; ne obstaja.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Napaka: Neveljavna kombinacija -regtest and -testnet</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Vnesite bitcoin naslov (npr.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1686,22 +1351,18 @@ Naslov: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Shrani sliko...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Kopiraj sliko</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Shrani QR kodo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG slika (*.png)</translation>
     </message>
@@ -1709,192 +1370,146 @@ Naslov: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Ime odjemalca</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>Neznano</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Različica odjemalca</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Informacije</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>OpenSSL različica v rabi</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Čas zagona</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Omrežje</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Število povezav</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
-        <translation type="unfinished"/>
+        <translation>Veriga blokov</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Trenutno število blokov</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
-        <translation type="unfinished"/>
+        <translation>Ocenjeno skupno število blokov</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
-        <translation type="unfinished"/>
+        <translation>Čas zadnjega bloka</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Odpri</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konzola</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Omrežni promet</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Pošisti</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Vsote</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Datum izgradnje</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Razhroščevalna dnevniška datoteka</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Počisti konzolo</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Vtipkaj &lt;b&gt;pomoč&lt;/b&gt; za vpogled v razpožljive ukaze.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 bitov</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 kilobitov</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 megabitov</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 gigabitov</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 minut</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 ur</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 ur %2 minut</translation>
     </message>
@@ -1902,105 +1517,82 @@ Naslov: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Količina:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Oznaka:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Sporočilo:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Pomožna oznaka je povezana z novim sprejemnim naslovom.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Počisti</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>&amp;Zahtevaj plačilo</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Pokaži</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation>Odstrani označene vnose iz seznama</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Odstrani</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopiraj oznako</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Kopiraj sporočilo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiraj količino</translation>
     </message>
@@ -2008,67 +1600,54 @@ Naslov: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR Koda</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Kopraj &amp;URl</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Kopiraj &amp;Naslov</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Shrani sliko..</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Informacija o plačilu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Naslov</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Količina</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Sporočilo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI predolg, skušajte zmanjšati besedilo oznake/sporočila.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2076,37 +1655,30 @@ Naslov: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Sporočilo</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Količina</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(ni oznake)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(ni sporočila)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(brez količine)</translation>
     </message>
@@ -2114,247 +1686,194 @@ Naslov: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Pošlji kovance</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Vnosi...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>samodejno izbran</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Premalo sredstev!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Količina:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Biti:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Znesek:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Prednostno mesto:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Provizija:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Sprememba:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Pošlji več prejemnikom hkrati</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Dodaj &amp;prejemnika</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Počisti &amp;vse</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Dobroimetje:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Potrdi odlivno dejanje</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>P&amp;ošlji</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Potrdi odliv kovancev </translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Kopiraj količino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiraj količino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Kopiraj provizijo</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Kopiraj bite</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Kopiraj prednostno mesto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>ali</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Količina za plačilo mora biti večja od 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Količina presega vaše dobroimetje</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Najdena kopija naslova, možnost pošiljanja na vsakega izmed naslov le enkrat ob pošiljanju.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Opozorilo: Neveljaven Bitcoin naslov</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ni oznake)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Ali ste prepričani, da želite poslati?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>dodano kot provizija transakcije</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Zahteva plačila je potekla</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Neveljaven naslov plačila %1</translation>
     </message>
@@ -2362,98 +1881,74 @@ Naslov: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>K&amp;oličina:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Prejemnik &amp;plačila:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Vnesite oznako za ta naslov, ki bo shranjena v imenik</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Oznaka:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Izberi zadnje uporabljen naslov</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Prilepi naslov iz odložišča</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Sporočilo:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Vnesite oznako za ta naslov, ki bo shranjena v seznam uporabljenih naslovov</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2461,12 +1956,10 @@ Naslov: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Ne zaustavite računalnika dokler to okno ne izgine.</translation>
     </message>
@@ -2474,186 +1967,142 @@ Naslov: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Podpisi - Podpiši/preveri sporočilo</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Podpiši sporočilo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Izberi zadnje uporabljen naslov</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Prilepi naslov iz odložišča</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Podpis</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Podpiši &amp;sporočilo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Počisti &amp;vse </translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Preveri sporočilo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Preveri &amp;Sporočilo</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Vnesite bitcoin naslov (npr.: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Kliknite &quot;Podpiši sporočilo&quot; za ustvaritev podpisa</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Vnešeni naslov ni veljaven.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Prosimo preverite naslov in poizkusite znova.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Odklepanje denarnice je bilo prekinjeno.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Zasebni ključ vnešenega naslov ni na voljo.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Podpisovanje sporočila spodletelo.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Sporočilo podpisano.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Ni bilo mogoče dešifrirati podpisa.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Prosimo preverite podpis in poizkusite znova.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Pregledovanje sporočila spodletelo.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Sporočilo pregledano.</translation>
     </message>
@@ -2661,17 +2110,14 @@ Naslov: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Jedro Bitcoina</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2679,7 +2125,6 @@ Naslov: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2687,184 +2132,138 @@ Naslov: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Odpri enoto %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepotrjeno</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potrdil</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Stanje</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Izvor</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Generirano</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Pošiljatelj</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Prejemnik</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>lasten naslov</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>oznaka</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>ni bilo sprejeto</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Dolg</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Provizija transakcije</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Neto količina</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Sporočilo</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Opomba</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID transakcije</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Trgovec</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Razhroščevalna informacija</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transakcija</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Vnosi</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Količina</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>pravilno</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>nepravilno</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, še ni bila uspešno raznešena</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>neznano</translation>
     </message>
@@ -2872,12 +2271,10 @@ Naslov: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Podrobnosti transakcije</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>To podokno prikazuje podroben opis transakcije</translation>
     </message>
@@ -2885,127 +2282,102 @@ Naslov: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Vrsta</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Naslov</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Količina</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Odpri enoto %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Potrjeno (%1 potrdil)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Ta blok ni prejelo še nobeno vozlišče. Najverjetneje ne bo sprejet!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generirano, toda ne sprejeto</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Nepotrjeno</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Prejeto z</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Prejeto od</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Poslano</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Izplačilo sebi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minirano</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(ni na voljo)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Stanje transakcije. Zapeljite z miško čez to polje za prikaz števila potrdil. </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Datum in čas, ko je transakcija bila prejeta.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Vrsta transakcije.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Naslov prejemnika transakcije.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Količina odlita ali prilita dobroimetju.</translation>
     </message>
@@ -3013,178 +2385,142 @@ Naslov: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Vse</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Danes</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Ta teden</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Ta mesec</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Prejšnji mesec</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>To leto</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Območje ...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Prejeto z</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Poslano</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Samemu sebi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minirano</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Drugo</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Vnesite naslov ali oznako za iskanje</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minimalna količina</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopiraj naslov</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopiraj oznako</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiraj količino</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopiraj ID transakcije</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Uredi oznako</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Prikaži podrobnosti transakcije</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Neuspešen izvoz</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Uspešen izvoz</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>Zgodovina poteklih transakcij je bila uspešno shranjena na %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Datoteka s podatki, ločenimi z vejico (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Potrjeno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Vrsta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Oznaka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Naslov</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Količina</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Območje:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>za</translation>
     </message>
@@ -3192,7 +2528,6 @@ Naslov: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3200,7 +2535,6 @@ Naslov: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Pošlji kovance</translation>
     </message>
@@ -3208,42 +2542,34 @@ Naslov: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Izvozi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Napravi varnostno kopijo denarnice</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Podatki denarnice (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Varnostna kopijo neuspešna</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Prišlo je do napake pri shranjevanju podatkov denarnice na %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Podatki denarnice so bili uspešno shranjena na %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Varnostna kopija uspešna</translation>
     </message>
@@ -3251,107 +2577,86 @@ Naslov: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Uporaba:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Prikaži ukaze</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Prikaži pomoč za ukaz</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Možnosti:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Določi datoteko z nastavitvami (privzeta: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Določi pid datoteko (privzeta: bitcoin.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Določi podatkovni imenik</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Nastavi pomnilnik podatkovne zbirke v megabajtih (privzeto: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Sprejmi povezave na &lt;port&gt; (privzeta vrata: 8333 ali testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Obdrži maksimalno število &lt;n&gt; povezav (privzeto: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Določite vaš lasten javni naslov</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Prag za prekinitev povezav s slabimi odjemalci (privzeto: 1000)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Sprejmi ukaze iz ukazne vrstice in JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Teci v ozadju in sprejemaj ukaze</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Uporabi testno omrežje</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3366,722 +2671,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Napaka: Transakcija ni bila sprejeta! To se je morebiti zgodilo, ker so nekateri kovanci v vaši denarnici bili že porabljeni, na primer če ste uporabili kopijo wallet.dat in so tako kovanci bili porabljeni v kopiji, ostali pa označeni kot neporabljeni.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Napaka: Ta transakcija potrebuje povizijo, ki je najmanj %s zaradi svoje količine, kompliciranosti, ali zaradi uporabe prejetih sredstev.</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Izvedi ukaz, ko bo transakcija denarnice se spremenila (V cmd je bil TxID zamenjan za %s)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>To je pred izdana poizkusna verzija - uporaba na lastno odgovornost - ne uporabljajte je za rudarstvo ali trgovske aplikacije</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Opozorilo: napaka pri branju wallet.dat! Vsi ključi so bili pravilno prebrani, podatki o transakciji ali imenik vnešenih naslovov so morda izgubljeni ali nepravilni.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;kategorija&gt; je lahko:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Možnosti ustvarjanja blokov:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Opozorilo: Premalo prostora na disku!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Opozorilo: Denarnica je zaklenjena, ni mogoče opraviti transkacijo! </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Napaka: sistemska napaka:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Zapisovanje informacij o datoteki neuspešno</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Neuspešno zapisovanje na bazi podatkov kovancev</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Ustvari kovance (privzeto: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Pošlji ukaz na Bitcoin strežnik</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Zaženi Bitcoin strežnik</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>Počakajte na zagon RPC strežnika</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Informacije</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL možnosti: (glejte Bitcoin Wiki za navodla, kako nastaviti SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Pošlji sledilne/razhroščevalne informacije v konzolo namesto jih shraniti v debug.log datoteko</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
-        <translation type="unfinished"/>
+        <translation>Podpisovanje transakcije spodletelo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Sistemska napaka:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Količina transakcije je pramajhna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Količina transkacije mora biti pozitivna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transkacija je prevelika</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Uporabniško ime za JSON-RPC povezave</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Opozorilo</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Opozorilo: ta različica je zastarela, potrebna je nadgradnja!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>različica</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat poškodovana, neuspešna obnova</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Geslo za JSON-RPC povezave</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Dovoli JSON-RPC povezave z določenega IP naslova</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Pošlji ukaze vozlišču na &lt;ip&gt; (privzet: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Posodobi denarnico v najnovejši zapis</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Nastavi velikost ključa bazena na &lt;n&gt; (privzeto: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Ponovno preglej verigo blokov za manjkajoče transakcije denarnice</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Uporabi OpenSSL (https) za JSON-RPC povezave</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Datoteka potrdila strežnika (privzeta: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Zasebni ključ strežnika (privzet: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>To sporočilo pomoči</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Nalaganje naslovov ...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Napaka pri nalaganju wallet.dat: denarnica pokvarjena</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Napaka pri nalaganju wallet.dat: denarnica zahteva novejšo različico Bitcoina</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Denarnica mora biti prepisana: ponovno zaženite Bitcoin za doknčanje</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Napaka pri nalaganju wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Neveljavna količina</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Premalo sredstev</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Nalaganje indeksa blokov ...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Dodaj vozlišče za povezavo nanj in skušaj le to obdržati odprto</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Nalaganje denarnice ...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Ne morem </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Ponovno pregledovanje ...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Nalaganje končano</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Napaka</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_sq.ts
+++ b/src/qt/locale/bitcoin_sq.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Klikoni 2 herë për të ndryshuar adressën ose etiketën</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Krijo një adresë të re</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopjo adresën e zgjedhur në memorjen e sistemit </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Fshi</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Skedar i ndarë me pikëpresje(*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiketë</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresë</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(pa etiketë)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Futni frazkalimin</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Frazkalim i ri</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Përsërisni frazkalimin e ri</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Futni frazkalimin e ri në portofol.&lt;br/&gt;Ju lutemi përdorni një frazkalim prej&lt;b&gt;10 ose më shumë shkronjash të rastësishme&lt;b/&gt;, ose tetë apo më shumë fjalë&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Enkripto portofolin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Ky veprim ka nevojë per frazkalimin e portofolit tuaj që të ç&apos;kyç portofolin.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>ç&apos;kyç portofolin.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Ky veprim kërkon frazkalimin e portofolit tuaj që të dekriptoj portofolin.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dekripto portofolin</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Ndrysho frazkalimin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Futni frazkalimin e vjetër dhe të ri në portofol. </translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Konfirmoni enkriptimin e portofolit</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Portofoli u enkriptua</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Enkriptimi i portofolit dështoi</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Enkriptimi i portofolit dështoi për shkak të një gabimi të brëndshëm. portofoli juaj nuk u enkriptua.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Frazkalimet e plotësuara nuk përputhen.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>ç&apos;kyçja e portofolit dështoi</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Frazkalimi i futur për dekriptimin e portofolit nuk ishte i saktë.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Dekriptimi i portofolit dështoi</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Duke u sinkronizuar me rrjetin...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Përmbledhje</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Trego një përmbledhje te përgjithshme të portofolit</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transaksionet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Shfleto historinë e transaksioneve</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Mbyllni aplikacionin</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Trego informacionin rreth Botkoin-it</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opsione</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Ndrysho frazkalimin e përdorur per enkriptimin e portofolit</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Skedar</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Konfigurimet</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Ndihmë</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Shiriti i mjeteve</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testo rrjetin]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n lidhje aktive me rrjetin e Bitkoin</numerusform><numerusform>%n lidhje aktive me rrjetin e Bitkoin</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>I azhornuar</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Duke u azhornuar...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Dërgo transaksionin</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Transaksion në ardhje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Portofoli po &lt;b&gt; enkriptohet&lt;/b&gt; dhe është &lt;b&gt; i ç&apos;kyçur&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Portofoli po &lt;b&gt; enkriptohet&lt;/b&gt; dhe është &lt;b&gt; i kyçur&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Sasia</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adresë</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(pa etiketë)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Ndrysho Adresën</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiketë</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adresa</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Adresë e re pritëse</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Adresë e re dërgimi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Ndrysho adresën pritëse</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>ndrysho adresën dërguese</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Adresa e dhënë &quot;%1&quot; është e zënë në librin e adresave. </translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Nuk mund të ç&apos;kyçet portofoli.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Krijimi i çelësit të ri dështoi.</translation>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Opsionet</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formilarë</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Transaksionet e fundit&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Futni një adresë Bitkoini (p.sh. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiketë:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adresë</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Sasia</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiketë</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiketë</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Sasia</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(pa etiketë)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Dërgo Monedha</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Dërgo marrësve të ndryshëm njëkohësisht</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Balanca:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Konfirmo veprimin e dërgimit</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>konfirmo dërgimin e monedhave</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Shuma e paguar duhet të jetë më e madhe se 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(pa etiketë)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Sh&amp;uma:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Paguaj &amp;drejt:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Krijoni një etiketë për këtë adresë që t&apos;ja shtoni librit të adresave</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiketë:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Ngjit nga memorja e sistemit</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Ngjit nga memorja e sistemit</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Futni një adresë Bitkoini (p.sh. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testo rrjetin]</translation>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Hapur deri më %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/I pakonfirmuar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 konfirmimet</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Sasia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, nuk është transmetuar me sukses deri tani</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>i/e panjohur</translation>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Detajet e transaksionit</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Ky panel tregon një përshkrim të detajuar të transaksionit</translation>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Lloji</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adresë</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Sasia</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Hapur deri më %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>I/E konfirmuar(%1 konfirmime)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Ky bllok është marrë nga ndonjë nyje dhe ka shumë mundësi të mos pranohet! </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>I krijuar por i papranuar</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Marrë me</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Dërguar drejt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Pagesë ndaj vetvetes</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minuar</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(p/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Marrë me</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Dërguar drejt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minuar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Skedar i ndarë me pikëpresje(*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Data</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Lloji</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiketë</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adresë</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Sasia</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Dërgo Monedha</translation>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_sr.ts
+++ b/src/qt/locale/bitcoin_sr.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Кликните два пута да промените адресу и/или етикету</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Прави нову адресу</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Копира изабрану адресу на системски клипборд</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Избриши</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Зарезом одвојене вредности (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Етикета</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(без етикете)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Унесите лозинку</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Нова лозинка</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Поновите нову лозинку</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Унесите нову лозинку за приступ новчанику.&lt;br/&gt;Молимо Вас да лозинка буде &lt;b&gt;10 или више насумице одабраних знакова&lt;/b&gt;, или &lt;b&gt;осам или више речи&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Шифровање новчаника</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Ова акција захтева лозинку Вашег новчаника да би га откључала.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Откључавање новчаника</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Ова акција захтева да унесете лозинку да би дешифловала новчаник.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Дешифровање новчаника</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Промена лозинке</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Унесите стару и нову лозинку за шифровање новчаника.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Одобрите шифровање новчаника</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Упозорење: Ако се ваш новчаник шифрује а потом изгубите лозинкзу, ви ћете &lt;b&gt;ИЗГУБИТИ СВЕ BITCOIN-Е&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Да ли сте сигурни да желите да се новчаник шифује?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Новчаник је шифрован</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Bitcoin će se sad zatvoriti da bi završio  proces enkripcije. Zapamti da enkripcija tvog novčanika ne može u potpunosti da zaštiti tvoje bitcoine da ne budu ukradeni od malawarea koji bi inficirao tvoj kompjuter.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Неуспело шифровање новчаника</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Настала је унутрашња грешка током шифровања новчаника. Ваш новчаник није шифрован.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Лозинке које сте унели се не подударају.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Неуспело откључавање новчаника</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Лозинка коју сте унели за откључавање новчаника је нетачна.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Неуспело дешифровање новчаника</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Лозинка за приступ новчанику је успешно промењена.</translation>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Синхронизација са мрежом у току...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Општи преглед</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Погледајте општи преглед новчаника</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Трансакције</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Претражите историјат трансакција</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>I&amp;zlaz</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Напустите програм</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Прегледајте информације о Bitcoin-у</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>О &amp;Qt-у</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Прегледајте информације о Qt-у</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>П&amp;оставке...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Шифровање новчаника...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Backup новчаника</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>Промени &amp;лозинку...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Пошаљите новац на bitcoin адресу</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Изаберите могућности bitcoin-а</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Мењање лозинке којом се шифрује новчаник</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>новчаник</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Фајл</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Подешавања</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>П&amp;омоћ</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Трака са картицама</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n активна веза са Bitcoin мрежом</numerusform><numerusform>%n активне везе са Bitcoin мрежом</numerusform><numerusform>%n активних веза са Bitcoin мрежом</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Ажурно</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Ажурирање у току...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Послана трансакција</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Придошла трансакција</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation>Datum: %1⏎ Iznos: %2⏎ Tip: %3⏎ Adresa: %4⏎</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Новчаник јс &lt;b&gt;шифрован&lt;/b&gt; и тренутно &lt;b&gt;откључан&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Новчаник јс &lt;b&gt;шифрован&lt;/b&gt; и тренутно &lt;b&gt;закључан&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Iznos:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>iznos</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Potvrdjen</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>kopiraj adresu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>kopiraj naziv</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>kopiraj iznos</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(без етикете)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Измени адресу</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Етикета</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Адреса</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Унешена адреса &quot;%1&quot; се већ налази у адресару.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Немогуће откључати новчаник.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>верзија</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Korišćenje:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Поставке</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Јединица за приказивање износа:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>новчаник</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Недавне трансакције&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Unesite Bitcoin adresu (n.pr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Етикета</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>kopiraj naziv</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>kopiraj iznos</translation>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>iznos</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Етикета</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Етикета</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>iznos</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(без етикете)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Слање новца</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Iznos:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Потврди акцију слања</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Пошаљи</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>kopiraj iznos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(без етикете)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Етикета</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+П</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Poruka:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+П</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Unesite Bitcoin adresu (n.pr. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Otvorite do %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/nepotvrdjeno</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 potvrde</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>datum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>етикета</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>iznos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, nije još uvek uspešno emitovan</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>nepoznato</translation>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>detalji transakcije</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Ovaj odeljak pokazuje detaljan opis transakcije</translation>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>tip</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>iznos</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Otvoreno do %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Potvrdjena (%1 potvrdjenih)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Ovaj blok nije primljen od ostalih čvorova (nodova) i verovatno neće biti prihvaćen!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Generisan ali nije prihvaćen</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Primljen sa</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Primljeno od</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Poslat ka</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Isplata samom sebi</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Minirano</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Status vaše transakcije. Predjite mišem preko ovog polja da bi ste videli broj konfirmacija</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Datum i vreme primljene transakcije.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Tip transakcije</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Destinacija  i adresa transakcije</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Iznos odbijen ili dodat balansu.</translation>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Sve</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Danas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>ove nedelje</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Ovog meseca</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Prošlog meseca</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Ove godine</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Opseg...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Primljen sa</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Poslat ka</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Vama - samom sebi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Minirano</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Drugi</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Navedite adresu ili naziv koji bi ste potražili</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Min iznos</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>kopiraj adresu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>kopiraj naziv</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>kopiraj iznos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>promeni naziv</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Зарезом одвојене вредности (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Potvrdjen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>tip</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Етикета</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>iznos</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Opseg:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>do</translation>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Слање новца</translation>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,108 +2573,87 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Korišćenje:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Listaj komande</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Zatraži pomoć za komande</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Opcije</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Potvrdi željeni konfiguracioni fajl (podrazumevani:bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Konkretizuj pid fajl (podrazumevani: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Gde je konkretni data direktorijum </translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Slušaj konekcije na &lt;port&gt; (default: 8333 or testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Održavaj najviše &lt;n&gt; konekcija  po priključku (default: 125)
 </translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Prihvati komandnu liniju i JSON-RPC komande</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Radi u pozadini kao daemon servis i prihvati komande</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Koristi testnu mrežu</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3363,722 +2668,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Korisničko ime za JSON-RPC konekcije</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>верзија</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Lozinka za JSON-RPC konekcije</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Dozvoli JSON-RPC konekcije sa posebne IP adrese</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Pošalji komande to nodu koji radi na &lt;ip&gt; (default: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Odredi veličinu zaštićenih ključeva na &lt;n&gt; (default: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Ponovo skeniraj lanac blokova za nedostajuće transakcije iz novčanika</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Koristi OpenSSL (https) za  JSON-RPC konekcije</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>privatni ključ za Server (podrazumevan: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Ova poruka Pomoći</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>učitavam adrese....</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Грешка током учитавања wallet.dat: Новчаник је покварен      </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Грешка током учитавања wallet.dat: Новчанику је неопходна нова верзија Bitcoin-a.</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Грешка током учитавања wallet.dat      </translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Učitavam blok indeksa...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Новчаник се учитава...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Ponovo skeniram...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Završeno učitavanje</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_sv.ts
+++ b/src/qt/locale/bitcoin_sv.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>Om Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
-        <translation type="unfinished"/>
+        <translation>&lt;b&gt;Bitcoin Core&lt;/b&gt;-version</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -28,159 +25,128 @@ Distribuerad under mjukvarulicensen MIT/X11, se den medföljande filen COPYING e
 Denna produkten innehåller mjukvara utvecklad av OpenSSL Project för användning i OpenSSL Toolkit (http://www.openssl.org/) och kryptografisk mjukvara utvecklad av Eric Young (eay@cryptsoft.com) samt UPnP-mjukvara skriven av Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Copyright</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core-utvecklarna</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
-        <translation type="unfinished"/>
+        <source>(%1-bit)</source>
+        <translation>(%1-bit)</translation>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
-        <translation>Dubbel-klicka för att ändra adressen eller etiketten</translation>
+        <translation>Dubbelklicka för att ändra adressen eller etiketten</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Skapa ny adress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Ny</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Kopiera den markerade adressen till systemets Urklipp</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopiera</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>S&amp;täng</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Kopiera adress</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Ta bort den valda adressen från listan</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportera informationen i den nuvarande fliken till en fil</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportera</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Radera</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
-        <translation type="unfinished"/>
+        <translation>Välj en adress att sända betalning till</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
-        <translation type="unfinished"/>
+        <translation>Välj en adress att ta emot betalning till</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>V&amp;älj</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Avsändaradresser</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Mottagaradresser</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Detta är dina Bitcoin adresser för att skicka betalningar. Kolla alltid summan och den mottagande adressen innan du skickar Bitcoins.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
-        <translation type="unfinished"/>
+        <translation>Detta är dina Bitcoin adresser för att ta emot betalningar. Det rekommenderas att använda en ny mottagningsadress för varje transaktion.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Kopiera &amp;etikett</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editera</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Exportera adresslistan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommaseparerad fil (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
-        <translation type="unfinished"/>
+        <translation>Exporteringen misslyckades</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
-        <translation type="unfinished"/>
+        <translation>Det inträffade ett fel när adresslistan skulle sparas till %1.</translation>
     </message>
 </context>
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etikett</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(Ingen etikett)</translation>
     </message>
@@ -188,140 +154,106 @@ Denna produkten innehåller mjukvara utvecklad av OpenSSL Project för användni
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Lösenords Dialog</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Ange lösenord</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Nytt lösenord</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Upprepa nytt lösenord</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Ange plånbokens nya lösenord. &lt;br/&gt; Använd ett lösenord på &lt;b&gt;10 eller fler slumpmässiga tecken,&lt;/b&gt; eller &lt;b&gt;åtta eller fler ord.&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Kryptera plånbok</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Denna operation behöver din plånboks lösenord för att låsa upp plånboken.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Lås upp plånbok</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Denna operation behöver din plånboks lösenord för att dekryptera plånboken.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Dekryptera plånbok</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Ändra lösenord</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Ange plånbokens gamla och nya lösenord.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Bekräfta kryptering av plånbok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>VARNING: Om du krypterar din plånbok och glömmer ditt lösenord, kommer du att &lt;b&gt;FÖRLORA ALLA DINA TILLGÅNGAR&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Är du säker på att du vill kryptera din plånbok?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>VIKTIGT: Alla tidigare säkerhetskopior du har gjort av plånbokens fil ska ersättas med den nya genererade, krypterade plånboks filen. Av säkerhetsskäl kommer tidigare säkerhetskopior av den okrypterade plånboks filen blir oanvändbara när du börjar använda en ny, krypterad plånbok.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Varning: Caps Lock är påslaget!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Plånboken är krypterad</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Programmet kommer nu att stänga ner för att färdigställa krypteringen. Tänk på att en krypterad plånbok inte skyddar mot stöld om din dator är infekterad med en keylogger.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Kryptering av plånbok misslyckades</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Kryptering av plånbok misslyckades på grund av ett internt fel. Din plånbok blev inte krypterad.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>De angivna lösenorden överensstämmer inte.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Upplåsning av plånbok misslyckades</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Lösenordet för dekryptering av plånbok var felaktig.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Dekryptering av plånbok misslyckades</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Plånbokens lösenord har ändrats.</translation>
     </message>
@@ -329,362 +261,286 @@ Denna produkten innehåller mjukvara utvecklad av OpenSSL Project för användni
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>Signera &amp;meddelande...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Synkroniserar med nätverk...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Översikt</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
-        <translation type="unfinished"/>
+        <translation>Nod</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Visa översiktsvy av plånbok</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Transaktioner</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Bläddra i transaktionshistorik</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Avsluta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Avsluta programmet</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Visa information om Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>Om &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Visa information om Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Alternativ...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Kryptera plånbok...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Säkerhetskopiera plånbok...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>&amp;Byt Lösenord...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
-        <translation type="unfinished"/>
+        <translation>Av&amp;sändaradresser...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
-        <translation type="unfinished"/>
+        <translation>Mottaga&amp;radresser...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
-        <translation type="unfinished"/>
+        <translation>Öppna &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Importerar block från disk...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Återindexerar block på disken...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Skicka mynt till en Bitcoin-adress</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Ändra konfigurationsalternativ för Bitcoin</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Säkerhetskopiera plånboken till en annan plats</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Byt lösenord för kryptering av plånbok</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Debug fönster</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Öppna debug- och diagnostikkonsolen</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>&amp;Verifiera meddelande...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Plånbok</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Skicka</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Ta emot</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Visa / Göm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Visa eller göm huvudfönstret</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Kryptera de privata nycklar som tillhör din plånbok</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Signera meddelanden med din Bitcoinadress för att bevisa att du äger dem</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Verifiera meddelanden för att vara säker på att de var signerade med den specificerade Bitcoin-adressen</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Arkiv</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Inställningar</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Hjälp</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Verktygsfält för Tabbar</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Kärna</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
-        <translation type="unfinished"/>
+        <translation>Begär betalning (genererar QR-koder och bitcoin-URI)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Om Bitcoin Core</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Visa listan av använda avsändaradresser och etiketter</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
-        <translation type="unfinished"/>
+        <translation>Visa listan av använda mottagningsadresser och etiketter</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
-        <translation type="unfinished"/>
+        <translation>Öppna en bitcoin: URI eller betalningsbegäran</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Kommandoradsalternativ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
-        <translation type="unfinished"/>
+        <translation>Visa Bitcoin Core hjälpmeddelande för att få en lista med möjliga Bitcoin kommandoradsalternativ.</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin-klient</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n aktiv anslutning till Bitcoin-nätverket</numerusform><numerusform>%n aktiva anslutningar till Bitcoin-nätverket</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Ingen block-källa tillgänglig...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Bearbetat %1 av %2 (uppskattade) block av transaktionshistorik.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Bearbetat %1 block i transaktionshistoriken.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n timme</numerusform><numerusform>%n timmar</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n dag</numerusform><numerusform>%n dagar</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n vecka</numerusform><numerusform>%n veckor</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
-        <translation type="unfinished"/>
+        <translation>%1 och %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>%n år</numerusform><numerusform>%n år</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 efter</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Senast mottagna block genererades %1 sen.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Transaktioner efter denna kommer inte ännu vara synliga.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Uppdaterad</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Hämtar senaste...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Transaktion skickad</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Inkommande transaktion</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +553,14 @@ Adress: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Denna plånbok är &lt;b&gt;krypterad&lt;/b&gt; och för närvarande &lt;b&gt;olåst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Denna plånbok är &lt;b&gt;krypterad&lt;/b&gt; och för närvarande &lt;b&gt;låst&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Ett allvarligt fel har uppstått. Bitcoin kan inte längre köras säkert och kommer att avslutas.</translation>
     </message>
@@ -715,7 +568,6 @@ Adress: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Nätverkslarm</translation>
     </message>
@@ -723,359 +575,285 @@ Adress: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
-        <translation type="unfinished"/>
+        <translation>Adressval för myntkontroll</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
-        <translation type="unfinished"/>
+        <translation>Kvantitet:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
-        <translation type="unfinished"/>
+        <translation>Antal Byte:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Belopp:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
-        <translation type="unfinished"/>
+        <translation>Prioritet:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Avgift:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
-        <translation type="unfinished"/>
+        <translation>Låg utmatning:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Efter avgift:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
-        <translation type="unfinished"/>
+        <translation>Växel:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
-        <translation type="unfinished"/>
+        <translation>(av)välj allt</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
-        <translation type="unfinished"/>
+        <translation>Trädmetod</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
-        <translation type="unfinished"/>
+        <translation>Listmetod</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Mängd</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
-        <translation type="unfinished"/>
+        <translation>Konfirmationer</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Bekräftad</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
-        <translation type="unfinished"/>
+        <translation>Prioritet</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Kopiera adress</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopiera etikett</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Kopiera belopp</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Kopiera transaktions ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
-        <translation type="unfinished"/>
+        <translation>Lås ospenderat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
-        <translation type="unfinished"/>
+        <translation>Lås upp ospenderat</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera kvantitet</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera avgift</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera efter avgift</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera byte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera prioritet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera låg utmatning</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera växel</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
-        <translation type="unfinished"/>
+        <translation>högst</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
-        <translation type="unfinished"/>
+        <translation>högre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
-        <translation type="unfinished"/>
+        <translation>hög</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
-        <translation type="unfinished"/>
+        <translation>medelhög</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
-        <translation type="unfinished"/>
+        <translation>medel</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
-        <translation type="unfinished"/>
+        <translation>lågmedel</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
-        <translation type="unfinished"/>
+        <translation>låg</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
-        <translation type="unfinished"/>
+        <translation>lägre</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
-        <translation type="unfinished"/>
+        <translation>lägst</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
-        <translation type="unfinished"/>
+        <translation>(%1 låst)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
-        <translation type="unfinished"/>
+        <translation>ingen</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
-        <translation type="unfinished"/>
+        <translation>Damm</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
-        <translation type="unfinished"/>
+        <translation>ja</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
-        <translation type="unfinished"/>
+        <translation>nej</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
-        <translation type="unfinished"/>
+        <translation>Denna etikett blir röd om transaktionen överstiger 1000 byte.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
-        <translation type="unfinished"/>
+        <translation>Detta betyder att en avgift på minst %1 per kB behövs.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
-        <translation type="unfinished"/>
+        <translation>Kan variera +/- 1 byte per inmatning.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
-        <translation type="unfinished"/>
+        <translation>Transaktioner med högre prioritet har större sannolikhet att inkluderas i ett block.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
-        <translation type="unfinished"/>
+        <translation>Denna etikett blir röd om prioriteten är mindre än &quot;medium&quot;.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
-        <translation type="unfinished"/>
+        <translation>Denna etikett blir röd om någon mottagare får en betalning som är mindre än %1.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
-        <translation type="unfinished"/>
+        <translation>Detta betyder att en avgift på minst %1 behövs.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
-        <translation type="unfinished"/>
+        <translation>Belopp mindre än 0.546 gånger den minsta vidarebefordringsavgiften visa som damm.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
-        <translation type="unfinished"/>
+        <translation>Denna etikett blir röd om växeln är mindre än %1.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(Ingen etikett)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
-        <translation type="unfinished"/>
+        <translation>växel från %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
-        <translation type="unfinished"/>
+        <translation>(växel)</translation>
     </message>
 </context>
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Redigera Adress</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etikett</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
-        <translation type="unfinished"/>
+        <translation>Etiketten associerad med denna adresslistas post</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
-        <translation type="unfinished"/>
+        <translation>Adressen associerad med denna adresslistas post. Detta kan bara ändras för sändningsadresser.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adress</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Ny mottagaradress</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Ny avsändaradress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Redigera mottagaradress</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Redigera avsändaradress</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Den angivna adressen &quot;%1&quot; finns redan i adressboken.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Den angivna adressen &quot;%1&quot; är inte en giltig Bitcoin-adress.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Plånboken kunde inte låsas upp.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Misslyckades med generering av ny nyckel.</translation>
     </message>
@@ -1083,27 +861,22 @@ Adress: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>En ny datakatalog kommer att skapas.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>namn</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Katalogen finns redan. Läggtill %1 om du vill skapa en ny katalog här.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Sökvägen finns redan, och är inte en katalog.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Kan inte skapa datakatalog här.</translation>
     </message>
@@ -1111,52 +884,46 @@ Adress: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core - Kommandoradsalternativ</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Kärna</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>version</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Användning:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>kommandoradsalternativ</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI alternativ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Ändra språk, till exempel &quot;de_DE&quot; (förvalt: systemets språk)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Starta som minimerad</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>Sätt SSL root-certifikat för betalningsbegäran (förvalt: -system-)</translation>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Visa startbilden vid uppstart (förvalt: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Välj datakatalog vid uppstart (förvalt: 0)</translation>
     </message>
@@ -1164,57 +931,46 @@ Adress: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Välkommen</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
-        <translation type="unfinished"/>
+        <translation>Välkommen till Bitcoin Core.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
-        <translation type="unfinished"/>
+        <translation>Eftersom detta är första gången programmet startas får du välja var Bitcoin Core skall lagra sitt data.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core kommer att ladda ner och spara en kopia av Bitcoin blockkedjan. Åtminstone %1GB av data kommer att sparas i denna katalog, och den kommer att växa över tiden. Plånboken kommer också att sparas i denna katalog.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Använd den förvalda datakatalogen</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Använd en anpassad datakatalog:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Fel: Den angivna datakatalogen &quot;%1&quot; kan inte skapas.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB ledigt utrymme är tillgängligt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(av %1GB behövs)</translation>
     </message>
@@ -1222,281 +978,229 @@ Adress: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
-        <translation type="unfinished"/>
+        <translation>Öppna URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
-        <translation type="unfinished"/>
+        <translation>Öppna betalningsbegäran från URI eller fil</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
-        <translation type="unfinished"/>
+        <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
-        <translation type="unfinished"/>
+        <translation>Välj betalningsbegäransfil</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
-        <translation type="unfinished"/>
+        <translation>Välj betalningsbegäransfil att öppna</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Alternativ</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Allmänt</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Valfri transaktionsavgift per kB som ser till att dina transaktioner behandlas snabbt. De flesta transaktioner är 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Betala överförings&amp;avgift</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Starta Bitcoin automatiskt efter inloggning.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Starta Bitcoin vid systemstart</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
-        <translation type="unfinished"/>
+        <translation>Storleken på &amp;databascache</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
-        <translation type="unfinished"/>
+        <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
-        <translation type="unfinished"/>
+        <translation>Antalet skript &amp; verifikationstrådar</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Ange antalet skriptkontrolltrådar (upp till 16, 0 = auto, &lt;0 = lämna så många kärnor lediga, förval: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
-        <translation type="unfinished"/>
+        <translation>Anslut till Bitcoin-nätverket genom en SOCKS-proxy.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Anslut genom SOCKS-proxy (förvald proxy):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
-        <translation type="unfinished"/>
+        <translation>Proxyns IP-adress (t.ex.  IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
-        <translation type="unfinished"/>
+        <translation>Aktiva kommandoradsalternativ som överrider alternativen ovan:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Återställ alla klient inställningar till förvalen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>&amp;Återställ Alternativ</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Nätverk</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation>(0 = auto, &lt;0 = lämna så många kärnor lediga)</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
-        <translation type="unfinished"/>
+        <translation>&amp;Plånbok</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation>Expert</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>Aktivera mynt och kontrollfunktioner</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
-        <translation type="unfinished"/>
+        <translation>Om du avaktiverar betalning med okonfirmerade växel, kan inte växeln från en transaktion användas förrän den transaktionen har minst en konfirmation.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>&amp;Spendera okonfirmerad växel</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Öppna automatiskt Bitcoin-klientens port på routern. Detta fungerar endast om din router har UPnP aktiverat.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Tilldela port med hjälp av &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Proxy-&amp;IP: </translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port: </translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Proxyns port (t.ex. 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;Version:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>SOCKS version av proxyn (t.ex. 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Fönster</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Visa endast en systemfältsikon vid minimering.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>&amp;Minimera till systemfältet istället för aktivitetsfältet</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Minimera applikationen istället för att stänga ner den när fönstret stängs. Detta innebär att programmet fotrsätter att köras tills du väljer Avsluta i menyn.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>M&amp;inimera vid stängning</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Visa</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Användargränssnittets &amp;språk: </translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Användargränssnittets språk kan ställas in här. Denna inställning träder i kraft efter en omstart av Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>&amp;Måttenhet att visa belopp i: </translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Välj en måttenhet att visa när du skickar mynt.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Anger om Bitcoin-adresser skall visas i transaktionslistan.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Visa adresser i transaktionslistan</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
-        <translation type="unfinished"/>
+        <translation>Om myntkontrollfunktioner skall visas eller inte</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Avbryt</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>standard</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
-        <translation type="unfinished"/>
+        <translation>ingen</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Bekräfta att alternativen ska återställs</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
-        <translation type="unfinished"/>
+        <translation>Klientomstart är nödvändig för att aktivera ändringarna.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
-        <translation type="unfinished"/>
+        <translation>Klienten skall stängas av, vill du fortsätta?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
-        <translation type="unfinished"/>
+        <translation>Denna ändring kräver en klientomstart.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Den medföljande proxy adressen är ogiltig.</translation>
     </message>
@@ -1504,69 +1208,54 @@ Adress: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Formulär</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Den visade informationen kan vara inaktuell. Plånboken synkroniseras automatiskt med Bitcoin-nätverket efter att anslutningen är upprättad, men denna process har inte slutförts ännu.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Plånbok</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
-        <translation type="unfinished"/>
+        <translation>Tillgängligt:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Ditt tillgängliga saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
-        <translation type="unfinished"/>
+        <translation>Pågående:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Totalt antal transaktioner som ännu inte bekräftats, och som ännu inte räknas med i aktuellt saldo</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Omogen:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Den genererade balansen som ännu inte har mognat</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Totalt:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Ditt nuvarande totala saldo</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Nyligen genomförda transaktioner&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>osynkroniserad</translation>
     </message>
@@ -1574,117 +1263,93 @@ Adress: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI hantering</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI går inte att tolkas! Detta kan orsakas av en ogiltig Bitcoin-adress eller felaktiga URI parametrar.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
-        <translation type="unfinished"/>
+        <translation>Begärd betalning av %1 är för liten (betraktas som damm).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
-        <translation type="unfinished"/>
+        <translation>Fel vid betalningsbegäran</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Kan inte starta bitcoin: klicka-och-betala handhavare</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
-        <translation type="unfinished"/>
+        <translation>Varningar från näthanteraren</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
-        <translation type="unfinished"/>
+        <translation>Din aktiva proxy stödjer inte SOCKS5, vilket är nödvändigt för att använda betalningsbegäran via proxy.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
-        <translation type="unfinished"/>
+        <translation>Betalningsbegärans hämta URL är felaktig: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
-        <translation type="unfinished"/>
+        <translation>Hantering av betalningsbegäransfil</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
-        <translation type="unfinished"/>
+        <translation>Betalningsbegäransfilen kan inte läsas eller behandlas! Detta kan orsakas av en felaktig betalningsbegäransfil.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
-        <translation type="unfinished"/>
+        <translation>Overifierade betalningsbegärningar till specialbetalningsskript stöds inte.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
-        <translation type="unfinished"/>
+        <translation>Återbetalning från %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
-        <translation type="unfinished"/>
+        <translation>Kommunikationsfel med %1: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
-        <translation type="unfinished"/>
+        <translation>Betalningsbegäran kan inte läsas eller behandlas!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
-        <translation type="unfinished"/>
+        <translation>Dåligt svar från server %1</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
-        <translation type="unfinished"/>
+        <translation>Betalningen bekräftad</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
-        <translation type="unfinished"/>
+        <translation>Fel vid närverksbegäran</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Fel: Den angivna datakatalogen &quot;%1&quot; finns inte.</translation>
     </message>
     <message>
-        <location line="-12"/>
-        <source>Error: Invalid combination of -regtest and -testnet.</source>
-        <translation type="unfinished"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Fel: Kan inte läsa konfigurationsfilen: %1. Använd bara nyckel=värde formatet.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
+        <source>Error: Invalid combination of -regtest and -testnet.</source>
+        <translation>Fel: Felaktig kombination av -regtest och -testnet.</translation>
+    </message>
+    <message>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ange en Bitcoin-adress (t.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1692,215 +1357,165 @@ Adress: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Spara Bild...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Kopiera Bild</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Spara QR-kod</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
-        <translation type="unfinished"/>
+        <translation>PNG-bild (*.png)</translation>
     </message>
 </context>
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Klientnamn</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>ej tillgänglig</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Klient-version</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Information</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
-        <translation type="unfinished"/>
+        <translation>Debug fönster</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
-        <translation type="unfinished"/>
+        <translation>Generell</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Använder OpenSSL version</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Uppstartstid</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Nätverk</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
-        <translation type="unfinished"/>
+        <translation>Namn</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Antalet anslutningar</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Blockkedja</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Aktuellt antal block</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Beräknade totala block</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Sista blocktid</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Öppna</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsol</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Nätverkstrafik</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Rensa</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
-        <translation type="unfinished"/>
+        <translation>Totalt</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>In:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>Ut:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Kompileringsdatum</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Debugloggfil</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Öppna Bitcoin debug-loggfilen som finns i datakatalogen. Detta kan ta några sekunder för stora loggfiler.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Rensa konsollen</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Välkommen till Bitcoin RPC-konsollen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Använd upp- och ner-pilarna för att navigera i historiken, och &lt;b&gt;Ctrl-L&lt;/b&gt; för att rensa skärmen.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Skriv &lt;b&gt;help&lt;/b&gt; för en översikt av alla kommandon.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 m</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 h</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 h %2 m</translation>
     </message>
@@ -1908,105 +1523,82 @@ Adress: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>%Belopp:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etikett:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Meddelande:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
-        <translation type="unfinished"/>
+        <translation>Återanvänd en av tidigare använda mottagningsadresser. Återanvändning av adresser har både säkerhets och integritetsbrister. Använd inte samma mottagningsadress om du inte gör om samma betalningsbegäran.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
-        <translation type="unfinished"/>
+        <translation>Åt&amp;eranvänd en existerande mottagningsadress (rekommenderas inte)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
-        <translation type="unfinished"/>
+        <translation>Ett frivilligt meddelande att bifoga betalningsbegäran, vilket visas när begäran öppnas. NB: Meddelandet kommer inte att sändas med betalningen över Bitcoinnätverket.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
-        <translation type="unfinished"/>
+        <translation>En frivillig etikett att associera med den nya mottagningsadressen.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
-        <translation type="unfinished"/>
+        <translation>Använd detta formulär för att begära betalningar. Alla fält är  &lt;b&gt;frivilliga&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
-        <translation type="unfinished"/>
+        <translation>En valfri summa att begära. Lämna denna tom eller noll för att inte begära en specifik summa.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished"/>
+        <translation>Rensa alla formulärfälten</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Rensa</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
-        <translation type="unfinished"/>
+        <translation>Historik för begärda betalningar</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
-        <translation type="unfinished"/>
+        <translation>Begä&amp;r betalning</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
-        <translation type="unfinished"/>
+        <translation>Visa valda begäranden (gör samma som att dubbelklicka på en post)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
-        <translation type="unfinished"/>
+        <translation>Visa</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
-        <translation type="unfinished"/>
+        <translation>Ta bort valda poster från listan</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
-        <translation type="unfinished"/>
+        <translation>Ta bort</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Kopiera etikett</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera meddelande</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiera belopp</translation>
     </message>
@@ -2014,67 +1606,54 @@ Adress: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR-kod</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>Kopiera &amp;URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>Kopiera &amp;Adress</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Spara Bild...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
-        <translation type="unfinished"/>
+        <translation>Begär betalning till %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Betalningsinformation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Mängd</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etikett</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Meddelande</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI:n är för lång, försöka minska texten för etikett / meddelande.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Fel vid skapande av QR-kod från URI.</translation>
     </message>
@@ -2082,584 +1661,454 @@ Adress: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etikett</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Meddelande</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Mängd</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(Ingen etikett)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
-        <translation type="unfinished"/>
+        <translation>(inget meddelande)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
-        <translation type="unfinished"/>
+        <translation>(ingen summa)</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Skicka pengar</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
-        <translation type="unfinished"/>
+        <translation>Myntkontrollfunktioner</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
-        <translation type="unfinished"/>
+        <translation>Inmatningar...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
-        <translation type="unfinished"/>
+        <translation>automatiskt vald</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
-        <translation type="unfinished"/>
+        <translation>Otillräckliga medel!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
-        <translation type="unfinished"/>
+        <translation>Kvantitet:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
-        <translation type="unfinished"/>
+        <translation>Antal Byte:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Belopp:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
-        <translation type="unfinished"/>
+        <translation>Prioritet:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Avgift:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
-        <translation type="unfinished"/>
+        <translation>Låg utmatning:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
-        <translation type="unfinished"/>
+        <translation>Efter avgift:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
-        <translation type="unfinished"/>
+        <translation>Växel:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
-        <translation type="unfinished"/>
+        <translation>Om denna är aktiverad men växeladressen är tom eller felaktig kommer växeln att sändas till en nygenererad adress.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
-        <translation type="unfinished"/>
+        <translation>Specialväxeladress</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Skicka till flera mottagare samtidigt</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Lägg till &amp;mottagare</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
-        <translation type="unfinished"/>
+        <translation>Rensa alla formulärfälten</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Rensa &amp;alla</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Balans:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Bekräfta sändordern</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Skicka</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Bekräfta skickade mynt</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 till %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera kvantitet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiera belopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera avgift</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera efter avgift</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera byte</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera prioritet</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera låg utmatning</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
-        <translation type="unfinished"/>
+        <translation>Kopiera växel</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
-        <translation type="unfinished"/>
+        <translation>Totalt %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
-        <translation type="unfinished"/>
+        <translation>eller</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Mottagarens adress är inte giltig, vänligen kontrollera igen.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Det betalade beloppet måste vara större än 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Värdet överstiger ditt saldo.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Totalvärdet överstiger ditt saldo när transaktionsavgiften %1 är pålagd.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Dubblett av adress funnen, kan bara skicka till varje adress en gång per sändning.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
-        <translation type="unfinished"/>
+        <translation>Transaktionen gick inte att skapa!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
-        <translation type="unfinished"/>
+        <translation>Transaktionen avslogs! Detta kan hända om några av mynten i plånboken redan spenderats, t.ex om du använt en kopia av wallet.dat och mynt spenderades i kopian men inte markerats som spenderade här.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
-        <translation type="unfinished"/>
+        <translation>Varning: Felaktig Bitcoinadress</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(Ingen etikett)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
-        <translation type="unfinished"/>
+        <translation>Varning: Okänd växeladress</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Är du säker på att du vill skicka?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
-        <translation type="unfinished"/>
+        <translation>adderad som transaktionsavgift</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
-        <translation type="unfinished"/>
+        <translation>Tiden för betalningsbegäran gick ut</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
-        <translation type="unfinished"/>
+        <translation>Felaktig betalningsadress %1</translation>
     </message>
 </context>
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Belopp:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>Betala &amp;Till:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adressen som betalningen skall skickas till  (t.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Ange ett namn för den här adressen och lägg till den i din adressbok</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etikett:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Välj tidigare använda adresser</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
-        <translation type="unfinished"/>
+        <translation>Detta är en normal betalning.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Klistra in adress från Urklipp</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
-        <translation type="unfinished"/>
+        <translation>Radera denna post</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Meddelande:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
-        <translation type="unfinished"/>
+        <translation>Detta är en verifierad betalningsbegäran.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
-        <translation type="unfinished"/>
+        <translation>Ange en etikett för denna adress att adderas till listan över använda adresser</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
-        <translation type="unfinished"/>
+        <translation>Ett meddelande som bifogades bitcoin-URI, vilket lagras med transaktionen som referens. NB: Meddelandet kommer inte att sändas över Bitcoinnätverket.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
-        <translation type="unfinished"/>
+        <translation>Detta är en overifierad betalningsbegäran.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
-        <translation type="unfinished"/>
+        <translation>Betala Till:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
-        <translation type="unfinished"/>
+        <translation>PM:</translation>
     </message>
 </context>
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core stängs av...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
-        <translation type="unfinished"/>
+        <translation>Stäng inte av datorn förrän denna ruta försvinner.</translation>
     </message>
 </context>
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Signaturer - Signera / Verifiera ett Meddelande</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Signera Meddelande</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Du kan signera meddelanden med dina adresser för att bevisa att du äger dem. Var försiktig med vad du signerar eftersom phising-attacker kan försöka få dig att skriva över din identitet till någon annan. Signera bara väldetaljerade påståenden du kan gå i god för.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adressen att signera meddelandet med  (t.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Välj tidigare använda adresser</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Klistra in adress från Urklipp</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Skriv in meddelandet du vill signera här</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Signatur</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Kopiera signaturen till systemets Urklipp</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Signera meddelandet för att bevisa att du äger denna adress</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>Signera &amp;Meddelande</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Rensa alla fält</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Rensa &amp;alla</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>&amp;Verifiera Meddelande</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Skriv in din adress, meddelande (se till att du kopierar radbrytningar, mellanslag, tabbar, osv. exakt) och signatur nedan för att verifiera meddelandet. Var noga med att inte läsa in mer i signaturen än vad som finns i det signerade meddelandet, för att undvika att luras av en man-in-the-middle attack.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Adressen som meddelandet var signerat med  (t.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Verifiera meddelandet för att vara säker på att den var signerad med den angivna Bitcoin-adressen</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Verifiera &amp;Meddelande</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Rensa alla fält</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ange en Bitcoin-adress (t.ex. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Klicka &quot;Signera Meddelande&quot; för att få en signatur</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Den angivna adressen är ogiltig.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Vad god kontrollera adressen och försök igen.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Den angivna adressen refererar inte till en nyckel.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Upplåsningen av plånboken avbröts.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Privata nyckel för den angivna adressen är inte tillgänglig.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Signeringen av meddelandet misslyckades.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Meddelandet är signerat.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Signaturen kunde inte avkodas.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Kontrollera signaturen och försök igen.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Signaturen matchade inte meddelandesammanfattningen.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Meddelandet verifikation misslyckades.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Meddelandet är verifierad.</translation>
     </message>
@@ -2667,17 +2116,14 @@ Adress: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Kärna</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core-utvecklarna</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2685,7 +2131,6 @@ Adress: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2693,184 +2138,138 @@ Adress: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Öppet till %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
-        <translation type="unfinished"/>
+        <translation>konflikterade</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/nerkopplad</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/obekräftade</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 bekräftelser</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Status</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, sänd genom %n nod</numerusform><numerusform>, sänd genom %n noder</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Källa</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Genererad</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Från</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Till</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>egen adress</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etikett</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Kredit</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>mognar om %n block</numerusform><numerusform>mognar om %n fler block</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>inte accepterad</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Belasta</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Transaktionsavgift</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Nettobelopp</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Meddelande</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Kommentar</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Transaktions-ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
-        <translation type="unfinished"/>
+        <translation>Handlare</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
-        <translation type="unfinished"/>
+        <translation>Genererade mynt måste vänta %1 block innan de kan användas. När du skapade detta block sändes det till nätverket för att läggas till i blockkedjan. Om blocket inte kommer in i kedjan kommer dess status att ändras till &quot;accepteras inte&quot; och kommer ej att gå att spendera. Detta kan ibland hända om en annan nod genererar ett block nästan samtidigt som dig.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Debug information</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Transaktion</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Inputs</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Mängd</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>sant</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>falsk</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, har inte lyckats skickas ännu</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Öppet för %n mer block</numerusform><numerusform>Öppet för %n mer block</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>okänd</translation>
     </message>
@@ -2878,12 +2277,10 @@ Adress: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Transaktionsdetaljer</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Den här panelen visar en detaljerad beskrivning av transaktionen</translation>
     </message>
@@ -2891,127 +2288,102 @@ Adress: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Mängd</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
-        <translation type="unfinished"/>
+        <translation>Omogen (%1 konfirmeringar, blir tillgänglig efter %2)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Öppet för %n mer block</numerusform><numerusform>Öppet för %n mer block</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Öppet till %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Bekräftad (%1 bekräftelser)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Det här blocket togs inte emot av några andra noder och kommer antagligen inte att bli godkänt.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Genererad men inte accepterad</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
-        <translation type="unfinished"/>
+        <translation>Nerkopplad</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
-        <translation type="unfinished"/>
+        <translation>Okonfirmerade</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
-        <translation type="unfinished"/>
+        <translation>Konfirmerar (%1 of %2 konfirmeringar)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
-        <translation type="unfinished"/>
+        <translation>Konflikterade</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Mottagen med</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Mottaget från</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Skickad till</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Betalning till dig själv</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Genererade</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(n/a)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Transaktionsstatus. Håll muspekaren över för att se antal bekräftelser.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Tidpunkt då transaktionen mottogs.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Transaktionstyp.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Transaktionens destinationsadress.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Belopp draget eller tillagt till balans.</translation>
     </message>
@@ -3019,178 +2391,142 @@ Adress: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Alla</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Idag</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Denna vecka</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Denna månad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Föregående månad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Det här året</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Period...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Mottagen med</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Skickad till</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Till dig själv</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Genererade</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Övriga</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Sök efter adress eller etikett </translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Minsta mängd</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Kopiera adress</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Kopiera etikett</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Kopiera belopp</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Kopiera transaktions ID</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Ändra etikett</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Visa transaktionsdetaljer</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
-        <translation type="unfinished"/>
+        <translation>Exportera Transaktionshistoriken</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
-        <translation type="unfinished"/>
+        <translation>Exporteringen misslyckades</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
-        <translation type="unfinished"/>
+        <translation>Det inträffade ett fel när transaktionshistoriken skulle sparas till %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
-        <translation type="unfinished"/>
+        <translation>Exporteringen lyckades</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
-        <translation type="unfinished"/>
+        <translation>Transaktionshistoriken sparades utan problem till %1.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Kommaseparerad fil (*. csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Bekräftad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Datum</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Typ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etikett</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adress</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Mängd</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Intervall:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>till</translation>
     </message>
@@ -3198,15 +2534,13 @@ Adress: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
-        <translation type="unfinished"/>
+        <translation>Ingen plånbok har laddats in.</translation>
     </message>
 </context>
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Skicka pengar</translation>
     </message>
@@ -3214,42 +2548,34 @@ Adress: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Exportera</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Exportera informationen i den nuvarande fliken till en fil</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Säkerhetskopiera Plånbok</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Plånboks-data (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Säkerhetskopiering misslyckades</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
-        <translation type="unfinished"/>
+        <translation>Det inträffade ett fel när plånbokens data skulle sparas till %1.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
-        <translation type="unfinished"/>
+        <translation>Plånbokens data sparades utan problem till %1.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Säkerhetskopiering lyckades</translation>
     </message>
@@ -3257,107 +2583,86 @@ Adress: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Användning:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Lista kommandon</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Få hjälp med ett kommando</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Inställningar:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Ange konfigurationsfil (förvalt: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Ange pid fil (förvalt: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Ange katalog för data</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Sätt databas cache storleken i megabyte (förvalt: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Lyssna efter anslutningar på &lt;port&gt; (förvalt: 8333 eller testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Ha som mest &lt;n&gt; anslutningar till andra klienter (förvalt: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Anslut till en nod för att hämta klientadresser, och koppla från</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Ange din egen publika adress</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Tröskelvärde för att koppla ifrån klienter som missköter sig (förvalt: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Antal sekunder att hindra klienter som missköter sig från att ansluta (förvalt: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>Ett fel uppstod vid upprättandet av RPC port %u för att lyssna på IPv4: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Lyssna på JSON-RPC-anslutningar på &lt;port&gt; (förvalt: 8332 eller testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Tillåt kommandon från kommandotolken och JSON-RPC-kommandon</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation>Bitcoin Core RPC-klient version</translation>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Kör i bakgrunden som tjänst och acceptera kommandon</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Använd testnätverket</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Acceptera anslutningar utifrån (förvalt: 1 om ingen -proxy eller -connect)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3382,722 +2687,682 @@ till exempel: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
-        <translation type="unfinished"/>
+        <translation>Accepterade krypteringsalgoritmer  (förvalt: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>Ett fel uppstod vid upprättandet av RPC port %u för att lyssna på IPv6, faller tillbaka till IPV4: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Bind till given adress och lyssna alltid på den. Använd [värd]:port notation för IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Kan inte låsa data-mappen %s. Bitcoin körs förmodligen redan.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation>Antalsbegränsa kontinuerligt fria transaktioner till &lt;n&gt;*1000 bytes per minut (förvalt:15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Ange regressiontestläge, som använder en speciell kedja i vilka block kan lösas omedelbart. Detta är avsett för regressiontestnings verktyg och applikationsutveckling.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
-        <translation type="unfinished"/>
+        <translation>Ange regressiontestläge, som använder en speciell kedja i vilka block kan lösas omedelbart.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation>Fel: Avlyssning av inkommande anslutningar misslyckades (Avlyssningen returnerade felkod %d)</translation>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Fel: Transaktionen avslogs! Detta kan hända om några av mynten i plånboken redan spenderats, t.ex om du använt en kopia av wallet.dat och mynt spenderades i kopian men inte markerats som spenderas här.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Fel: Denna transaktion kräver en transaktionsavgift på minst %s på grund av dess storlek, komplexitet, eller användning av senast mottagna bitcoins!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Exekvera kommando när en plånbokstransaktion ändras (%s i cmd är ersatt av TxID)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation>Avgifter mindre än detta betraktas som nollavgift (för transaktionsskapande) (förvalt:</translation>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation>Töm databasens minnespool till disk varje &lt;n&gt; megabytes (förvalt: 100)</translation>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation>Hur grundlig blockverifikationen vid -checkblocks är (0-4, förvalt: 3)</translation>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation>I denna mode kontrollerar -genproclimit hur många block som genereras på en gång.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation>Ange antalet skriptkontrolltrådar (%u till %d, 0 = auto, &lt;0 = lämna så många kärnor lediga, förval: %d)</translation>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation>Sätt processorbegränsning när blockgenereringen är på (-1 = obegränsad, förvalt: -1)</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Detta är ett förhands testbygge - använd på egen risk - använd inte för mining eller handels applikationer</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
-        <translation type="unfinished"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation>Det går inte att binda till %s på den här datorn. Bitcoin Core är förmodligen redan igång.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
+        <translation>Använd separat SOCKS5 proxy för att nå kollegor via dolda tjänster i Tor (default: -proxy)</translation>
+    </message>
+    <message>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Varning: -paytxfee är satt väldigt hög! Detta är avgiften du kommer betala för varje transaktion.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Varning: Vänligen kolla så att din dators datum och tid är korrekt! Om din klocka går fel kommer Bitcoin inte fungera korrekt.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Varning: Nätverket verkar inte vara helt överens! Några miners verkar ha problem.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Varning: Vi verkar inte helt överens med våra peers! Du kan behöva uppgradera, eller andra noder kan behöva uppgradera.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Varning: fel vid läsning av wallet.dat! Alla nycklar lästes korrekt, men transaktionsdatan eller adressbokens poster kanske saknas eller är felaktiga.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Varning: wallet.dat korrupt, datan har räddats! Den ursprungliga wallet.dat har sparas som wallet.{timestamp}.bak i %s; om ditt saldo eller transaktioner är felaktiga ska du återställa från en säkerhetskopia.</translation>
     </message>
     <message>
-        <location line="+9"/>
-        <source>&lt;category&gt; can be:</source>
-        <translation type="unfinished"/>
+        <source>(default: 1)</source>
+        <translation>(förvalt: 1)</translation>
     </message>
     <message>
-        <location line="+6"/>
+        <source>(default: wallet.dat)</source>
+        <translation>(förvalt: wallet.dat)</translation>
+    </message>
+    <message>
+        <source>&lt;category&gt; can be:</source>
+        <translation>&lt;category&gt; Kan vara:</translation>
+    </message>
+    <message>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Försök att rädda de privata nycklarna från en korrupt wallet.dat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
-        <translation type="unfinished"/>
+        <translation>Bitcoin Core tjänsten</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Bitcoin RPC-klient version</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Block skapande inställningar:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
-        <translation type="unfinished"/>
+        <translation>Töm listan över plånbokstransaktioner (diagnostikverktyg; medför -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Koppla enbart upp till den/de specificerade noden/noder</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
-        <translation type="unfinished"/>
+        <translation>Anslut genom SOCKS-proxy</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
-        <translation type="unfinished"/>
+        <translation>Anslut till JSON-RPC på &lt;port&gt; (förval: 8332 eller testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>Anslutningsoptioner:</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Korrupt blockdatabas har upptäckts</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation>Avlusnings/Testnings optioner:</translation>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation>Avaktivera säkert läge. Åsidosätt en riktigt säkert läge händelse (förvalt: 0)</translation>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Hitta egen IP-adress (förvalt: 1 under lyssning och utan -externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
-        <translation type="unfinished"/>
+        <translation>Ladda inte plånboken och stäng av RPC-anrop till plånboken</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Vill du bygga om blockdatabasen nu?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Fel vid initiering av blockdatabasen</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Fel vid initiering av plånbokens databasmiljö %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Fel vid inläsning av blockdatabasen</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Fel vid öppning av blockdatabasen</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Fel: Hårddiskutrymme är lågt!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Fel: Plånboken är låst, det går ej att skapa en transaktion!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Fel: systemfel:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Misslyckades att lyssna på någon port. Använd -listen=0 om du vill detta.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Misslyckades att läsa blockinformation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Misslyckades att läsa blocket</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Misslyckades att synkronisera blockindex</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Misslyckades att skriva blockindex</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Misslyckades att skriva blockinformation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Misslyckades att skriva blocket</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Misslyckades att skriva filinformation</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Misslyckades att skriva till myntdatabas</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Misslyckades att skriva transaktionsindex</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Misslyckades att skriva ångradata</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Avgift per kB att lägga till på transaktioner du skickar</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation>Avgifter mindre än detta betraktas som nollavgift (för vidarebefodran) (förvalt:</translation>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Sök efter klienter med DNS sökningen (förvalt: 1 om inte -connect)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation>Tvångskör i säkert läge (förvalt: 0)</translation>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Generera mynt (förvalt: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Hur många block att kontrollera vid uppstart (standardvärde: 288, 0 = alla)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Hur grundlig blockverifikationen är (0-4, förvalt: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
-        <translation type="unfinished"/>
+        <translation>Om &lt;category&gt; inte anges, skrivs all avlusningsinformation ut.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Felaktig eller inget genesisblock hittades. Fel datadir för nätverket?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Ogiltig -onion adress:&apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Inte tillräckligt med filbeskrivningar tillgängliga.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
-        <translation type="unfinished"/>
+        <translation>Skriv ut tidsstämpel i avlusningsinformationen (förvalt: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
-        <translation type="unfinished"/>
+        <translation>RPC klientoptioner:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Återskapa blockkedjans index från nuvarande blk000??.dat filer</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
-        <translation type="unfinished"/>
+        <translation>Välj SOCKS-version att använda för -proxy (4 eller 5, förvalt: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Skicka commando till Bitcoinserver</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation>Sätt databasens cachestorlek i megabyte (%d till %d, förvalt: %d)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
-        <translation type="unfinished"/>
+        <translation>Sätt maximal blockstorlek i byte (förvalt: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Ange antalet trådar för att hantera RPC anrop (standard: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Ange plånboksfil (inom datakatalogen)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
-        <translation type="unfinished"/>
+        <translation>Spendera okonfirmerad växel när transaktioner sänds (förvalt: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Starta Bitcoinserver</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
-        <translation type="unfinished"/>
+        <translation>Detta är avsett för regressionstestningsverktyg och applikationsutveckling.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
-        <translation type="unfinished"/>
+        <translation>Användning (föråldrat, använd bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Verifierar block...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Verifierar plånboken...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
-        <translation type="unfinished"/>
+        <translation>Vänta på att RPC.servern startar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>Plånbok %s ligger utanför datakatalogen %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
-        <translation type="unfinished"/>
+        <translation>Plånboksinställningar:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
-        <translation type="unfinished"/>
+        <translation>Varning: Föråldrat argument -debugnet ignorerad, använd -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>Du måste återskapa databasen med -reindex för att ändra -txindex</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Importerar block från extern blk000??.dat fil</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation>Kan inte låsa data-mappen %s. Bitcoin Core körs förmodligen redan.</translation>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>Exekvera kommando när ett relevant meddelande är mottagen eller när vi ser en väldigt lång förgrening (%s i cmd är utbytt med ett meddelande)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
-        <translation type="unfinished"/>
+        <translation>Skriv ut avlusningsinformation (förvalt: 0, att ange &lt;category&gt; är frivilligt)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
-        <translation type="unfinished"/>
+        <translation>Sätt den maximala storleken av hög-prioriterade/låg-avgifts transaktioner i byte (förvalt: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Ange antalet skriptkontrolltrådar (upp till 16, 0 = auto, &lt;0 = lämna så många kärnor lediga, förval: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Information</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ogiltigt belopp för -minrelaytxfee=&lt;belopp&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ogiltigt belopp för -mintxfee=&lt;belopp&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation>Begränsa signaturcachestorleken till &lt;n&gt; poster (förvalt: 50000)</translation>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation>Logga transaktionsprioritet och avgift per kB vid blockbrytning (förvalt: 0)</translation>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Upprätthåll ett fullständigt transaktionsindex (förval: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Maximal buffert för mottagning per anslutning, &lt;n&gt;*1000 byte (förvalt: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Maximal buffert för sändning per anslutning, &lt;n&gt;*1000 byte (förvalt: 5000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Acceptera bara blockkedjans matchande inbyggda kontrollpunkter (förvalt: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Anslut enbart till noder i nätverket &lt;net&gt; (IPv4, IPv6 eller Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation>Skriv ut block vid uppstart, om det hittas i blockindexet</translation>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation>Skriv ut blockträdet vid uppstart (förvalt: 0)</translation>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>RPC SSL optioner: (se Bitcoin Wiki för SSL inställningsinstruktioner)</translation>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>RPC serveroptioner:</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation>Slumpmässigt tappa 1 av varje &lt;n&gt; nåtverksmeddelande</translation>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation>Slupmässigt brus 1 gång varje &lt;n&gt; nätverksmeddelande</translation>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation>Kör en tråd för att tömma plånboken periodiskt (förvalt: 1)</translation>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL-inställningar: (se Bitcoin-wikin för SSL-setup instruktioner)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation>Sänd kommando till Bitcoin Core</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Skicka trace-/debuginformation till terminalen istället för till debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Sätt minsta blockstorlek i byte (förvalt: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation>Sätt DB_PRIVATE flaggan i plånbokens databasmiljö (förvalt: 1)</translation>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>Visa alla avlusningsoptioner (använd: --help -help-debug)</translation>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation>Visa riktmärknings information (förvalt: 0)</translation>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Krymp debug.log filen vid klient start (förvalt: 1 vid ingen -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Signering av transaktion misslyckades</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Ange timeout för uppkoppling i millisekunder (förvalt: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation>Starta Bitcoin Core tjänsten</translation>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Systemfel:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Transaktions belopp för liten</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Transaktionens belopp måste vara positiva</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Transaktionen är för stor</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Använd UPnP för att mappa den lyssnande porten (förvalt: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Använd UPnP för att mappa den lyssnande porten (förvalt: 1 under lyssning)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Användarnamn för JSON-RPC-anslutningar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Varning</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Varning: denna version är föråldrad, uppgradering krävs!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
-        <translation type="unfinished"/>
+        <translation>Töm plånboken på alla transaktioner...</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>under uppstarten</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>version</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat korrupt, räddning misslyckades</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Lösenord för JSON-RPC-anslutningar</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Tillåt JSON-RPC-anslutningar från specifika IP-adresser</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Skicka kommandon till klient på &lt;ip&gt; (förvalt: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Exekvera kommando när det bästa blocket ändras (%s i cmd är utbytt av blockhash)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Uppgradera plånboken till senaste formatet</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Sätt storleken på nyckelpoolen till &lt;n&gt; (förvalt: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Sök i blockkedjan efter saknade plånboks transaktioner</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Använd OpenSSL (https) för JSON-RPC-anslutningar</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Serverns certifikatfil (förvalt: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Serverns privata nyckel (förvalt: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Det här hjälp medelandet</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Det går inte att binda till %s på den här datorn (bind returnerade felmeddelande %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Tillåt DNS-sökningar för -addnode, -seednode och -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Laddar adresser...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Fel vid inläsningen av wallet.dat: Plånboken är skadad</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Fel vid inläsningen av wallet.dat: Plånboken kräver en senare version av Bitcoin</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Plånboken behöver skrivas om: Starta om Bitcoin för att färdigställa</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Fel vid inläsning av plånboksfilen wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Ogiltig -proxy adress: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Okänt nätverk som anges i -onlynet: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Okänd -socks proxy version begärd: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>Kan inte matcha -bind adress: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>Kan inte matcha -externalip adress: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Ogiltigt belopp för -paytxfee=&lt;belopp&gt;:&apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Ogiltig mängd</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Otillräckligt med bitcoins</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Laddar blockindex...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Lägg till en nod att koppla upp mot och försök att hålla anslutningen öppen</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Det går inte att binda till %s på den här datorn. Bitcoin är förmodligen redan igång.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Laddar plånbok...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Kan inte nedgradera plånboken</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Kan inte skriva standardadress</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Söker igen...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Klar med laddning</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Att använda %s alternativet</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Fel</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_th_TH.ts
+++ b/src/qt/locale/bitcoin_th_TH.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>ดับเบิลคลิก เพื่อแก้ไขที่อยู่ หรือชื่อ</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>สร้างที่อยู่ใหม่</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>คัดลอกที่อยู่ที่ถูกเลือกไปยัง คลิปบอร์ดของระบบ</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>ลบ</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>ชื่อ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>ที่อยู่</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(ไม่มีชื่อ)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>ใส่รหัสผ่าน</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>รหัสผา่นใหม่</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>กรุณากรอกรหัสผ่านใหม่อีกครั้งหนึ่ง</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>กระเป๋าสตางค์ที่เข้ารหัส</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>เปิดกระเป๋าสตางค์</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>ถอดรหัสกระเป๋าสตางค์</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>เปลี่ยนรหัสผ่าน</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>กรอกรหัสผ่านเก่าและรหัสผ่านใหม่สำหรับกระเป๋าสตางค์</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>ยืนยันการเข้ารหัสกระเป๋าสตางค์</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>กระเป๋าสตางค์ถูกเข้ารหัสเรียบร้อยแล้ว</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>การเข้ารหัสกระเป๋าสตางค์ผิดพลาด</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>รหัสผ่านที่คุณกรอกไม่ตรงกัน</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>ที่อยู่</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(ไม่มีชื่อ)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>ที่อยู่</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>ชื่อ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>ชื่อ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(ไม่มีชื่อ)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(ไม่มีชื่อ)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>ที่อยู่</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>วันนี้</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>ชื่อ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>ที่อยู่</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_tr.ts
+++ b/src/qt/locale/bitcoin_tr.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>Bitcoin Çekirdeği hakkında</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;Bitcoin Çekirdek&lt;/b&gt; sürümü</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ This product includes software developed by the OpenSSL Project for use in the O
  Bu ürün OpenSSL projesi tarafından OpenSSL araç takımı (http://www.openssl.org/) için geliştirilen yazılımlar, Eric Young (eay@cryptsoft.com) tarafından hazırlanmış şifreleme yazılımları ve Thomas Bernard tarafından programlanmış UPnP yazılımı içerir.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Telif hakkı</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Çekirdeği geliştiricileri</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
-        <translation> (%1-bit)</translation>
+        <source>(%1-bit)</source>
+        <translation>(%1-bit)</translation>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Adresi ya da etiketi düzenlemek için çift tıklayınız</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Yeni bir adres oluştur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>&amp;Yeni</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Şu anda seçili olan adresi sistem panosuna kopyala</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopyala</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation>K&amp;apat</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>Adresi &amp;kopyala</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Seçili adresi listeden sil</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Güncel sekmedeki verileri bir dosyaya aktar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp;Dışa aktar</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Sil</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>Bitcoin yollanacak adresi seç</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>Bitcoin alınacak adresi seç</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>S&amp;eç</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>Yollama adresleri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>Alım adresleri</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Bunlar ödeme yapmak için kullanacağınız Bitcoin adreslerinizdir. Bitcoin yollamadan önce meblağı ve alıcı adresini daima kontrol ediniz.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>Bunlar ödeme almak için kullanacağınız Bitcoin adreslerinizdir. Her muamele için yeni bir alım adresi kullanmanız tavsiye edilir.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>&amp;Etiketi kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Düzenle</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>Adres listesini dışa aktar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Virgülle ayrılmış değerler dosyası (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>Dışa aktarım başarısız oldu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>Adres listesinin %1 konumuna kaydedilmesi sırasında bir hata meydana geldi.</translation>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(boş etiket)</translation>
     </message>
@@ -187,140 +153,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Parola diyaloğu</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Parolayı giriniz</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Yeni parola</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Yeni parolayı tekrarlayınız</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Cüzdanınız için yeni parolayı giriniz.&lt;br/&gt;Lütfen &lt;b&gt;10 ya da daha fazla rastgele karakter&lt;/b&gt; veya &lt;b&gt;sekiz ya da daha fazla kelime&lt;/b&gt; içeren bir parola seçiniz.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Cüzdanı şifrele</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Bu işlem cüzdan kilidini açmak için cüzdan parolanızı gerektirir.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Cüzdan kilidini aç</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Bu işlem, cüzdan şifresini açmak için cüzdan parolasını gerektirir.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Cüzdan şifresini aç</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Parolayı değiştir</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Cüzdan için eski ve yeni parolaları giriniz.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Cüzdan şifrelenmesini teyit eder</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>Uyarı: Eğer cüzdanınızı şifrelerseniz ve parolanızı kaybederseniz, &lt;b&gt;TÜM BİTCOİNLERİNİZİ KAYBEDERSİNİZ&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Cüzdanınızı şifrelemek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>ÖNEMLİ: Önceden yapmış olduğunuz cüzdan dosyası yedeklemelerinin yeni oluşturulan şifrelenmiş cüzdan dosyası ile değiştirilmeleri gerekir. Güvenlik nedenleriyle yeni, şifrelenmiş cüzdanı kullanmaya başladığınızda eski şifrelenmemiş cüzdan dosyaları işe yaramaz hale gelecektir.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Uyarı: Caps Lock tuşu faal durumda!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Cüzdan şifrelendi</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Şifreleme işlemini tamamlamak için Bitcoin şimdi kapanacaktır. Cüzdanınızı şifrelemenin, Bitcoinlerinizin bilgisayara bulaşan kötücül bir yazılım tarafından çalınmaya karşı tamamen koruyamayacağını unutmayınız.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Cüzdan şifrelemesi başarısız oldu</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Dahili bir hata sebebiyle cüzdan şifrelemesi başarısız oldu. Cüzdanınız şifrelenmedi.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Girilen parolalar birbirleriyle uyumlu değil.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Cüzdan kilidinin açılması başarısız oldu</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Cüzdan şifresinin açılması için girilen parola yanlıştı.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Cüzdan şifresinin açılması başarısız oldu</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Cüzdan parolası başarılı bir şekilde değiştirildi.</translation>
     </message>
@@ -328,362 +260,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;Mesaj imzala...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Şebeke ile senkronizasyon...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Genel bakış</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation>Düğüm</translation>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Cüzdana genel bakışı göster</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>&amp;Muameleler</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Muamele tarihçesini tara</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Çık</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Uygulamadan çık</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Bitcoin hakkında bilgi göster</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>&amp;Qt hakkında</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Qt hakkında bilgi görüntü</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Seçenekler...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>Cüzdanı &amp;şifrele...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>Cüzdanı &amp;yedekle...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>Parolayı &amp;değiştir...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;Gönderme adresleri...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;Alma adresleri...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>&amp;URI aç...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Bloklar diskten içe aktarılıyor...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Diskteki bloklar yeniden endeksleniyor...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Bir Bitcoin adresine Bitcoin yolla</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Bitcoin seçeneklerinin yapılandırmasını değiştir</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Cüzdanı diğer bir konumda yedekle</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Cüzdan şifrelemesi için kullanılan parolayı değiştir</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>&amp;Hata ayıklama penceresi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Hata ayıklama ve teşhis penceresini aç</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>Mesaj &amp;kontrol et...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Cüzdan</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Gönder</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Al</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>&amp;Göster / Sakla</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Ana pencereyi görüntüle ya da sakla</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Cüzdanınızın özel anahtarlarını şifrele</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Mesajları adreslerin size ait olduğunu ispatlamak için Bitcoin adresleri ile imzala</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Belirtilen Bitcoin adresleri ile imzalandıklarından emin olmak için mesajları kontrol et</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Dosya</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Ayarlar</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Yardım</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Sekme araç çubuğu</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Çekirdeği</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>Ödeme talep et (QR kodu ve bitcoin URI&apos;si oluşturur)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>Bitcoin Çekirdeği &amp;hakkında</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>Kullanılmış gönderme adresleri ve etiketlerin listesini göster</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>Kullanılmış alım adresleri ve etiketlerin listesini göster</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>Bir bitcoin: bağlantısı ya da ödeme talebi aç</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;Komut satırı seçenekleri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>Bitcoin komut satırı seçeneklerinin listesini elde etmek için Bitcoin Çekirdeği yardım mesajını göster</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin istemcisi</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>Bitcoin şebekesine %n faal bağlantı</numerusform><numerusform>Bitcoin şebekesine %n faal bağlantı</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Hiçbir blok kaynağı mevcut değil...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>Muamele tarihçesinin toplam (tahmini) %2 blokundan %1 blok işlendi.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Muamele tarihçesinde %1 blok işlendi.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n saat</numerusform><numerusform>%n saat</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n gün</numerusform><numerusform>%n gün</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n hafta</numerusform><numerusform>%n hafta</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
-        <translation type="unfinished"/>
+        <translation>%1 ve %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
-        <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
+        <translation><numerusform>%n yıl</numerusform><numerusform>%n yıl</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>%1 geride</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>Son alınan blok %1 evvel oluşturulmuştu.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Bundan sonraki muameleler henüz görüntülenemez.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Uyarı</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Bilgi</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Güncel</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Aralık kapatılıyor...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Muamele yollandı</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Gelen muamele</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +552,14 @@ Adres: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>Cüzdan &lt;b&gt;şifrelenmiştir&lt;/b&gt; ve şu anda &lt;b&gt;kilidi açıktır&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>Cüzdan &lt;b&gt;şifrelenmiştir&lt;/b&gt; ve şu anda &lt;b&gt;kilitlidir&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Ciddi bir hata oluştu. Bitcoin artık güvenli bir şekilde işlemeye devam edemez ve kapanacaktır.</translation>
     </message>
@@ -714,7 +567,6 @@ Adres: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Şebeke hakkında uyarı</translation>
     </message>
@@ -722,291 +574,230 @@ Adres: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>Para kontrolü adres seçimi</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>Miktar:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>Bayt:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Meblağ:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>Öncelik:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>Ücret:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Düşük çıktı:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Ücretten sonra:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Para üstü:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>tümünü seç(me)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>Ağaç kipi</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>Liste kipi</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Meblağ</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Tarih</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>Doğrulamalar</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Doğrulandı</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>Öncelik</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Adresi kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Etiketi kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Meblağı kopyala</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Muamele kimliğini kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>Harcanmamışı kilitle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>Harcanmamışın kilidini aç</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>Miktarı kopyala</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>Ücreti kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Ücretten sonrakini kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Baytları kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Önceliği kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Düşük çıktıyı kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Para üstünü kopyala</translation>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation>azami</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>daha yüksek</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>yüksek</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>orta-yüksek</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>orta</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>düşük-orta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>düşük</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>daha düşük</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>asgari</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 kilitlendi)</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation>boş</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>Toz</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>evet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>hayır</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>Eğer muamele boyutu 1000 bayttan büyükse bu etkiket kırmızı olur.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>Bu, kB başına en az %1 ücret gerektiği anlamnına gelir.</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>Girdi başına +/- 1 bayt değişebilir.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>Yüksek öncelikli muamelelerin bir bloğa dahil olmaları daha olasıdır.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>Eğer öncelik &quot;ortadan&quot; düşükse bu etiket kırmızı olur.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>Eğer herhangi bir alıcı %1&apos;den düşük bir meblağ alırsa bu etiket kırmızı olur.</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>Bu, en az %1 tutarında bir ücret gerektiği anlamına gelir.</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>Asgari yönlendirme ücretinin 0.546 oranının altındaki meblağlar toz olarak gösterilir.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>Eğer para üstü %1&apos;den düşükse bu etiket kırmızı olur.</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(boş etiket)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation>%1 unsurundan para üstü (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(para üstü)</translation>
     </message>
@@ -1014,67 +805,54 @@ Adres: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Adresi düzenle</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Etiket</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>Bu adres listesi girdisi ile ilişkili etiket</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>Bu adres listesi girdisi ile ilişkili adres. Sadece gönderme adresleri için değiştirilebilir.</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Adres</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Yeni alım adresi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Yeni gönderi adresi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Alım adresini düzenle</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Gönderi adresini düzenle</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Girilen &quot;%1&quot; adresi hâlihazırda adres defterinde mevcuttur.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Girilen &quot;%1&quot; adresi geçerli bir Bitcoin adresi değildir.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Cüzdan kilidi açılamadı.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Yeni anahtar oluşturulması başarısız oldu.</translation>
     </message>
@@ -1082,27 +860,22 @@ Adres: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation>Yeni bir veri klasörü oluşturulacaktır.</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>isim</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>Klasör hâlihazırda mevcuttur. Burada yeni bir klasör oluşturmak istiyorsanız, %1 ilâve ediniz.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>Erişim yolu zaten mevcuttur ve klasör değildir.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>Burada veri klasörü oluşturulamaz.</translation>
     </message>
@@ -1110,52 +883,46 @@ Adres: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>Bitcoin Çekirdeği - Komut satırı seçenekleri</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Çekirdeği</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>sürüm</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Kullanım:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>komut satırı seçenekleri</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Kullanıcı arayüzü seçenekleri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Lisan belirt, mesela &quot;de_De&quot; (varsayılan: sistem dili)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Küçültülmüş olarak başlat</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation>Ödeme talebi için SSL kök sertifikalarını belirle (varsayılan: -system-)</translation>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Başlatıldığında başlangıç ekranını göster (varsayılan: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>Başlangıçta veri klasörü seç (varsayılan: 0)</translation>
     </message>
@@ -1163,57 +930,46 @@ Adres: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Hoş geldiniz</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>Bitcoin Çekirdeğine hoş geldiniz.</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>Bu programı ilk kez başlattığınızdan dolayı Bitcoin Çekirdeğinin verilerini nereye saklayacağını seçebilirsiniz.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>Bitcoin çekirdeği Bitcoin blok zincirinin bir kopyasını indirip saklayacaktır. Asgari %1GB bouyutunda veri bu klasörde saklanacak ve zamanla bu boyut artacaktır. Cüzdan da bu klasörde saklanacaktır. </translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>Varsayılan veri klasörünü kullan</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>Özel bir veri klasörü kullan:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>Hata: belirtilen &quot;%1&quot; veri klasörü oluşturulamaz.</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB boş alan mevcuttur</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(gereken boyut: %1GB)</translation>
     </message>
@@ -1221,27 +977,22 @@ Adres: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>URI aç</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>Dosyadan veya URI&apos;den ödeme talebi aç</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>Ödeme talebi dosyasını seç</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>Açılacak ödeme talebi dosyasını seç</translation>
     </message>
@@ -1249,253 +1000,206 @@ Adres: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Seçenekler</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Esas ayarlar</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Muamelelerin hızlı işlenmesini garantilemeye yardım eden, seçime dayalı kB başı muamele ücreti. Muamelelerin çoğunluğunun boyutu 1 kB&apos;dir.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Muamele ücreti &amp;öde</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Sistemde oturum açıldığında Bitcoin&apos;i otomatik olarak başlat.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>Bitcoin&apos;i sistem oturumuyla &amp;başlat</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>&amp;Veritabanı tamponunun boyutu</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>İş parçacıklarını &amp;denetleme betiği sayısı</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Betik kontrolü iş parçacığı sayısını belirt (azami 16, 0 = otomatik, &lt;0 = bu sayıda çekirdeği boş bırak, varsayılan: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation>Doğrulanmamış para üstünü &amp;harca (sadece uzman kullanıcılar için)</translation>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>Bitcoin şebekesine bir SOCKS vekil sunucusu vasıtasıyla bağlan.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>SOCKS vekil sunucusuyla &amp;bağlan (varsayılan vekil):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>Vekil sunucusunun IP adresi (mesela IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation>Yukarıdaki seçeneklerin yerine geçen faal komut satırı seçenekleri:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>İstemcinin tüm seçeneklerini varsayılan değerlere geri al.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>Seçenekleri Sıfı&amp;rla</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Şebeke</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation>(0 = otomatik, &lt;0 = bu kadar çekirdeği kullanma)</translation>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation>&amp;Cüzdan</translation>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation>Gelişmiş</translation>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation>Para &amp;kontrolü özelliklerini etkinleştir</translation>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>Teyit edilmemiş para üstünü harcamayı devre dışı bırakırsanız, bir muamelenin para üstü bu muamele için en az bir teyit olana dek harcanamaz. Bu, aynı zamanda bakiyenizin nasıl hesaplandığını da etkiler.</translation>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation>Teyit edilmemiş para üstünü &amp;harca</translation>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Yönlendiricide Bitcoin istemci portlarını otomatik olarak açar. Bu, sadece yönlendiricinizin UPnP desteği bulunuyorsa ve etkinse çalışabilir.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Portları &amp;UPnP kullanarak haritala</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>Vekil &amp;İP:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Port:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Vekil sunucunun portu (mesela 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS &amp;sürümü:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Vekil sunucunun SOCKS sürümü (mesela 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Pencere</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Küçültüldükten sonra sadece çekmece ikonu göster.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>İşlem çubuğu yerine sistem çekmecesine &amp;küçült</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Pencere kapatıldığında uygulamadan çıkmak yerine uygulamayı küçültür. Bu seçenek etkinleştirildiğinde, uygulama sadece menüden çıkış seçildiğinde kapanacaktır.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>Kapatma sırasında k&amp;üçült</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Görünüm</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Kullanıcı arayüzü &amp;lisanı:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Kullanıcı arayüzünün dili burada belirtilebilir. Bu ayar Bitcoin tekrar başlatıldığında etkinleşecektir.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>Meblağları göstermek için &amp;birim:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Bitcoin gönderildiğinde arayüzde gösterilecek varsayılan alt birimi seçiniz.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Muamele listesinde Bitcoin adreslerinin gösterilip gösterilmeyeceklerini belirler.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>Muamele listesinde adresleri &amp;göster</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation>Para kontrol özelliklerinin gösterilip gösterilmeyeceğini ayarlar.</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation>Para &amp;kontrol özelliklerini görüntüle (sadece uzman kullanıcılar için)</translation>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;Tamam</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;İptal</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>varsayılan</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>boş</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Seçeneklerin sıfırlanmasını teyit et</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>Değişikliklerin uygulanması için istemcinin yeniden başlatılması lazımdır.</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>İstemci kapanacaktır, devam etmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>Bu değişiklik istemcinin tekrar başlatılmasını gerektirir.</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Girilen vekil sunucu adresi geçersizdir.</translation>
     </message>
@@ -1503,69 +1207,54 @@ Adres: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Form</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Görüntülenen veriler zaman aşımına uğramış olabilir. Bağlantı kurulduğunda cüzdanınız otomatik olarak şebeke ile eşleşir ancak bu işlem henüz tamamlanmamıştır.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Cüzdan</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>Mevcut:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Güncel harcanabilir bakiyeniz</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>Beklemede:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Henüz teyit edilmemiş ve harcanabilir bakiyeye eklenmemiş muamelelerin toplamı</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>Olgunlaşmamış:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Oluşturulan bakiye henüz olgunlaşmamıştır</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>Toplam:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Güncel toplam bakiyeniz</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Son muameleler&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>eşleşme dışı</translation>
     </message>
@@ -1573,93 +1262,70 @@ Adres: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI yönetimi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI okunamadı! Sebebi geçersiz bir Bitcoin adresi veya hatalı URI parametreleri olabilir.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>Talep edilen %1 meblağında ödeme çok düşüktür (toz olarak kabul edilir).</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>Ödeme talebi hatası</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>Bitcoin başlatılamadı: tıkla-ve-öde yöneticisi</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>Şebeke yöneticisi uyarısı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>Faal vekil sunucunuz, vekil vasıtasıyla ödeme talepleri için gereken SOCKS5&apos;i desteklememektedir.</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>Ödeme talebini alma URL&apos;i geçersiz: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>Ödeme talebi dosyası yönetimi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>Ödeme talebi okunamaz ya da işlenemez! Bunun sebebi geçersiz bir ödeme talebi dosyası olabilir.</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>Özel ödeme betiklerine teyit edilmemiş ödeme talepleri desteklenmez.</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>%1 öğesinden iade</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>%1 ile iletişimde hata: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>Ödeme talebi ayrıştırılamaz ya da işlenemez!</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>%1 sunucusundan hatalı cevap</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>Ödeme teyit edildi</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>Şebeke talebi hatası</translation>
     </message>
@@ -1667,23 +1333,22 @@ Adres: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>Hata: belirtilen &quot;%1&quot; veri klasörü yoktur.</translation>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation>Hata: %1 yapılandırma dosyası ayrıştırılamadı. Sadece anahtar=değer dizimini kullanınız.</translation>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>Hata: -regtest ve -testnet&apos;in geçersiz kombinasyonu.</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin adresi giriniz (mesela 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1691,22 +1356,18 @@ Adres: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>Resmi k&amp;aydet...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>Resmi &amp;kopyala</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>QR kodu kaydet</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG resim (*.png)</translation>
     </message>
@@ -1714,192 +1375,146 @@ Adres: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>İstemci ismi</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>Mevcut değil</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>İstemci sürümü</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Malumat</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>Hata ayıklama penceresi</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>Genel</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Kullanılan OpenSSL sürümü</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Başlama zamanı</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Şebeke</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>İsim</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Bağlantı sayısı</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Blok zinciri</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Güncel blok sayısı</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Tahmini toplam blok sayısı</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Son blok zamanı</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>&amp;Aç</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>&amp;Konsol</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>&amp;Şebeke trafiği</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>&amp;Temizle</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>Toplamlar</translation>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation>İçeri:</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation>Dışarı:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Derleme tarihi</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Hata ayıklama kütük dosyası</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Güncel veri klasöründen Bitcoin hata ayıklama kütük dosyasını açar. Büyük kütük dosyaları için bu birkaç saniye alabilir.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Konsolu temizle</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Bitcoin RPC konsoluna hoş geldiniz.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Tarihçede gezinmek için imleç tuşlarını kullanınız, &lt;b&gt;Ctrl-L&lt;/b&gt; ile de ekranı temizleyebilirsiniz.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Mevcut komutların listesi için &lt;b&gt;help&lt;/b&gt; yazınız.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation>%1 B</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 d</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 s %2 d</translation>
     </message>
@@ -1907,105 +1522,82 @@ Adres: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Meblağ:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiket:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>Me&amp;saj:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>Daha önce kullanılmış bir alım adresini kullan. Adresleri tekrar kullanmak güvenlik ve gizlilik sorunları doğurur. Bunu, daha önce yaptığınız bir talebi tekrar oluşturmak durumu dışında kullanmayınız.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>&amp;Hâlihazırda bulunan bir alım adresini kullan (önerilmez)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>Talep açıldığında gösterilecek, isteğinize dayalı, ödeme talebi ile ilişkilendirilecek bir mesaj. Not: Bu mesaj ödeme ile birlikte Bitcoin şebekesi üzerinden gönderilmeyecektir.</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>Yeni alım adresi ile ilişkili, seçiminize dayalı etiket.</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>Ödeme talep etmek için bu formu kullanın. Tüm alanlar &lt;b&gt;seçime dayalıdır&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>Seçiminize dayalı talep edilecek meblağ. Belli bir meblağ talep etmemek için bunu boş bırakın veya sıfır değerini kullanın.</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Formdaki tüm alanları temizle.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Temizle</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>Talep edilen ödemelerin tarihçesi</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>Ödeme &amp;talep et</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>Seçilen talebi göster (bir unsura çift tıklamakla aynı anlama gelir)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>Göster</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation>Seçilen unsurları listeden kaldır</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>Kaldır</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Etiketi kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>Mesajı kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Meblağı kopyala</translation>
     </message>
@@ -2013,67 +1605,54 @@ Adres: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR Kodu</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>&amp;URI&apos;yi kopyala</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>&amp;Adresi kopyala</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>Resmi ka&amp;ydet...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>%1 unsuruna ödeme talep et</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>Ödeme bilgisi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Meblağ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Sonuç URI çok uzun, etiket ya da mesaj metnini kısaltmayı deneyiniz.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>URI&apos;nin QR koduna kodlanmasında hata oluştu.</translation>
     </message>
@@ -2081,37 +1660,30 @@ Adres: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Tarih</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Meblağ</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(boş etiket)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(boş mesaj)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(boş meblağ)</translation>
     </message>
@@ -2119,247 +1691,194 @@ Adres: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Bitcoin yolla</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>Para kontrolü özellikleri</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>Girdiler...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>otomatik seçilmiş</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>Yetersiz fon!</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>Miktar:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>Bayt:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Meblağ:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>Öncelik:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>Ücret:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>Düşük çıktı:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>Ücretten sonra:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>Para üstü:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>Bu etkinleştirildiyse fakat para üstü adresi boş ya da geçersizse para üstü yeni oluşturulan bir adrese gönderilecektir.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>Özel para üstü adresi</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Birçok alıcıya aynı anda gönder</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>&amp;Alıcı ekle</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Formdaki tüm alanları temizle.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Tümünü &amp;temizle</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Bakiye:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Yollama etkinliğini teyit ediniz</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>G&amp;önder</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Gönderiyi teyit ediniz</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 öğesinden %2 unsuruna</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>Miktarı kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Meblağı kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>Ücreti kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>Ücretten sonrakini kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>Baytları kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>Önceliği kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>Düşük çıktıyı kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>Para üstünü kopyala</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>Toplam meblağ %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>veya</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Alıcı adresi geçerli değildir, lütfen denetleyiniz.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Ödeyeceğiniz tutarın sıfırdan yüksek olması gerekir.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Tutar bakiyenizden yüksektir.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Toplam, %1 muamele ücreti ilâve edildiğinde bakiyenizi geçmektedir.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Çift adres bulundu, belli bir gönderi sırasında her adrese sadece tek bir gönderide bulunulabilir.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>Muamelenin oluşturulması başarısız oldu!</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Muamele reddedildi! Cüzdanınızdaki madenî paraların bazıları zaten harcanmış olduğunda bu meydana gelebilir. Örneğin wallet.dat dosyasının bir kopyasını kullandıysanız ve kopyada para harcandığında ancak burada harcandığı işaretlenmediğinde.</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>Uyarı: geçersiz Bitcoin adresi</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(boş etiket)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>Uyarı: geçersiz para üstü adresi</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Göndermek istediğinizden emin misiniz?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>muamele ücreti olarak eklendi</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>Ödeme talebinin ömrü doldu</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>Geçersiz ödeme adresi %1</translation>
     </message>
@@ -2367,98 +1886,74 @@ Adres: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>Mebla&amp;ğ:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Şu adrese öde:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Ödemenin gönderileceği adres (mesela 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Adres defterinize eklemek için bu adrese ilişik bir etiket giriniz</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Etiket:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Önceden kullanılmış adres seç</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>Bu, normal bir ödemedir.</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Panodan adres yapıştır</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>Bu unsuru kaldır</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Mesaj:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>Bu, teyit edilmiş bir ödeme talebidir.</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>Kullanılmış adres listesine eklemek için bu adrese bir etiket girin</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>Bitcoin: URI&apos;siyle ilişkili ve bilginiz için muameleyle saklanacak bir mesaj. Not: Bu mesaj Bitcoin şebekesi üzerinden gönderilmeyecektir.</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>Bu, teyit edilmemiş bir ödeme talebidir.</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>Şu adrese öde:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Not:</translation>
     </message>
@@ -2466,12 +1961,10 @@ Adres: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>Bitcoin Çekirdeği kapanıyor...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>Bu pencere kalkıncaya dek bilgisayarı kapatmayınız.</translation>
     </message>
@@ -2479,186 +1972,142 @@ Adres: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>İmzalar - Mesaj İmzala / Kontrol et</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>Mesaj &amp;imzala</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Bir adresin sizin olduğunu ispatlamak için adresinizle mesaj imzalayabilirsiniz. Oltalama saldırılarının kimliğinizi imzanızla elde etmeyi deneyebilecekleri için belirsiz hiçbir şey imzalamamaya dikkat ediniz. Sadece ayrıntılı açıklaması olan ve tümüne katıldığınız ifadeleri imzalayınız.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Mesajın imzalanmasında kullanılacak adres (mesela 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Önceden kullanılmış adres seç</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Panodan adres yapıştır</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>İmzalamak istediğiniz mesajı burada giriniz</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>İmza</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Güncel imzayı sistem panosuna kopyala</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Bu Bitcoin adresinin sizin olduğunu ispatlamak için mesajı imzalayın</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>&amp;Mesajı imzala</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Tüm mesaj alanlarını sıfırla</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Tümünü &amp;temizle</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>Mesaj &amp;kontrol et</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>İmza için kullanılan adresi, mesajı (satır sonları, boşluklar, sekmeler vs. karakterleri tam olarak kopyaladığınızdan emin olunuz) ve imzayı aşağıda giriniz. Bir ortadaki adam saldırısı tarafından kandırılmaya mâni olmak için imzadan, imzalı mesajın içeriğini aşan bir anlam çıkarmamaya dikkat ediniz.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Mesajı imzalamak için kullanılmış olan adres (mesela 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Belirtilen Bitcoin adresi ile imzalandığını doğrulamak için mesajı kontrol et</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>&amp;Mesaj kontrol et</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Tüm mesaj kontrolü alanlarını sıfırla</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Bitcoin adresi giriniz (mesela 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>İmzayı oluşturmak için &quot;Mesaj İmzala&quot; unsurunu tıklayın</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Girilen adres geçersizdir.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Adresi kontrol edip tekrar deneyiniz.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Girilen adres herhangi bir anahtara işaret etmemektedir.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Cüzdan kilidinin açılması iptal edildi.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Girilen adres için özel anahtar mevcut değildir.</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Mesajın imzalanması başarısız oldu.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Mesaj imzalandı.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>İmzanın kodu çözülemedi.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>İmzayı kontrol edip tekrar deneyiniz.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>İmza mesajın hash değeri ile eşleşmedi.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Mesaj doğrulaması başarısız oldu.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Mesaj doğrulandı.</translation>
     </message>
@@ -2666,17 +2115,14 @@ Adres: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Çekirdeği</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Çekirdeği geliştiricileri</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2684,7 +2130,6 @@ Adres: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2692,184 +2137,138 @@ Adres: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>%1 değerine dek açık</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>çakışma</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/çevrim dışı</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/doğrulanmadı</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 teyit</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Durum</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>, %n düğüm vasıtasıyla yayınlandı</numerusform><numerusform>, %n düğüm vasıtasıyla yayınlandı</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Tarih</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Kaynak</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Oluşturuldu</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Gönderen</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Alıcı</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>kendi adresiniz</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>etiket</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Gider</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>%n ek blok sonrasında olgunlaşacak</numerusform><numerusform>%n ek blok sonrasında olgunlaşacak</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>kabul edilmedi</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Gelir</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Muamele ücreti</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Net meblağ</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Yorum</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>Muamele tanımlayıcı</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>Tüccar</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>Oluşturulan bitcoin&apos;lerin harcanabilmelerinden önce %1 blok beklemeleri gerekmektedir. Bu blok, oluşturduğunuzda, blok zincirine eklenmesi için ağda yayınlandı. Zincire eklenmesi başarısız olursa, durumu &quot;kabul edilmedi&quot; olarak değiştirilecek ve harcanamayacaktır. Bu, bazen başka bir düğüm sizden birkaç saniye önce ya da sonra blok oluşturursa meydana gelebilir.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Hata ayıklama verileri</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Muamele</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>Girdiler</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Meblağ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>doğru</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>yanlış</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, henüz başarılı bir şekilde yayınlanmadı</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>%n ilâve blok için açık</numerusform><numerusform>%n ilâve blok için açık</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>bilinmiyor</translation>
     </message>
@@ -2877,12 +2276,10 @@ Adres: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Muamele detayları</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Bu pano muamelenin ayrıntılı açıklamasını gösterir</translation>
     </message>
@@ -2890,127 +2287,102 @@ Adres: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Tarih</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Tür</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Meblağ</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>Olgunlaşmamış (%1 teyit, %2 teyit ardından kullanılabilir olacaktır)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>%n ilâve blok için açık</numerusform><numerusform>%n ilâve blok için açık</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>%1 değerine dek açık</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Doğrulandı (%1 teyit)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Bu blok başka hiçbir düğüm tarafından alınmamıştır ve muhtemelen kabul edilmeyecektir!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Oluşturuldu ama kabul edilmedi</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>Çevrim dışı</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>Teyit edilmemiş</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>Teyit ediliyor (tavsiye edilen %2 teyit üzerinden %1 doğrulama)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>Çakışma</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Şununla alındı</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Alındığı kişi</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Gönderildiği adres</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Kendinize ödeme</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Madenden çıkarılan</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(mevcut değil)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Muamele durumu. Doğrulama sayısını görüntülemek için imleci bu alanda tutunuz.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Muamelenin alındığı tarih ve zaman.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Muamele türü.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Muamelenin alıcı adresi.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Bakiyeden alınan ya da bakiyeye eklenen meblağ.</translation>
     </message>
@@ -3018,178 +2390,142 @@ Adres: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Hepsi</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Bugün</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>Bu hafta</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>Bu ay</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Geçen ay</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Bu sene</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Aralık...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Şununla alınan</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Gönderildiği adres</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Kendinize</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Oluşturulan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Diğer</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Aranacak adres ya da etiket giriniz</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Asgari meblağ</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Adresi kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Etiketi kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Meblağı kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Muamele kimliğini kopyala</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Etiketi düzenle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Muamele detaylarını göster</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation>Muamele tarihçesini dışa aktar</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>Dışa aktarım başarısız oldu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>Muamele tarihçesinin %1 konumuna kaydedilmesi sırasında bir hata meydana geldi.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>Dışa aktarım başarılı oldu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>Muamele tarihçesi başarılı bir şekilde %1 konumuna kaydedildi.</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Virgülle ayrılmış değerler dosyası (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Doğrulandı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Tarih</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Tür</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Etiket</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Adres</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Meblağ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>Tanımlayıcı</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Aralık:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>ilâ</translation>
     </message>
@@ -3197,7 +2533,6 @@ Adres: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>Hiçbir cüzdan yüklenmemiştir.</translation>
     </message>
@@ -3205,7 +2540,6 @@ Adres: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Bitcoin yolla</translation>
     </message>
@@ -3213,42 +2547,34 @@ Adres: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp;Dışa aktar</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Güncel sekmedeki verileri bir dosyaya aktar</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Cüzdanı Yedekle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Cüzdan verileri (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Yedekleme başarısız oldu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>Cüzdan verilerinin %1 konumuna kaydedilmesi sırasında bir hata meydana geldi.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>Cüzdan verileri %1 konumuna başarıyla kaydedildi.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Yedekleme başarılı</translation>
     </message>
@@ -3256,107 +2582,86 @@ Adres: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Kullanım:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Komutları listele</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Bir komut için yardım al</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Seçenekler:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Yapılandırma dosyası belirt (varsayılan: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Pid dosyası belirt (varsayılan: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Veri dizinini belirt</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Veritabanı önbellek boyutunu megabayt olarak belirt (varsayılan: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Bağlantılar için dinlenecek &lt;port&gt; (varsayılan: 8333 ya da testnet: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Eşler ile en çok &lt;n&gt; adet bağlantı kur (varsayılan: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Eş adresleri elde etmek için bir düğüme bağlan ve ardından bağlantıyı kes</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Kendi genel adresinizi tanımlayın</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Aksaklık gösteren eşlerle bağlantıyı kesme sınırı (varsayılan: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Aksaklık gösteren eşlerle yeni bağlantıları engelleme süresi, saniye olarak (varsayılan: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>IPv4 üzerinde dinlemek için %u numaralı RPC portunun kurulumu sırasında hata meydana geldi: %s</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>JSON-RPC bağlantılarını &lt;port&gt; üzerinde dinle (varsayılan: 8332 veya tesnet: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Konut satırı ve JSON-RPC komutlarını kabul et</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation>Bitcoin Çekirdeği RPC istemci sürümü</translation>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Arka planda daemon (servis) olarak çalış ve komutları kabul et</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Deneme şebekesini kullan</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Dışarıdan gelen bağlantıları kabul et (varsayılan: -proxy veya -connect yoksa 1)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,722 +2686,682 @@ mesela: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.com
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>Kabul edilebilir şifreler (varsayılan: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>IPv6 üzerinde dinlemek için %u numaralı RPC portu kurulurken bir hata meydana geldi, IPv4&apos;e dönülüyor: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Belirtilen adrese bağlan ve daima ondan dinle. IPv6 için [makine]:port yazımını kullanınız</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>%s veri dizininde kilit elde edilemedi. Bitcoin muhtemelen hâlihazırda çalışmaktadır.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation>Devamlı olarak ücretsiz muameleleri dakikada &lt;n&gt;*1000 bayt olarak sınırla (varsayılan: 15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Anında çözümlenebilen bloklar içeren ve özel zincir kullanan regresyon test kipine gir. Bu, uygulama geliştirme ve regresyon testi araçları için tasarlanmıştır.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>Blokların anında çözülebileceği özel bir zincir kullanan regresyon deneme kipine gir.</translation>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation>Hata: İçeri gelen bağlantıların dinlenmesi başarısız oldu (dinleme %d hatası verdi)</translation>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Hata: Muamele reddedildi! Cüzdanınızdaki madenî paraların bazıları zaten harcanmış olduğunda bu meydana gelebilir. Örneğin wallet.dat dosyasının bir kopyasını kullandıysanız ve kopyada para harcandığında ancak burada harcandığı işaretlenmediğinde.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>Hata: Muamelenin meblağı, karmaşıklığı ya da yakın geçmişte alınan fonların kullanılması nedeniyle bu muamele en az %s tutarında ücret gerektirmektedir!</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>Bir cüzdan muamelesi değiştiğinde komutu çalıştır (komuttaki %s TxID ile değiştirilecektir)</translation>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation>Bundan düşük ücretler sıfır değerinde sayılır (muamele oluşturulması için) (varsayılan:</translation>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation>Veritabanı etkinliğini bellekten disk kütüğüne her &lt;n&gt; megabaytta aktar (varsayılan: 100)</translation>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation>-checkblocks&apos;un blok kontrolünün ne kadar kapsamlı olacağı (0 ilâ 4, varsayılan: 3)</translation>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation>Bu kipte -genproclimit kaç sayıda bloğun anında oluşturulduğunu kontrol eder.</translation>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation>Betik kontrolü iş parçacıklarının sayısını belirler (%u ilâ %d, 0 = otomatik, &lt;0 = bu sayıda çekirdeği kullanma, varsayılan: %d)</translation>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation>Oluşturma etkinken işlemci sınırını belirler (-1 = sınırsız, varsayılan: -1)</translation>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Bu yayın öncesi bir deneme sürümüdür - tüm riski siz üstlenmiş olursunuz - bitcoin oluşturmak ya da ticari uygulamalar için kullanmayınız</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation>Bu bilgisayarda %s unsuruna bağlanılamadı. Bitcoin Çekirdeği muhtemelen hâlihazırda çalışmaktadır.</translation>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>Eşlere gizli Tor servisleri ile ulaşmak için ayrı SOCKS5 vekil sunucusu kullan (varsayılan: -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Uyarı: -paytxfee çok yüksek bir değere ayarlanmış! Bu, muamele gönderirseniz ödeyeceğiniz muamele ücretidir.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Uyarı: Lütfen bilgisayarınızın tarih ve saatinin doğru olup olmadığını kontrol ediniz! Saatiniz doğru değilse Bitcoin gerektiği gibi çalışamaz.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>Uyarı: şebeke tamamen mutabık değil gibi görünüyor! Bazı madenciler sorun yaşıyor gibi görünüyor.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>Uyarı: eşlerimizle tamamen mutabık değiliz gibi görünüyor! Güncelleme yapmanız gerekebilir ya da diğer düğümlerin güncelleme yapmaları gerekebilir.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Uyarı: wallet.dat dosyasının okunması sırasında bir hata meydana geldi! Tüm anahtarlar doğru bir şekilde okundu, ancak muamele verileri ya da adres defteri unsurları hatalı veya eksik olabilir.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Uyarı: wallet.dat bozuk, veriler geri kazanıldı! Özgün wallet.dat, wallet.{zamandamgası}.bak olarak %s klasörüne kaydedildi; bakiyeniz ya da muameleleriniz yanlışsa bir yedeklemeden tekrar yüklemeniz gerekir.</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation>(varsayılan: 1)</translation>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation>(varsayılan: wallet.dat)</translation>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;kategori&gt; şunlar olabilir:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Bozuk bir wallet.dat dosyasından özel anahtarları geri kazanmayı dene</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>Bitcoin Çekirdek servisi</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation>Bitcoin RPC istemci sürümü</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Blok oluşturma seçenekleri:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>Cüzdanın muamele listesini temizle (tanı aracı; -rescan ima eder)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Sadece belirtilen düğüme veya düğümlere bağlan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>SOCKS vekil sunucusuyla bağlan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>&lt;port&gt; numarasında JSON-RPC&apos;ye bağlan (varsayılan: 8332 veya testnet: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation>Bağlantı seçenekleri:</translation>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Bozuk blok veritabanı tespit edildi</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation>Hata ayıklama/deneme seçenekleri:</translation>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation>Güvenli kipi devre dışı bırak, gerçek bir güvenli olayı geçersiz kıl (varsayılan: 0)</translation>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Kendi IP adresini keşfet (varsayılan: dinlenildiğinde ve -externalip yoksa 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>Cüzdanı yükleme ve cüzdan RPC çağrılarını devre dışı bırak</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Blok veritabanını şimdi yeniden inşa etmek istiyor musunuz?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Blok veritabanını başlatılırken bir hata meydana geldi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>%s cüzdan veritabanı ortamının başlatılmasında hata meydana geldi!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Blok veritabanının yüklenmesinde hata</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Blok veritabanının açılışı sırasında hata</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Hata: Disk alanı düşük!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Hata: Cüzdan kilitli, muamele oluşturulamadı!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Hata: sistem hatası:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Herhangi bir portun dinlenmesi başarısız oldu. Bunu istiyorsanız -listen=0 seçeneğini kullanınız.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Blok verileri okunamadı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Blok okunamadı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Blok indeksi eşleştirilemedi</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Blok indeksi yazılamadı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Blok verileri yazılamadı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Blok yazılamadı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Dosya verileri yazılamadı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Madenî para veritabanına yazılamadı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Muamele indeksi yazılamadı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Geri alma verilerinin yazılamadı</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Yolladığınız muameleler için eklenecek kB başı ücret</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation>Bundan düşük ücretler sıfır değerinde sayılacaktır (aktarım için) (varsayılan:</translation>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Eşleri DNS araması vasıtasıyla bul (varsayılan: 1, eğer -connect kullanılmadıysa)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation>Güvenli kipi zorla (varsayılan: 0)</translation>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Bitcoin oluştur (varsayılan: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Başlangıçta kontrol edilecek blok sayısı (varsayılan: 288, 0 = hepsi)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Blok kontrolünün ne kadar derin olacağı (0 ilâ 4, varsayılan: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>&lt;kategori&gt; sağlanmamışsa tüm hata ayıklama verilerini dök.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>Yanlış ya da bulunamamış doğuş bloku. Şebeke için yanlış veri klasörü mü?</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>Geçersiz -onion adresi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Kafi derecede dosya tanımlayıcıları mevcut değil.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>Hata ayıklama verilerinin önüne zaman damgası ekle (varsayılan: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation>RPC istemci seçenekleri:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>Blok zinciri indeksini güncel blk000??.dat dosyalarından tekrar inşa et</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>-proxy için SOCKS sürümünü seç (4 veya 5, varsayılan: 5)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Bitcoin sunucusuna komut gönder</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation>Veritabanı önbellek boyutunu megabayt olarak belirt (%d ilâ %d, varsayılan: %d)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>Azami blok boyutunu bayt olarak ayarla (varsayılan: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>RPC aramaları için iş parçacığı sayısını belirle (varsayılan: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>Cüzdan dosyası belirtiniz (veri klasörünün içinde)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>Gönderme muamelelerinde teyit edilmemiş para üstünü harca (varsayılan: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Bitcoin sunucusunu başlat</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>Bu, regresyon deneme araçları ve uygulama geliştirmesi için tasarlanmıştır. </translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Kullanım (önerilmemektedir, bitcoin-cli kullanın):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Bloklar kontrol ediliyor...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Cüzdan kontrol ediliyor...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>RPC sunucusunun başlamasını bekle</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>%s cüzdan %s veri klasörünün dışında bulunuyor</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>Cüzdan seçenekleri:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>Uyarı: eskimiş seçenek -debugnet görmezden gelinir, -debug=net kullanınız</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>-txindex&apos;i değiştirmek için veritabanını -reindex kullanarak tekrar inşa etmeniz gerekmektedir</translation>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Harici blk000??.dat dosyasından blokları içe aktarır</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation>%s veri dizininde kilit elde edilemedi. Bitcoin Çekirdeği muhtemelen hâlihazırda çalışmaktadır.</translation>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>İlgili bir uyarı alındığında ya da gerçekten uzun bir çatallama gördüğümüzde komutu çalıştır (komuttaki %s mesaj ile değiştirilir)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>Hata ayıklama bilgisi dök (varsayılan:0, &lt;kategori&gt; sağlanması seçime dayalıdır)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>Yüksek öncelikli/düşük ücretli muamelelerin azami boyutunu bayt olarak ayarla (varsayılan: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Betik kontrolü iş parçacığı sayısını belirt (azami 16, 0 = otomatik, &lt;0 = bu sayıda çekirdeği boş bırak, varsayılan: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Bilgi</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-minrelaytxfee=&lt;amount&gt; için geçersiz meblağ: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-mintxfee=&lt;amount&gt; için geçersiz meblağ: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation>İmza arabelleğinin boyutunu &lt;n&gt; unsurla sınırla (varsayılan: 50000)</translation>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation>Blok oluşturulduğunda muamele önceliğini ve kB başı ücreti kütüğe al (varsayılan: 0)</translation>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Muamelelerin tamamının indeksini tut (varsayılan: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Bağlantı başına azami alım tamponu, &lt;n&gt;*1000 bayt (varsayılan: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Bağlantı başına azami yollama tamponu, &lt;n&gt;*1000 bayt (varsayılan: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Sadece yerleşik kontrol noktalarıyla eşleşen blok zincirini kabul et (varsayılan: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Sadece &lt;net&gt; şebekesindeki düğümlere bağlan (IPv4, IPv6 ya da Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation>Başlangıçta bloğu göster, blok indeksinde bulunduysa</translation>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation>Başlangıçta blok ağacını göster (varsayılan: 0)</translation>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation>RPC SSL seçenekleri: (SSL kurulumu yönergeleri için Bitcoin vikisine bakınız)</translation>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation>RPC sunucu seçenekleri:</translation>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation>Her &lt;n&gt; şebeke mesajından rastgele 1 mesajı görmezden gel</translation>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation>Her &lt;n&gt; şebeke mesajından rastgele birini bulanıklaştır</translation>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation>Periyodik olarak cüdanı diske yazdırmak için bir iş parçacığı çalıştır (varsayılan: 1)</translation>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation> SSL seçenekleri: (SSL kurulum bilgisi için Bitcoin vikisine bakınız)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation>Bitcoin Çekirdeğine komut yolla</translation>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Trace/hata ayıklama verilerini debug.log dosyası yerine konsola gönder</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Bayt olarak asgari blok boyutunu tanımla (varsayılan: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation>Cüzdan veritabanı ortamında DB_PRIVATE bayrağını koyar (varsayılan: 1)</translation>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation>Tüm hata ayıklama seçeneklerini göster (kullanımı: --help -help-debug)</translation>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation>Denektaşı verilerini göster (varsayılan: 0)</translation>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>İstemci başlatıldığında debug.log dosyasını küçült (varsayılan: -debug bulunmadığında 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Muamelenin imzalanması başarısız oldu</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Bağlantı zaman aşım süresini milisaniye olarak belirt (varsayılan: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation>Bitcoin Çekirdeği servisini başlat</translation>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Sistem hatası:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Muamele meblağı çok düşük</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Muamele tutarının pozitif olması lazımdır</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Muamele çok büyük</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Dinlenecek portu haritalamak için UPnP kullan (varsayılan: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Dinlenecek portu haritalamak için UPnP kullan (varsayılan: dinlenildiğinde 1)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>JSON-RPC bağlantıları için kullanıcı ismi</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Uyarı</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Uyarı: Bu sürüm çok eskidir, güncellemeniz gerekir!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Cüzdandaki tüm muameleler kaldırılıyor...</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation>başlangıçta</translation>
+    </message>
+    <message>
         <source>version</source>
         <translation>sürüm</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat bozuk, geri kazanım başarısız oldu</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>JSON-RPC bağlantıları için parola</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Belirtilen İP adresinden JSON-RPC bağlantılarını kabul et</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Şu &lt;ip&gt; adresinde (varsayılan: 127.0.0.1) çalışan düğüme komut yolla</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>En iyi blok değiştiğinde komutu çalıştır (komut için %s parametresi blok hash değeri ile değiştirilecektir)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Cüzdanı en yeni biçime güncelle</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Anahtar alan boyutunu &lt;n&gt; değerine ayarla (varsayılan: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Blok zincirini eksik cüzdan muameleleri için tekrar tara</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>JSON-RPC bağlantıları için OpenSSL (https) kullan</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Sunucu sertifika dosyası (varsayılan: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Sunucu özel anahtarı (varsayılan: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Bu yardım mesajı</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Bu bilgisayarda %s unsuruna bağlanılamadı. (bind şu hatayı iletti: %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>-addnode, -seednode ve -connect için DNS aramalarına izin ver</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Adresler yükleniyor...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>wallet.dat dosyasının yüklenmesinde hata oluştu: bozuk cüzdan</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>wallet.dat dosyasının yüklenmesinde hata oluştu: cüzdanın daha yeni bir Bitcoin sürümüne ihtiyacı var</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Cüzdanın tekrar yazılması gerekiyordu: işlemi tamamlamak için Bitcoin&apos;i yeniden başlatınız</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>wallet.dat dosyasının yüklenmesinde hata oluştu</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Geçersiz -proxy adresi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>-onlynet için bilinmeyen bir şebeke belirtildi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>Bilinmeyen bir -socks vekil sürümü talep edildi: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>-bind adresi çözümlenemedi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>-externalip adresi çözümlenemedi: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-paytxfee=&lt;meblağ&gt; için geçersiz meblağ: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Geçersiz meblağ</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Yetersiz bakiye</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Blok indeksi yükleniyor...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Bağlanılacak düğüm ekle ve bağlantıyı zinde tutmaya çalış</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Bu bilgisayarda %s unsuruna bağlanılamadı. Bitcoin muhtemelen hâlihazırda çalışmaktadır.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Cüzdan yükleniyor...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Cüzdan eski biçime geri alınamaz</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Varsayılan adres yazılamadı</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Yeniden tarama...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Yükleme tamamlandı</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>%s seçeneğini kullanmak için</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_uk.ts
+++ b/src/qt/locale/bitcoin_uk.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,141 +24,113 @@ This product includes software developed by the OpenSSL Project for use in the O
 Цей продукт включає в себе програмне забезпечення, розроблене в рамках проекту OpenSSL (http://www.openssl.org/), криптографічне програмне забезпечення, написане Еріком Янгом (eay@cryptsoft.com), та функції для роботи з UPnP, написані Томасом Бернардом.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>Авторське право</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Двічі клікніть на адресу чи назву для їх зміни</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Створити нову адресу</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Копіювати виділену адресу в буфер обміну</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>&amp;Скопіювати адресу</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation>Вилучити вибрані адреси з переліку</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Експортувати дані з поточної вкладки в файл</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>&amp; Експорт</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Видалити</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>Це ваші Bitcoin адреси для відправки платежів. Перед відправкою монети Завжди перевіряйте суму та адресу прийому.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>Скопіювати &amp;мітку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>&amp;Редагувати</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Файли відділені комами (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(немає назви)</translation>
     </message>
@@ -187,140 +153,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>Діалог введення паролю</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>Введіть пароль</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>Новий пароль</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>Повторіть пароль</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>Введіть новий пароль для гаманця.&lt;br/&gt;Будь ласка, використовуйте паролі що містять &lt;b&gt;як мінімум 10 випадкових символів&lt;/b&gt;, або &lt;b&gt;як мінімум 8 слів&lt;/b&gt;.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>Зашифрувати гаманець</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>Ця операція потребує пароль для розблокування гаманця.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>Розблокувати гаманець</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>Ця операція потребує пароль для дешифрування гаманця.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>Дешифрувати гаманець</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>Змінити пароль</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>Ввести старий та новий паролі для гаманця.</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>Підтвердити шифрування гаманця</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>УВАГА: Якщо ви зашифруєте гаманець і забудете пароль, ви &lt;b&gt;ВТРАТИТЕ ВСІ СВОЇ БІТКОІНИ&lt;/b&gt;!</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>Ви дійсно хочете зашифрувати свій гаманець?</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>ВАЖЛИВО: Всі попередні резервні копії, які ви зробили з вашого гаманця файл повинен бути замінений новоствореному, зашифрованому файлі гаманця. З міркувань безпеки, попередні резервні копії в незашифрованому файлі гаманець стане марним, як тільки ви починаєте використовувати нову, зашифрований гаманець.</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>Увага: Ввімкнено Caps Lock!</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>Гаманець зашифровано</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>Біткоін-клієнт буде закрито для завершення процесу шифрування. Пам&apos;ятайте, що шифрування гаманця не може повністю захистити ваші біткоіни від крадіжки, у випадку якщо ваш комп&apos;ютер буде інфіковано шкідливими програмами.</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>Не вдалося зашифрувати гаманець</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>Виникла помилка під час шифрування гаманця. Ваш гаманець не було зашифровано.</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>Введені паролі не співпадають.</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>Не вдалося розблокувати гаманець</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>Введений пароль є невірним.</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>Не вдалося розшифрувати гаманець</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>Пароль було успішно змінено.</translation>
     </message>
@@ -328,362 +260,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation>&amp;Підписати повідомлення...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>Синхронізація з мережею...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>&amp;Огляд</translation>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation>Показати загальний огляд гаманця</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>Транзакції</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>Переглянути історію транзакцій</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>&amp;Вихід</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>Показати інформацію про Bitcoin</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>&amp;Про Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>Показати інформацію про Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>&amp;Параметри...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>&amp;Шифрування гаманця...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>&amp;Резервне копіювання гаманця...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>Змінити парол&amp;ь...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>Імпорт блоків з диску...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>Переіндексація блоків на диску ...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>Відправити монети на вказану адресу</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>Редагувати параметри</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>Резервне копіювання гаманця в інше місце</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>Змінити пароль, який використовується для шифрування гаманця</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>Вікно зневадження</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>Відкрити консоль зневадження і діагностики</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>Перевірити повідомлення...</translation>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation>Гаманець</translation>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation>&amp;Відправити</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>&amp;Отримати</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>Показати / Приховати</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>Показує або приховує головне вікно</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>Шифрування закритих ключів, які належать вашому гаманці</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>Підтвердіть, що Ви є власником повідомлення підписавши його Вашою Bitcoin-адресою </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>Перевірте повідомлення для впевненості, що воно підписано вказаною Bitcoin-адресою</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>&amp;Файл</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>&amp;Налаштування</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>&amp;Довідка</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>Панель вкладок</translation>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation>[тестова мережа]</translation>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Ядро</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>Bitcoin-клієнт</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n активне з&apos;єднання з мережею</numerusform><numerusform>%n активні з&apos;єднання з мережею</numerusform><numerusform>%n активних з&apos;єднань з мережею</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>Ні блок джерела доступні ...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>Оброблено %1 блоків історії транзакцій.</translation>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>Угоди після цього буде ще не буде видно.</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>Увага</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>Інформація</translation>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation>Синхронізовано</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation>Синхронізується...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>Надіслані транзакції</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>Отримані перекази</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -696,17 +552,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>&lt;b&gt;Зашифрований&lt;/b&gt; гаманець &lt;b&gt;розблоковано&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>&lt;b&gt;Зашифрований&lt;/b&gt; гаманець &lt;b&gt;заблоковано&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>Сталася фатальна помилка. Bitcoin більше не може продовжувати безпечно і піде.</translation>
     </message>
@@ -714,7 +567,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation>Сповіщення мережі</translation>
     </message>
@@ -722,291 +574,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>Кількість:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Кількість</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>Підтверджені</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation>Скопіювати адресу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Скопіювати мітку</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>Копіювати кількість</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>Копіювати ID транзакції </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(немає назви)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1014,67 +805,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>Редагувати адресу</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>&amp;Мітка</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>&amp;Адреса</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>Нова адреса для отримання</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>Нова адреса для відправлення</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>Редагувати адресу для отримання</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>Редагувати адресу для відправлення</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>Введена адреса «%1» вже присутня в адресній книзі.</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>Введена адреса «%1» не є коректною адресою в мережі Bitcoin.</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>Неможливо розблокувати гаманець.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>Не вдалося згенерувати нові ключі.</translation>
     </message>
@@ -1082,27 +860,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>назва</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1110,52 +883,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Ядро</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>версія</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>Використання:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>параметри командного рядка</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>Параметри інтерфейсу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>Встановлення мови, наприклад &quot;de_DE&quot; (типово: системна)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>Запускати згорнутим</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>Показувати заставку під час запуску (типово: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1163,57 +930,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>Вітання</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>ГБ вільного простору доступно</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1221,27 +977,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1249,253 +1000,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>&amp;Головні</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>Оплата додаткових транзакцій за Кб, що допомагає переконатися, що ваші транзакції обробляються швидко. Велика частина операцій проводиться 1 Кб.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>Заплатити комісі&amp;ю</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>Автоматично запускати гаманець при вході до системи.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>&amp;Запускати гаманець при вході в систему</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Встановіть кількість перевірки скрипт потоків (до 16, 0 = авто, &lt;0 = залишити, що багато сердечники безкоштовно, за замовчуванням: 0)</translation>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>Скинути всі параметри клієнта на типові.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>Скинути параметри</translation>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation>&amp;Мережа</translation>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>Автоматично відкривати порт для клієнту біткоін на роутері. Працює лише якщо ваш роутер підтримує UPnP і ця функція увімкнена.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>Відображення порту через &amp;UPnP</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>&amp;IP проксі:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>&amp;Порт:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>Порт проксі-сервера (наприклад 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS версії:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Версія SOCKS-проксі (наприклад 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>&amp;Вікно</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>Показувати лише іконку в треї після згортання вікна.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>Мінімізувати &amp;у трей</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>Згортати замість закриття. Якщо ця опція включена, програма закриється лише після вибору відповідного пункту в меню.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>Згортати замість закритт&amp;я</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>&amp;Відображення</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>Мова інтерфейсу користувача:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>Встановлює мову інтерфейсу. Зміни набудуть чинності після перезапуску Bitcoin.</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>В&amp;имірювати монети в:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>Виберіть одиницю вимірювання монет, яка буде відображатись в гаманці та при відправленні.</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>Незалежно від того, щоб показати Bitcoin адреси в списку транзакцій чи ні.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>&amp;Відображати адресу в списку транзакцій</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation>&amp;Гаразд</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Скасувати</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation>типово</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation>Підтвердження скидання параметрів</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>Невірно вказано адресу проксі.</translation>
     </message>
@@ -1503,69 +1207,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>Форма</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>Показана інформація вже може бути застарілою. Ваш гаманець буде автоматично синхронізовано з мережею Bitcoin після встановлення підключення, але цей процес ще не завершено.</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>Гаманець</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>Ваш поточний баланс расходуемого</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>Всього угод, які ще мають бути підтверджені, і до цих пір не враховуються в расходуемого балансу</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>незрілі:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>Замінований баланс, який ще не дозрів</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>всього:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>Ваше поточне Сукупний баланс</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;Недавні транзакції&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>не синхронізовано</translation>
     </message>
@@ -1573,93 +1262,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>Обробка URI</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>Неможливо обробити URI! Це може бути викликано неправильною Bitcoin-адресою, чи невірними параметрами URI.</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1667,23 +1333,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation>Bitcoin</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Введіть адресу Bitcoin (наприклад 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1691,22 +1356,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Зберегти зображення...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>&amp;Копіювати зображення</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>Зберегти QR-код</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1714,192 +1375,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>Назва клієнту</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation>Н/Д</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>Версія клієнту</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>&amp;Інформація</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>Використовується OpenSSL версії</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>Час запуску</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>Мережа</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>Ім’я</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>Кількість підключень</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>Ланцюг блоків</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>Поточне число блоків</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>Розрахункове число блоків</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>Час останнього блоку</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>Консоль</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>Дата збирання</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>Файл звіту зневадження</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>Відкрийте налагодження файл журналу Bitcoin з поточного каталогу даних. Це може зайняти кілька секунд для великих файлів журналів.</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>Очистити консоль</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>Вітаємо у консолі Bitcoin RPC.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>Використовуйте стрілки вгору вниз для навігації по історії, і &lt;b&gt;Ctrl-L&lt;/b&gt; для очищення екрана.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>Наберіть &lt;b&gt;help&lt;/b&gt; для перегляду доступних команд.</translation>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1907,105 +1522,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>&amp;Кількість:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>&amp;Мітка:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>&amp;Повідомлення:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>Очистити всі поля в формі</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>Очистити</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation>Скопіювати мітку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Копіювати кількість</translation>
     </message>
@@ -2013,67 +1605,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR-Код</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>&amp;Зберегти зображення...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Кількість</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>Повідомлення</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>Кінцевий URI занадто довгий, спробуйте зменшити текст для мітки / повідомлення.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>Помилка при кодуванні URI в QR-код.</translation>
     </message>
@@ -2081,37 +1660,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Назва</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>Повідомлення</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Кількість</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(немає назви)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2119,247 +1691,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>Відправити</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>Кількість:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>Відправити на декілька адрес</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>Дод&amp;ати одержувача</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>Очистити всі поля в формі</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>Очистити &amp;все</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation>Баланс:</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation>Підтвердити відправлення</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>&amp;Відправити</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>Підтвердіть відправлення</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Копіювати кількість</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>Адреса отримувача невірна, будь ласка перепровірте.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>Кількість монет для відправлення повинна бути більшою 0.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>Кількість монет для відправлення перевищує ваш баланс.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>Сума перевищить ваш баланс, якщо комісія %1 буде додана до вашої транзакції.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>Знайдено адресу що дублюється. Відправлення на кожну адресу дозволяється лише один раз на кожну операцію переказу.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(немає назви)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>Ви впевнені, що хочете відправити?</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2367,98 +1886,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>&amp;Кількість:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>&amp;Отримувач:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Звернення до відправити платіж на (наприклад 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>Введіть мітку для цієї адреси для додавання її в адресну книгу</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>&amp;Мітка:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>Обрати ранiш використовувану адресу</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>Вставити адресу</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>Повідомлення:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>Нотатка:</translation>
     </message>
@@ -2466,12 +1961,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2479,186 +1972,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>Підписи - Підпис / Перевірка повідомлення</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>&amp;Підписати повідомлення</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>Ви можете зареєструватися повідомленнями зі своїми адресами, щоб довести, що ви є їх власником. Будьте обережні, щоб не підписувати що-небудь неясне, як фішинг-атак може спробувати обдурити вас в підписанні вашу особистість до них. Тільки підписати повністю докладні свідчення, користувач зобов&apos;язується.</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Введіть адресу Bitcoin (наприклад 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>Обрати ранiш використовувану адресу</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>Вставити адресу</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>Введіть повідомлення, яке ви хочете підписати тут</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>Підпис</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>Копіювати поточну сигнатуру до системного буферу обміну</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>Підпишіть повідомлення щоб довести, що ви є власником цієї адреси</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>&amp;Підписати повідомлення</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>Скинути всі поля підпису повідомлення</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>Очистити &amp;все</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>Перевірити повідомлення</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>Введіть адресу підписання, повідомлення (забезпечення копіюванні розриви рядків, прогалини, вкладки і т.д. точно) і підпис нижче, щоб перевірити повідомлення. Будьте обережні, щоб не читати далі в підпис, ніж те, що в підписаному самого повідомлення, щоб уникнути обдурять нападу чоловік-в-середній.</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Введіть адресу Bitcoin (наприклад 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>Перевірте повідомлення для впевненості, що воно підписано вказаною Bitcoin-адресою</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>Перевірити повідомлення</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>Скинути всі поля перевірки повідомлення</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>Введіть адресу Bitcoin (наприклад 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>Натисніть кнопку «Підписати повідомлення», для отримання підпису</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>Введена нечинна адреса.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>Будь ласка, перевірте адресу та спробуйте ще.</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>Введений адреса не відноситься до ключа.</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>Розблокування Гаманець був скасований.</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>Приватний ключ для введеної адреси недоступний. </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>Не вдалося підписати повідомлення.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>Повідомлення підписано.</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>Підпис не можливо декодувати.</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>Будь ласка, перевірте підпис та спробуйте ще.</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>Підпис не відповідає дайджест повідомлення.</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>Не вдалося перевірити повідомлення.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>Повідомлення перевірено.</translation>
     </message>
@@ -2666,17 +2115,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation>Bitcoin Ядро</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[тестова мережа]</translation>
     </message>
@@ -2684,7 +2130,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>КБ/с</translation>
     </message>
@@ -2692,184 +2137,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>Відкрити до %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1/поза інтернетом</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/не підтверджено</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 підтверджень</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>Статус</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>Джерело</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>Згенеровано</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>Відправник</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>Отримувач</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>Власна адреса</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>Мітка</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>Кредит</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>не прийнято</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>Дебет</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>Комісія за транзакцію</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>Загальна сума</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>Повідомлення</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>Коментар</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>ID транзакції</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>Отладочна інформація</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>Транзакція</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>витрати</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Кількість</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>true</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>false</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>, ще не було успішно розіслано</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>невідомий</translation>
     </message>
@@ -2877,12 +2276,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>Деталі транзакції</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>Даний діалог показує детальну статистику по вибраній транзакції</translation>
     </message>
@@ -2890,127 +2287,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Кількість</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>Відкрити до %1</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>Підтверджено (%1 підтверджень)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>Цей блок не був отриманий жодними іншими вузлами і, ймовірно, не буде прийнятий!</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>Згенеровано, але не підтверджено</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>Отримано</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>Отримано від</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>Відправлено</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>Відправлено собі</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>Добуто</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(недоступно)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>Статус транзакції. Наведіть вказівник на це поле, щоб показати кількість підтверджень.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>Дата і час, коли транзакцію було отримано.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>Тип транзакції.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>Адреса отримувача транзакції.</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>Сума, додана чи знята з балансу.</translation>
     </message>
@@ -3018,178 +2390,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>Всі</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>Сьогодні</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>На цьому тижні</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>На цьому місяці</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>Минулого місяця</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>Цього року</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>Проміжок...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>Отримані на</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>Відправлені на</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>Відправлені собі</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>Добуті</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>Інше</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>Введіть адресу чи мітку для пошуку</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>Мінімальна сума</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>Скопіювати адресу</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>Скопіювати мітку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>Копіювати кількість</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>Копіювати ID транзакції </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>Редагувати мітку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>Показати деталі транзакції</translation>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Файли, розділені комою (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>Підтверджені</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>Дата</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>Тип</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Мітка</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Адреса</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Кількість</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>Ідентифікатор</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>Діапазон від:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>до</translation>
     </message>
@@ -3197,7 +2533,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3205,7 +2540,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>Відправити</translation>
     </message>
@@ -3213,42 +2547,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation>&amp; Експорт</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>Експортувати дані з поточної вкладки в файл</translation>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation>Зробити резервне копіювання гаманця</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>Данi гаманця (*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>Помилка резервного копіювання</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>Успішне створення резервної копії</translation>
     </message>
@@ -3256,107 +2582,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation>Використання:</translation>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation>Список команд</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>Отримати довідку по команді</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation>Параметри:</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>Вкажіть файл конфігурації (типово: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>Вкажіть pid-файл (типово: bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>Вкажіть робочий каталог</translation>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation>Встановити розмір кешу бази даних в мегабайтах (типово: 25)</translation>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>Чекати на з&apos;єднання на &lt;port&gt; (типово: 8333 або тестова мережа: 18333)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>Підтримувати не більше &lt;n&gt; зв&apos;язків з колегами (типово: 125)</translation>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>Підключитись до вузла, щоб отримати список адрес інших учасників та від&apos;єднатись</translation>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation>Вкажіть вашу власну публічну адресу</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>Поріг відключення неправильно під&apos;єднаних пірів (типово: 100)</translation>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>Максимальній розмір вхідного буферу на одне з&apos;єднання (типово: 86400)</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>Прослуховувати &lt;port&gt; для JSON-RPC-з&apos;єднань (типово: 8332 або тестова мережа: 18332)</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>Приймати команди із командного рядка та команди JSON-RPC</translation>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>Запустити в фоновому режимі (як демон) та приймати команди</translation>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation>Використовувати тестову мережу</translation>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>Приймати з&apos;єднання ззовні (за замовчуванням: 1, якщо ні-проксі або-з&apos;єднання)</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3371,722 +2676,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>Прив&apos;язка до даного адресою і завжди слухати на ньому. Використовуйте [господаря]: позначення порту для IPv6</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
-        <translation>Не вдалося отримати блокування на каталог даних% с. Bitcoin, ймовірно, вже запущений.</translation>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>Введіть тестовий режим регресії, яка використовує спеціальну ланцюг, в якій блоки можуть бути вирішені негайно. Це призначено для регресійного тестування інструментів і розробки додатків.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>Помилка: транзакцію було відхилено. Це може статись, якщо декілька монет з вашого гаманця вже використані, наприклад, якщо ви використовуєте одну копію гаманця (wallet.dat), а монети були використані з іншої копії, але не позначені як використані в цій.</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>Це тест збірки попередньою версією - використовуйте на свій страх і ризик - не використовувати для гірничодобувних або торгових додатків</translation>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>Увага: встановлено занадто велику комісію (-paytxfee). Комісія зніматиметься кожен раз коли ви проводитимете транзакції.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>Увага: будь ласка, перевірте дату і час на своєму комп&apos;ютері. Якщо ваш годинник йде неправильно, Bitcoin може працювати некоректно.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>Увага: помилка читання wallet.dat! Всі ключі прочитано коректно, але дані транзакцій чи записи адресної книги можуть бути пропущені, або пошкоджені.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>Увага: файл wallet.dat пошкоджено, дані врятовано! Оригінальний wallet.dat збережено як wallet.{timestamp}.bak до %s; якщо Ваш баланс чи транзакції неправильні, Ви можете відновити їх з резервної копії. </translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>Спроба відновити закриті ключі з пошкодженого wallet.dat</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation>Опції створення блоку:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>Підключитись лише до вказаного вузла</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation>Виявлено пошкоджений блок бази даних</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>Відкрийте власну IP-адресу (за замовчуванням: 1, коли не чує і-externalip)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>Ви хочете перебудувати базу даних блоку зараз?</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>Помилка ініціалізації бази даних блоків</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>Помилка завантаження бази даних блоків</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>Помилка відкриття блоку бази даних </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>Помилка: Мало вільного місця на диску!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>Помилка: Гаманець заблокований, неможливо створити транзакцію!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>Помилка: системна помилка: </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>Не вдалося слухати на будь-якому порту. Використовуйте-слухати = 0, якщо ви хочете цього.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>Не вдалося розпізнати блок інформації </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>Не вдалося розпізнати блок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>Не вдалося синхронізувати індекс блоку </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>Не вдалося записати індекс блоку</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>Не вдалося записати інформацію індекса</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>Не вдалося записати блок</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>Не вдалося записати інформацію файла</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>Не вдалося записати до бази даних монет</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>Не вдалося записати індекс транзакції</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>Не вдалося записати скасувати дані</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>Комісія за Кб</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>Знайти однолітків за допомогою DNS пошук (за замовчуванням: 1, якщо-ні підключити)</translation>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation>Генерація монети (за замовчуванням: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>Скільки блоків перевіряти під час запуску (типово: 288, 0 = всі)</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation>Як ретельне блок перевірка (0-4, за замовчуванням: 3)</translation>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation>Бракує дескрипторів файлів, доступних.</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
-        <translation>Надіслати команду серверу Біткойну</translation>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
+        <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>Встановити число потоків до дзвінків служба RPC (за замовчуванням: 4)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation>Запустити сервер Біткойну</translation>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>Використання (застаріле, використовуйте bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>Перевірка блоків...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>Перевірка гаманця... </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>Імпорт блоків з зовнішнього файлу blk000??.dat</translation>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation>Встановіть кількість перевірки скрипт потоків (до 16, 0 = авто, &lt;0 = залишити, що багато сердечники безкоштовно, за замовчуванням: 0)</translation>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation>Інформація</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>Підтримувати індекс повний транзакцій (за замовчуванням: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>Максимальний буфер, &lt;n&gt;*1000 байт (типово: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>Максимальній розмір вихідного буферу на одне з&apos;єднання, &lt;n&gt;*1000 байт (типово: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>Тільки приймати блок відповідності ланцюга вбудованих контрольно-пропускних пунктів (за замовчуванням: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>Підключити тільки до вузлів в мережі &lt;net&gt; (IPv4, IPv6 або Tor)</translation>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>Параметри SSL: (див. Bitcoin Wiki для налаштування SSL)</translation>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>Відсилати налагоджувальну інформацію на консоль, а не у файл debug.log</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>Встановити мінімальний розмір блоку у байтах (типово: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>Стискати файл debug.log під час старту клієнта (типово: 1 коли відсутутній параметр -debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>Підписання угоди не вдалося</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>Вказати тайм-аут підключення у мілісекундах (типово: 5000)</translation>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation>Системна помилка: </translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>Сума угоди занадто малий</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>Суми угоди має бути позитивним</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>Угода занадто великий</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>Намагатись використовувати UPnP для відображення порту, що прослуховується на роутері (default: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>Намагатись використовувати UPnP для відображення порту, що прослуховується на роутері (default: 1 when listening)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>Ім&apos;я користувача для JSON-RPC-з&apos;єднань</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>Попередження</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>Увага: Поточна версія застаріла, необхідне оновлення!</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation>версія</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>wallet.dat пошкоджено, відновлення не вдалося</translation>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation>Пароль для JSON-RPC-з&apos;єднань</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>Дозволити JSON-RPC-з&apos;єднання з вказаної IP-адреси</translation>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>Відправляти команди на вузол, запущений на &lt;ip&gt; (типово: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>Виконати команду, коли з&apos;явиться новий блок (%s в команді змінюється на хеш блоку)</translation>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation>Модернізувати гаманець до останнього формату</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>Встановити розмір пулу ключів &lt;n&gt; (типово: 100)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>Пересканувати ланцюжок блоків, в пошуку втрачених транзакцій</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>Використовувати OpenSSL (https) для JSON-RPC-з&apos;єднань</translation>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>Файл сертифіката сервера (типово: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>Закритий ключ сервера (типово: server.pem)</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation>Дана довідка</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>Неможливо прив&apos;язати до порту %s на цьому комп&apos;ютері (bind returned error %d, %s)</translation>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>Дозволити пошук в DNS для команд -addnode, -seednode та -connect</translation>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation>Завантаження адрес...</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>Помилка при завантаженні wallet.dat: Гаманець пошкоджено</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>Помилка при завантаженні wallet.dat: Гаманець потребує новішої версії Біткоін-клієнта</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>Потрібно перезаписати гаманець: перезапустіть Біткоін-клієнт для завершення</translation>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation>Помилка при завантаженні wallet.dat</translation>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>Помилка в адресі проксі-сервера: «%s»</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>Невідома мережа вказана в -onlynet: «%s»</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>В параметрі -socks запитується невідома версія: %i</translation>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>Помилка у величині комісії -paytxfee=&lt;amount&gt;: «%s»</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>Некоректна кількість</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>Недостатньо коштів</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation>Завантаження індексу блоків...</translation>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>Додати вузол до підключення і лишити його відкритим</translation>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation>Неможливо прив&apos;язати до порту %s на цьому комп&apos;ютері. Можливо гаманець вже запущено.</translation>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation>Завантаження гаманця...</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation>Не вдається понизити версію гаманця</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>Неможливо записати типову адресу</translation>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation>Сканування...</translation>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation>Завантаження завершене</translation>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation>Щоб використати опцію %s</translation>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_ur_PK.ts
+++ b/src/qt/locale/bitcoin_ur_PK.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,18 +19,14 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -41,122 +34,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>ایڈریس یا لیبل میں ترمیم کرنے پر ڈبل کلک کریں</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>نیا ایڈریس بنائیں</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>چٹ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation> پتہ</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>چٹ کے بغیر</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>پاس فریز داخل کریں</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>نیا پاس فریز</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>نیا پاس فریز دہرائیں</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>بٹوا ان لاک</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>خفیہ کشائی کر یںبٹوے کے</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>پاس فریز تبدیل کریں</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,363 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>نقص</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -688,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -706,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -714,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>رقم</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation> پتہ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>چٹ کے بغیر</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1006,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1074,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1102,57 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1160,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>نقص</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1218,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1246,258 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1505,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1575,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1669,29 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1699,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1722,194 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1917,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2023,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation> پتہ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>رقم</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>چٹ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2091,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>چٹ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>رقم</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>چٹ کے بغیر</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2129,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>بیلنس:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>چٹ کے بغیر</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2377,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2476,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2489,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2676,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2694,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2702,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>رقم</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2887,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2900,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>ٹائپ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation> پتہ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>رقم</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>کو بھیجا</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(N / A)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3028,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>تمام</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>آج</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>اس ہفتے</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>اس مہینے</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>پچھلے مہینے</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>اس سال</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>دیگر</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>کو بھیجا</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>تاریخ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>ٹائپ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>چٹ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation> پتہ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>رقم</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3207,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3215,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3223,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3266,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,852 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>یہ مدد کا پیغام</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>غلط رقم</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>ناکافی فنڈز</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>نقص</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_uz@Cyrl.ts
+++ b/src/qt/locale/bitcoin_uz@Cyrl.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,18 +19,14 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -41,122 +34,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,363 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -688,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -706,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -714,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1006,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1074,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1102,57 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1160,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1218,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1246,258 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1505,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1575,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1669,29 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1699,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1722,194 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1917,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2023,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2091,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2129,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2377,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2476,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2489,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2676,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2694,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2702,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2887,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2900,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3028,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3207,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3215,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3223,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3266,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,852 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_vi.ts
+++ b/src/qt/locale/bitcoin_vi.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>Click đúp chuột để chỉnh sửa địa chỉ hoặc nhãn dữ liệu</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Tạo một địa chỉ mới</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>Sao chép các địa chỉ đã được chọn vào bộ nhớ tạm thời của hệ thống</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>&amp;Xóa</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Tập tin tách biệt bởi dấu phẩy (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>Nhãn dữ liệu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Địa chỉ</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(chưa có nhãn)</translation>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>Số lượng</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>Địa chỉ</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation>(chưa có nhãn)</translation>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>Địa chỉ</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>Số lượng</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>Nhãn dữ liệu</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>Nhãn dữ liệu</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Số lượng</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(chưa có nhãn)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(chưa có nhãn)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>Số lượng</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>Địa chỉ</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>Số lượng</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>Tập tin tách biệt bởi dấu phẩy (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>Nhãn dữ liệu</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>Địa chỉ</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>Số lượng</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_vi_VN.ts
+++ b/src/qt/locale/bitcoin_vi_VN.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,141 +19,113 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
-        <source> (%1-bit)</source>
+        <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
 </context>
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>Tạo một địa chỉ mới</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-41"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,362 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+295"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-137"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+138"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+430"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-643"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+146"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-284"/>
-        <location line="+376"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-401"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+23"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-85"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -687,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+435"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -705,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+119"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -713,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+42"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+323"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+66"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1005,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1073,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+65"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1101,52 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Set SSL root certificates for payment request (default: -system-)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1154,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+85"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1212,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1240,253 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+107"/>
-        <source>&amp;Spend unconfirmed change (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+37"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+224"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-323"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-86"/>
+        <source>(0 = auto, &lt;0 = leave that many cores free)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
+        <source>Expert</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Enable coin &amp;control features</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
+        <source>&amp;Spend unconfirmed change</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Display coin &amp;control features (experts only)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+136"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+70"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1494,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1564,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1658,23 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+71"/>
-        <location line="+11"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
+        <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+82"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1682,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1705,192 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+359"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-30"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+122"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1898,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+38"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2004,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2072,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2110,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2358,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2457,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+48"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2470,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2657,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+28"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2675,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2683,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2868,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2881,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3009,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+142"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3188,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3196,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3204,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+43"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+181"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3247,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+223"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-55"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-9"/>
-        <source>Set database cache size in megabytes (default: 25)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="-26"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-51"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-150"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
+        <source>Bitcoin Core RPC client version</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+40"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-120"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3362,722 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <source>Cannot obtain a lock on data directory %s. Bitcoin is probably already running.</source>
+        <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
+        <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
+        <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
+        <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>(default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>(default: wallet.dat)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Bitcoin RPC client version</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Connection options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Debugging/Testing options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable safemode, override a real safe mode event (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>Force safe mode (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>How thorough the block verification is (0-4, default: 3)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Send command to Bitcoin server</source>
+        <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <source>Start Bitcoin server</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+3"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-106"/>
+        <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
-        <source>Set the number of script verification threads (up to 16, 0 = auto, &lt;0 = leave that many cores free, default: 0)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+90"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
+        <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
+        <source>Print block on startup, if found in block index</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Print block tree on startup (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>RPC server options:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Run a thread to flush wallet periodically (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
+        <source>Send command to Bitcoin Core</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
+        <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show all debugging options (usage: --help -help-debug)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show benchmark information (default: 0)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
+        <source>Start Bitcoin Core Daemon</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
+        <source>on startup</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-60"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+81"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-133"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+163"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-31"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-109"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+61"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-101"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+31"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-103"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-63"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-32"/>
-        <source>Unable to bind to %s on this computer. Bitcoin is probably already running.</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location line="+96"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+68"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-58"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+86"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-78"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-36"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>关于比特币核心</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;比特币核心&lt;/b&gt; 版本</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -27,18 +24,14 @@ Distributed under the MIT/X11 software license, see the accompanying file COPYIN
 This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/) and cryptographic software written by Eric Young (eay@cryptsoft.com) and UPnP software written by Thomas Bernard.</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>版权</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Core 的开发者</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -46,122 +39,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>双击编辑地址或标签</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>创建新地址</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>新建(&amp;N)</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>复制当前选中的地址到系统剪贴板</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>复制(&amp;C)</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>关闭(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>复制地址(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>从列表中删除选中的地址</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>导出当前数据到文件</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>导出(&amp;E)</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>删除(&amp;D)</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>选择发款地址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>选择收款地址</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>选择(&amp;H)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>正在发送地址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>正在接收地址</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>这是您用来付款的比特币地址。在付款前，请总是核实付款金额和收款地址。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>这些都是您的比特币地址，可用于收款。建议对每笔交易都使用一个新的地址。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>复制标签(&amp;L)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>编辑(&amp;E)</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>导出地址列表</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>逗号分隔文件 (*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>导出失败</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>地址列表保存至 %1 时发生错误。</translation>
     </message>
@@ -169,17 +138,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>标签</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(没有标签)</translation>
     </message>
@@ -187,140 +153,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>密码对话框</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>输入密码</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>新密码</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>重复新密码</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>输入钱包的新密码。&lt;br/&gt;使用的密码请至少包含&lt;b&gt;10个以上随机字符&lt;/&gt;，或者是&lt;b&gt;8个以上的单词&lt;/b&gt;。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>加密钱包</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>此操作需要您首先使用密码解锁该钱包。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>解锁钱包</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>该操作需要您首先使用密码解密钱包。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>解密钱包</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>更改密码</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>请输入该钱包的旧密码与新密码。</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>确认加密钱包</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>警告：如果您加密了您的钱包，但是忘记了密码，你将会&lt;b&gt;丢失所有的比特币&lt;/b&gt;！</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>您确定需要为钱包加密吗？</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>重要提示：您以前备份的钱包文件应该替换成最新生成的加密钱包文件（重新备份）。从安全性上考虑，您以前备份的未加密的钱包文件，在您使用新的加密钱包后将无效，请重新备份。</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>警告：大写锁定键处于打开状态！</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>钱包已加密</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>比特币客户端将关闭软件以完成加密过程。请您谨记：钱包加密并不是万能的，电脑中毒等原因仍可能导致您的比特币意外丢失。</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>钱包加密失败</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>由于一个本地错误，加密钱包的操作已经失败。您的钱包没能被加密。</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>密码不匹配。</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>钱包解锁失败</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>用于解密钱包的密码不正确。</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>钱包解密失败。</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>修改钱包密码成功。</translation>
     </message>
@@ -328,363 +260,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>消息签名(&amp;M)...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>正在与网络同步...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>概况(&amp;O)</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>节点</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>显示钱包概况</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>交易记录(&amp;T)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>查看交易历史</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>退出(&amp;X)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>退出程序</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>显示比特币的相关信息</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>关于 &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>显示 Qt 相关信息</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>选项(&amp;O)...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>加密钱包(&amp;E)...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>备份钱包(&amp;B)...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>更改密码(&amp;C)...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>&amp;付款地址 </translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>&amp;收款地址</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>打开 &amp;URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>正在从磁盘导入数据块...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>正在为数据块建立索引...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>向一个比特币地址发送比特币</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>设置选项</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>备份钱包到其他文件夹</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>更改钱包加密口令</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>调试窗口(&amp;D)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>打开调试和诊断控制台</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>验证消息(&amp;V)...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>比特币</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>钱包</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>发送(&amp;S)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>接收(&amp;R)</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>显示 / 隐藏(&amp;S)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>显示或隐藏主窗口</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>对钱包中的私钥加密</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>用比特币地址关联的私钥为消息签名，以证明您拥有这个比特币地址</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>校验消息，确保该消息是由指定的比特币地址所有者签名的</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>文件(&amp;F)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>设置(&amp;S)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>帮助(&amp;H)</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>分页工具栏</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[测试网络]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>比特币核心</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>请求支付（生成二维码和 bitcoin: URI）</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>关于比特币核心(&amp;A)</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>显示用过的发送地址和标签的列表</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>显示用过的接收地址和标签的列表</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>打开一个比特币：URI 或支付请求</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>&amp;命令行 选项</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>显示比特币核心 程序帮助信息，获取可用的命令行选项 </translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>比特币客户端</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n条到比特币网络的活动连接</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>沒有可用的区块来源...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>%1 / %2 个交易历史的区块已下载</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>已处理 %1 个交易历史数据块。</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n 小时前</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n 天前</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n 周前</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1 和 %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n 年</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>落后 %1 </translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>最新收到的区块产生于 %1。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>在此之后的交易尚未可见</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>信息</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>已是最新</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>更新中...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>发送交易</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>流入交易</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -697,17 +552,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>钱包已被&lt;b&gt;加密&lt;/b&gt;，当前为&lt;b&gt;解锁&lt;/b&gt;状态</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>钱包已被&lt;b&gt;加密&lt;/b&gt;，当前为&lt;b&gt;锁定&lt;/b&gt;状态</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>发生严重错误。</translation>
     </message>
@@ -715,7 +567,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>网络警报</translation>
     </message>
@@ -723,291 +574,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>选择交易源地址</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>总量：</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>字节：</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>金额：</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>优先级：</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>费用：</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>低输出</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>加上交易费用后:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>变更 : </translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>(不)全选</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>树状模式</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>列表模式</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>金额</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>确认</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>已确认</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>优先级</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>复制地址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>复制标签</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>复制金额</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>复制交易编号</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>锁定未花费</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>解锁未花费</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>复制金额</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>复制交易费</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>复制含交易费的金额</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>复制字节</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>复制优先级</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>复制低输出</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>复制零钱</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>最高</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>更高</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>高</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>中高</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>中等</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>中低</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>低</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>更低</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>最低</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(%1 锁定)</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation>无</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>尘埃交易</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>否</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>如果这笔交易大于1000字节，标签会变成红色。</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>这意味着将对交易收取 %1/千字节 的交易费。</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>每笔输入可能会有 正负1字节的偏差。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>交易的优先级越高，被矿工收入数据块的速度也越快。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>如果优先级小于&quot;中位数&quot; ，标签将变成红色。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>如果收款地址收到小于%1的比特币，标签将变成红色。</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>这意味着至少需要 %1的交易费。</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>小于最小转发交易费的0.546倍的 转账金额将被视为 尘埃交易。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>如果零钱小于 %1，标签将变成红色。</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(没有标签)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation>来自%1的零钱 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(零钱)</translation>
     </message>
@@ -1015,67 +805,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>编辑地址</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>标签(&amp;L)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>与此地址相关的标签项</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>该地址已与地址列表中的条目关联，只能被发送地址修改。</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>地址(&amp;A)</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>新建接收地址</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>新建发送地址</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>编辑接收地址</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>编辑发送地址</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>输入的地址“%1”已经存在于地址簿中。</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>您输入的“%1”不是有效的比特币地址。</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>无法解锁钱包</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>新的密钥生成失败。</translation>
     </message>
@@ -1083,27 +860,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation>一个新的数据目录将被创建。</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>目录已存在。如果您打算在这里创建一个新目录，添加 %1。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>路径已存在，并且不是一个目录。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>无法在此创建数据目录。</translation>
     </message>
@@ -1111,58 +883,47 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>比特币核心程序 - 命令行选项</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>比特币核心</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>使用：</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>命令行选项</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>UI选项</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>设置语言, 例如“zh-TW”（默认为系统语言）</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>启动时最小化
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>启动时显示版权页 (缺省: 1)</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>在启动时选择数据目录（默认：0）</translation>
     </message>
@@ -1170,57 +931,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>欢迎</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>欢迎使用 比特币核心 程序。</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>由于这是第一次运行 比特币核心 程序，您可以选择数据存储目录。</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>比特币核心 程序会下载储存一份数据块链(blockchain)。至少需要 %1 GB的存储空间，随着时间推移会需要更多的存储空间。钱包文件也储存在该目录。</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>使用默认的数据目录</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>使用自定义的数据目录：</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>比特币</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>错误：指定的数据目录“%1”无法创建。</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>可用空间（GB）</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>（需要 %1GB）</translation>
     </message>
@@ -1228,27 +978,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>打开 URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>打开来自URI或文件的付款请求 </translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI: </translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>选择付款请求文件 </translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>选择需要打开的付款请求文件 </translation>
     </message>
@@ -1256,258 +1001,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>主要(&amp;M)</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>可选的每 kB 交易费，这有助于您的交易被更快的处理。大多数交易都是 1 kB。</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>支付交易费用(&amp;F)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>登录系统后自动开启比特币客户端</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>系统启动时运行(&amp;S)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>数据库缓存大小(&amp;D)</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>脚本&amp;验证 进程数 </translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>通过 SOCKS 代理连接到比特币网络。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>通过 SO&amp;CKS 代理连接 (默认代理):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>代理的 IP 地址 (例如 IPv4: 127.0.0.1 / IPv6: ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation>有效的命令行参数覆盖上述选项:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>恢复客户端的缺省设置</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>恢复缺省设置(&amp;R)</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>网络(&amp;N)</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation>&amp;钱包</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>专家</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>如果禁用未确认的零钱，则零钱至少需要1个确认才能使用。同时账户余额显示会受到影响。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>自动在路由器中打开比特币端口。只有当您的路由器开启了 UPnP 选项时此功能才有效。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>使用 &amp;UPnP 映射端口</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>代理服务器 &amp;IP：</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>端口(&amp;P)：</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>代理端口（例如 9050）</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>Socks 版本(&amp;V)：</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>Socks 代理版本（例如 5）</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>窗口(&amp;W)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>最小化窗口后仅显示托盘图标</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>最小化到托盘(&amp;M)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>当窗口关闭时程序最小化而不是退出。当使用该选项时，程序只能通过在菜单中选择退出来关闭</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>单击关闭按钮最小化(&amp;I)</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>显示(&amp;D)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>用户界面语言(&amp;L)：</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>在这里设置用户界面的语言。设置将在客户端重启后生效。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>比特币金额单位(&amp;U)：</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>选择比特币单位。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>是否需要在交易清单中显示比特币地址。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>在交易清单中显示比特币地址(&amp;D)</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>是否需要交易源地址控制功能。</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>确定(&amp;O)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>取消(&amp;C)</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>默认</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>无</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation>确认恢复缺省设置</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>更改生效需要重启客户端。</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>客户端即将关闭，确定继续吗？</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>此更改需要重启客户端。</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>提供的代理服务器地址无效。</translation>
     </message>
@@ -1515,69 +1208,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>表单</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>现在显示的消息可能是过期的. 在连接上比特币网络节点后，您的钱包将自动与网络同步，但是这个过程还没有完成。</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>钱包</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>可使用的余额：</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>您当前可使用的余额</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>等待中的余额：</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>尚未确认的交易总额，未计入当前余额</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>未成熟的：</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>尚未成熟的挖矿收入余额</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>总额：</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>您当前的总余额</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;最近交易记录&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>数据同步中</translation>
     </message>
@@ -1585,93 +1263,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI 处理</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>URI无法解析！原因可能是比特币地址不正确，或者URI参数错误。</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>请求支付的金额 %1 太小（就像尘埃）。</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>支付请求出错</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>暂时无法启动比特币：点击支付功能</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>网络管理器警告</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>您的活动代理不支持 SOCKS5，而通过代理进行支付请求时这是必须的。</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>付款请求URI链接非法: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>付款请求文件处理 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>付款请求文件不能读取或无法识别！这可能是个不合格的付款请求文件。</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>不支持到自定义付款脚本的未验证付款请求。</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>退款来自 %1</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>%1: %2 通讯出错</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>支付请求不能被解析或处理！</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>来自 %1 服务器的错误响应</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>支付已到账</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>网络请求出错</translation>
     </message>
@@ -1679,29 +1334,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>比特币</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>错误：指定的数据目录“%1”不存在。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>错误：无效的 -regtest 与 -testnet 结合体。</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>请输入比特币地址（例如: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L）</translation>
     </message>
@@ -1709,22 +1357,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>保存图片(&amp;S)...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>复制图片(&amp;C)</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>保存二维码</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG图片(*.png)</translation>
     </message>
@@ -1732,194 +1376,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>客户端名称</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>不可用</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>客户端版本</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>信息(&amp;I)</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>调试窗口</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>常规</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>使用 OpenSSL 版本</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>启动时间</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>网络</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>姓名</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>连接数</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>数据链</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>当前数据块数量</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>预计数据块数量</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>上一数据块时间</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>打开(&amp;O)</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>控制台(&amp;C)</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>网络流量(&amp;N)</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>清除(&amp;C)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>总数</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>输入：</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>输出：</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>创建时间</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>调试日志文件</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>打开当前目录中的调试日志文件。日志文件大的话可能要等上几秒钟。</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>清空控制台</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>欢迎来到 RPC 控制台。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>使用上下方向键浏览历史,  &lt;b&gt;Ctrl-L&lt;/b&gt;清除屏幕。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>使用 &lt;b&gt;help&lt;/b&gt; 命令显示帮助信息。</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 字节</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 分钟</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 小时</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 小时 %2 分钟</translation>
     </message>
@@ -1927,105 +1523,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>总额(&amp;A)：</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>标签(&amp;L)：</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>消息(&amp;M)：</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>重复使用以前用过的接收地址。重用地址有安全和隐私方面的隐患。除非是为重复生成同一项支付请求，否则请不要这样做。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>重用现有的接收地址（不推荐）</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>可在付款请求上备注一条信息，在打开付款请求时可以看到。注意：该消息不是通过比特币网络传送。</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>可为新建的收款地址添加一个标签。</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>使用此表单要求付款。所有字段都是&lt;b&gt;可选&lt;/b&gt;。</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>可选的请求金额。留空或填零为不要求具体金额。</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>清空此表单的所有字段。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>清除</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>请求付款的历史</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>请求付款(&amp;R)</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>显示选中的请求 (双击也可以显示)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>显示</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation>从列表中移除选中的条目</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>移除</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>复制标签</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>复制消息 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>复制金额</translation>
     </message>
@@ -2033,67 +1606,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>复制 URI(&amp;U)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>复制地址(&amp;A)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>保存图片(&amp;S)...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>请求付款到 %1</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>付款信息</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>金额</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>标签</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>消息</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>URI 太长，请试着精简标签或消息文本。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>将 URI 转为二维码失败。</translation>
     </message>
@@ -2101,37 +1661,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>标签</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>消息</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>金额</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(没有标签)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(无消息)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(无金额) </translation>
     </message>
@@ -2139,247 +1692,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>发送货币</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>交易源地址控制功能</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>输入...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>自动选择</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>存款不足！</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>总量：</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>字节：</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>金额：</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>优先级：</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>费用：</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>低输出</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>加上交易费用后:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>变更 : </translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>如果激活该选项，但是零钱地址用光或者非法，将会新生成零钱地址，转入零钱。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>自定义零钱地址</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>一次发送给多个接收者</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>添加收款人(&amp;R)</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>清除此表单的所有字段。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>清除所有(&amp;A)</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>余额：</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>确认并发送货币</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>发送(&amp;E)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>确认发送货币</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 到 %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>复制金额</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>复制金额</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>复制交易费</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>复制含交易费的金额</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>复制字节</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>复制优先级</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>复制低输出</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>复制零钱</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>总额 %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>或</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>收款人地址不合法，请检查。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>支付金额必须大于0。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>金额超出您的账上余额。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>计入 %1 交易费后的金额超出您的账上余额。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>发现重复的地址, 每次只能对同一地址发送一次。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>交易创建失败！</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>错误：该交易被拒绝！发生这种错误的原因可能是：钱包中的比特币已经被用掉，有可能您复制了wallet.dat钱包文件，然后用复制的钱包文件支付了比特币，但是这个钱包文件中没有记录。</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>警告：无效的比特币地址</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(没有标签)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>警告：未知的更改地址</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>您确定要发出吗？</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>已添加交易费</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>支付请求已过期</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>无效的付款地址 %1</translation>
     </message>
@@ -2387,98 +1887,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>金额(&amp;M)</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>付给(&amp;T)：</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>付款给这个地址  (例如 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>为这个地址输入一个标签，以便将它添加到您的地址簿</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>标签(&amp;L)：</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>选择以前用过的地址</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>这是笔正常的支付。</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>从剪贴板粘贴地址</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>移除此项</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>消息：</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>这是个有效的支付请求。</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>请为此地址输入一个标签以将它加入用过的地址列表</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>bitcoin:URI 附带的备注信息，将会和交易一起存储，备查。 注意：该消息不会通过比特币网络传输。</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>这是个非有效的支付请求。</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>支付给:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>便条：</translation>
     </message>
@@ -2486,12 +1962,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>比特币核心正在关机...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation>在此窗口消失前不要关闭计算机。</translation>
     </message>
@@ -2499,186 +1973,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>签名 - 为消息签名/验证签名消息</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>签名消息(&amp;S)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>您可以用你的地址对消息进行签名，以证明您是该地址的所有人。注意不要对模棱两可的消息签名，以免遭受钓鱼式攻击。请确保消息内容准确的表达了您的真实意愿。</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>用于签名消息的地址（例如: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L）</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>选择以前用过的地址</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>从剪贴板粘贴地址</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>请输入您要发送的签名消息</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>签名</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>复制当前签名至剪切板</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>签名消息，证明这个地址属于您。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>消息签名(&amp;M)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>清空所有签名消息栏</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>清除所有(&amp;A)</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>验证消息(&amp;V)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>在下面输入签名地址，消息（请确保换行符、空格符、制表符等等一个不漏）和签名以验证消息。请确保签名信息准确，提防中间人攻击。</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>用于签名消息的地址(例如: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>验证消息，确保消息是由指定的比特币地址签名过的。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>验证消息签名(&amp;M)</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>清空所有验证消息栏</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>请输入比特币地址 (例如: 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>单击“签名消息“产生签名。</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>输入的地址非法。</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>请检查地址后重试。</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>输入的地址没有关联的公私钥对。</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>钱包解锁动作取消。</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>找不到输入地址关联的私钥。</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>消息签名失败。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>消息已签名。</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>签名无法解码。</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>请检查签名后重试。</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>签名与消息摘要不匹配。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>消息验证失败。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>消息验证成功。</translation>
     </message>
@@ -2686,17 +2116,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation>比特币核心</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>Bitcoin Core 的开发者</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2704,7 +2131,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2712,184 +2138,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>至 %1 个数据块时开启</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>发现冲突</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1 / 离线</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1/未确认</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>%1 已确认</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>状态</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>通过 %n 个节点广播</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>源</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>生成</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>来自</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>到</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>自己的地址</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>标签</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>收入</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>将在 %n 个数据块后成熟</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>未被接受</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>支出</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>交易费</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>净额</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>消息</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>备注</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>交易ID</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>商店</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>生成的比特币在可以使用前必须有 %1 个成熟的区块。当您生成了此区块后，它将被广播到网络中以加入区块链。如果它未成功进入区块链，其状态将变更为“不接受”并且不可使用。这可能偶尔会发生，如果另一个节点比你早几秒钟成功生成一个区块。</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>调试信息</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>交易</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>输入</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>金额</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>正确</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>，未被成功广播</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Open for %n more block</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>
@@ -2897,12 +2277,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>交易细节</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>当前面板显示了交易的详细信息</translation>
     </message>
@@ -2910,127 +2288,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>类型</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>数量</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>未成熟 (%1 个确认，将在 %2 个后可用)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>Open for %n more block</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>至 %1 个数据块时开启</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>已确认 (%1 条确认信息)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>此数据块未被任何其他节点接收，可能不被接受！</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>已生成但未被接受</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>掉线</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>未确认的 </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>确认中 (推荐 %2个确认，已经有 %1个确认)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>冲突的</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>接收于</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>收款来自</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>发送给</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>付款给自己</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>挖矿所得</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>（不可用）</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>交易状态。 鼠标移到此区域可显示确认项数量。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>接收到交易的时间</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>交易类别。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>交易目的地址。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>从余额添加或移除的金额。</translation>
     </message>
@@ -3038,178 +2391,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>今天</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>本周</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>本月</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>上月</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>今年</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>范围...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>接收于</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>发送给</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>到自己</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>挖矿所得</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>其他</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>输入地址或标签进行搜索</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>最小金额</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>复制地址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>复制标签</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>复制金额</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>复制交易编号</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>编辑标签</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>显示交易详情</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>导出交易历史</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>导出失败</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>导出交易历史到 %1 时发生错误。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>导出成功</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>交易历史已成功保存到 %1。</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>逗号分隔文件 (*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>已确认</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>类别</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>标签</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>地址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>金额</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>范围：</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>到</translation>
     </message>
@@ -3217,7 +2534,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>没有载入钱包。</translation>
     </message>
@@ -3225,7 +2541,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>发送比特币</translation>
     </message>
@@ -3233,42 +2548,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation>导出(&amp;E)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>导出当前数据到文件</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation>备份钱包</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>钱包文件(*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>备份失败</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>尝试保存钱包数据至 %1 时发生错误。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>钱包数据成功保存至 %1 。</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>备份成功</translation>
     </message>
@@ -3276,117 +2583,96 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>使用：</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>列出命令
 </translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>获得某条命令的帮助
 </translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>选项：
 </translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>指定配置文件 (默认为 bitcoin.conf)
 </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>指定 pid 文件 (默认为 bitcoind.pid)
 </translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>指定数据目录
 </translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>监听端口连接 &lt;port&gt;（缺省: 8333 或测试网络: 18333）</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>最大连接数 &lt;n&gt; （缺省: 125）</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>连接一个节点并获取对端地址，然后断开连接</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation>指定您的公共地址</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>断开行为不端对端阀值（缺省: 100）</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>重新连接异常节点的秒数(缺省: 86400)</translation>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>设置RPC监听端口%u时发生错误, IPv4:%s</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>JSON-RPC连接监听端口&lt;port&gt; (缺省：8332　testnet：18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>接受命令行和 JSON-RPC 命令
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>在后台运行并接受命令
 
 </translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>使用测试网络
 </translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>接受来自外部的连接 (缺省: 如果不带 -proxy or -connect 参数设置为1)</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3411,857 +2697,687 @@ rpcpassword=%s
 </translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>可接受的密码（默认：TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH）</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>在IPv6模式下设置RPC监听端口 %u 失败，返回到IPv4模式: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>绑定指定的IP地址开始监听。IPv6地址请使用[host]:port 格式</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>进入回归测试模式，它采用一种特殊的可立即解决的区块链模拟情况。这是为了回归测试工具和应用的开发所设。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>进入回归测试模式，它采用一种特殊的可立即解决的区块链模拟情况。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>错误：该交易被拒绝！发生这种错误的原因可能是：钱包中的比特币已经被用掉，有可能您复制了wallet.dat钱包文件，然后用复制的钱包文件支付了比特币，但是这个钱包文件中没有记录。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>错误：因为该交易的数量、复杂度或者动用了刚收到不久的资金，您需要支付不少于%s的交易费用。</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>当最佳区块变化时执行命令 (命令行中的 %s 会被替换成区块哈希值)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>这是测试用的预发布版本 - 请谨慎使用 - 不要用来挖矿，或者在正式商用环境下使用</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>连接至 Tor隐藏服务器时 使用不同的SOCKS5代理 (缺省: -proxy) </translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>警告：-paytxfee 交易费设置得太高了！每笔交易都将支付交易费。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>警告：请检查电脑的日期时间设置是否正确！时间错误可能会导致比特币客户端运行异常。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>警告：网络似乎并不完全同意！有些矿工似乎遇到了问题。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>警告：我们的同行似乎不完全同意！您可能需要升级，或者其他节点可能需要升级。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>警告：钱包文件wallet.dat读取失败！最重要的公钥、私钥数据都没有问题，但是交易记录或地址簿数据不正确，或者存在数据丢失。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>警告：钱包文件wallet.dat损坏! 原始的钱包文件已经备份到%s目录下并重命名为{timestamp}.bak 。如果您的账户余额或者交易记录不正确，请使用您的钱包备份文件恢复。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; 可能是：</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>尝试从损坏的钱包文件wallet.dat中恢复私钥</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>比特币核心 守护程序</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation>数据块创建选项：</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>清除钱包中的交易记录 (诊断用，意味着需要重新扫描 -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>仅连接到指定节点</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>通过Socks代理连接:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>连接到 JSON-RPC 于 &lt;port&gt;（默认: 8332，或测试网络: 18332）</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation>检测发现数据块数据库损坏。请使用 -reindex参数重启客户端。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>发现自己的IP地址(缺省:不带 -externalip 参数监听时设置为1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>不要加载钱包和禁用钱包的 RPC 调用</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>你想现在就重建块数据库吗？</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>初始化数据块数据库出错</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>Error initializing wallet database environment %s!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>导入数据块数据库出错</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>导入数据块数据库出错</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>错误：磁盘剩余空间低!</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>错误：钱包被锁定，无法创建交易！</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>错误：系统出错。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>监听端口失败。请使用 -listen=0 参数。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>无法读取数据块信息</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>读取数据块失败</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>无法同步数据块索引</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>无法写入数据块索引</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>无法写入数据块信息</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>无法写数据块</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>无法写入文件信息</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>无法写入coin数据库</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>无法写入交易索引</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>无法写入回滚信息</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>为付款交易支付比特币(每kb)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>通过DNS查找节点(缺省：1 除非使用 -connect 选项)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation>生成比特币（默认为 0）</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>启动时检测多少个数据块(缺省：288，0=所有)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>如果&lt;category&gt;未提供，将输出所有调试信息。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>不正确或没有找到起源区块。网络错误？</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>无效的 -onion 地址：“%s”</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation>没有足够的文件描述符可用。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>调试信息输出时，前面加上时间戳 (缺省: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation>RPC 客户端选项：</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>重新为当前的blk000??.dat文件建立索引</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>用 -proxy 选择 SOCKS 版本（4 或 5，默认为 5）</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>设置最大区块大小 (默认: %d，单位字节)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>设置使用调用服务 RPC 的线程数量（默认：4）</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>指定钱包文件（数据目录内）</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>付款时允许使用未确认的零钱 (缺省: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>这是用于回归测试和应用开发目的。</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>用法（不推荐，请使用 bitcoin-cli）：</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>正在验证数据库的完整性...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>正在检测钱包的完整性...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>等待 RPC 服务器</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>钱包 %s 在外部的数据目录 %s</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>钱包选项:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>警告：已废弃的 -debugnet 参数已忽略，请用 -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>您需要将 -reindex 改为 -txindex 以重建数据库</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>从blk000??.dat文件导入数据块</translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>当收到相关提醒或者我们看到一个长分叉时执行命令（%s 将替换为消息）</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>输出调试信息（默认为0，提供  &lt;category&gt; 是可选的）</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>设置 高优先级/低交易费 交易的最大字节  (缺省: %d)</translation>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>信息</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-minrelaytxfee=&lt;amount&gt;: &apos;%s&apos; 无效的金额</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>-mintxfee=&lt;amount&gt;: &apos;%s&apos; 无效的金额</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>维护一份完整的交易索引(缺省：0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>每个连接的最大接收缓存，&lt;n&gt;*1000 字节(缺省：5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>每个连接的最大发送缓存，&lt;n&gt;*1000 字节(缺省：1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>仅接受符合客户端检查点设置的数据块文件</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>仅连接至指定网络的节点&lt;net&gt;(IPv4, IPv6 或者 Tor)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation>启动时打印块树 (默认: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation>RPC 服务器选项：</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL选项：(参见Bitcoin Wiki关于SSL设置栏目)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>跟踪/调试信息输出到控制台，不输出到 debug.log 文件</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>设置最小数据块大小(缺省:0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>客户端启动时压缩debug.log文件(缺省：no-debug模式时为1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>签署交易失败</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>设置连接超时时间(缺省：5000毫秒)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>系统错误：</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>交易量太小</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>交易金额必须是积极的</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>交易太大</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>使用UPnP映射监听端口 (缺省: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>使用UPnp映射监听端口(缺省: 监听状态设为1)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>JSON-RPC 连接用户名</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>警告：该软件版本已过时，请升级！</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>Zapping all transactions from wallet...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>钱包文件wallet.dat损坏，抢救备份失败</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>JSON-RPC 连接密码
 </translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>允许从指定IP接受到的 JSON-RPC 连接</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>向IP地址为 &lt;ip&gt; 的节点发送指令 (缺省: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>当最佳数据块变化时执行命令 (命令行中的 %s 会被替换成数据块哈希值)</translation>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>将钱包升级到最新的格式</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>设置密钥池大小为 &lt;n&gt; (缺省: 100)
 </translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>重新扫描区块链以查找遗漏的钱包交易</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>为 JSON-RPC 连接使用 OpenSSL (https) 连接</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>服务器证书 (默认为 server.cert)
 </translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>服务器私钥 (默认为 server.pem)
 </translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>本帮助信息
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>无法绑定本机端口 %s  (返回错误消息 %d, %s)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>使用 -addnode, -seednode 和 -connect 选项时允许查询DNS</translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>正在加载地址簿...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>wallet.dat 钱包文件加载出错：钱包损坏</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>wallet.dat 钱包文件加载错误：请升级到最新版Bitcoin客户端</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>钱包文件需要被重写：请退出并重新启动Bitcoin客户端</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>wallet.dat 钱包文件加载出错</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>无效的代理地址：%s</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>-onlynet 指定的是未知网络：%s</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>被指定的是未知socks代理版本: %i</translation>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>无法解析 -bind 端口地址: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>无法解析 -externalip 地址: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>非法金额 -paytxfee=&lt;amount&gt;: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>无效金额</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>金额不足</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>正在加载数据块索引...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>添加节点并与其保持连接</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>正在加载钱包...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation>无法降级钱包</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>无法写入默认地址</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>正在重新扫描...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>加载完成</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>使用 %s 选项</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>错误</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_zh_HK.ts
+++ b/src/qt/locale/bitcoin_zh_HK.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -22,18 +19,14 @@ This product includes software developed by the OpenSSL Project for use in the O
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation type="unfinished"/>
     </message>
@@ -41,122 +34,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation type="unfinished"/>
     </message>
@@ -164,17 +133,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
@@ -182,140 +148,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation type="unfinished"/>
     </message>
@@ -323,363 +255,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -688,17 +543,14 @@ Address: %4
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation type="unfinished"/>
     </message>
@@ -706,7 +558,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation type="unfinished"/>
     </message>
@@ -714,291 +565,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation type="unfinished"/>
     </message>
@@ -1006,67 +796,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation type="unfinished"/>
     </message>
@@ -1074,27 +851,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation type="unfinished"/>
     </message>
@@ -1102,57 +874,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
@@ -1160,57 +921,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation type="unfinished"/>
     </message>
@@ -1218,27 +968,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation type="unfinished"/>
     </message>
@@ -1246,258 +991,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation type="unfinished"/>
     </message>
@@ -1505,69 +1198,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation type="unfinished"/>
     </message>
@@ -1575,93 +1253,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation type="unfinished"/>
     </message>
@@ -1669,29 +1324,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
@@ -1699,22 +1347,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation type="unfinished"/>
     </message>
@@ -1722,194 +1366,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation type="unfinished"/>
     </message>
@@ -1917,105 +1513,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
@@ -2023,67 +1596,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation type="unfinished"/>
     </message>
@@ -2091,37 +1651,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation type="unfinished"/>
     </message>
@@ -2129,247 +1682,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation type="unfinished"/>
     </message>
@@ -2377,98 +1877,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation type="unfinished"/>
     </message>
@@ -2476,12 +1952,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation type="unfinished"/>
     </message>
@@ -2489,186 +1963,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation type="unfinished"/>
     </message>
@@ -2676,17 +2106,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation type="unfinished"/>
     </message>
@@ -2694,7 +2121,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation type="unfinished"/>
     </message>
@@ -2702,184 +2128,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation type="unfinished"/>
     </message>
@@ -2887,12 +2267,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation type="unfinished"/>
     </message>
@@ -2900,127 +2278,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation type="unfinished"/>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation type="unfinished"><numerusform></numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation type="unfinished"/>
     </message>
@@ -3028,178 +2381,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation type="unfinished"/>
     </message>
@@ -3207,7 +2524,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation type="unfinished"/>
     </message>
@@ -3215,7 +2531,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation type="unfinished"/>
     </message>
@@ -3223,42 +2538,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation type="unfinished"/>
     </message>
@@ -3266,107 +2573,86 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3381,852 +2667,682 @@ for example: alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>

--- a/src/qt/locale/bitcoin_zh_TW.ts
+++ b/src/qt/locale/bitcoin_zh_TW.ts
@@ -2,17 +2,14 @@
 <context>
     <name>AboutDialog</name>
     <message>
-        <location filename="../forms/aboutdialog.ui" line="+14"/>
         <source>About Bitcoin Core</source>
         <translation>關於位元幣核心</translation>
     </message>
     <message>
-        <location line="+39"/>
         <source>&lt;b&gt;Bitcoin Core&lt;/b&gt; version</source>
         <translation>&lt;b&gt;位元幣核心&lt;/b&gt; 版本</translation>
     </message>
     <message>
-        <location line="+57"/>
         <source>
 This is experimental software.
 
@@ -29,18 +26,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 此產品也包含了由 OpenSSL Project 所開發的 OpenSSL Toolkit (http://www.openssl.org/) 軟體，和由 Eric Young (eay@cryptsoft.com) 撰寫的加解密軟體，以及由 Thomas Bernard 所撰寫的 UPnP 軟體。</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+29"/>
         <source>Copyright</source>
         <translation>版權</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The Bitcoin Core developers</source>
         <translation>位元幣核心開發人員</translation>
     </message>
     <message>
-        <location line="+12"/>
-        <location line="+2"/>
         <source>(%1-bit)</source>
         <translation>(%1 位元)</translation>
     </message>
@@ -48,122 +41,98 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressBookPage</name>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="+30"/>
         <source>Double-click to edit address or label</source>
         <translation>按兩下來編輯位址或標記</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Create a new address</source>
         <translation>製造新的位址</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;New</source>
         <translation>新增</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Copy the currently selected address to the system clipboard</source>
         <translation>複製目前選擇的位址到系統剪貼簿</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy</source>
         <translation>複製</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>C&amp;lose</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="+74"/>
         <source>&amp;Copy Address</source>
         <translation>複製位址</translation>
     </message>
     <message>
-        <location filename="../forms/addressbookpage.ui" line="-47"/>
         <source>Delete the currently selected address from the list</source>
         <translation>把目前選擇的位址從列表中刪掉</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Export the data in the current tab to a file</source>
         <translation>把目前分頁的資料匯出存成檔案</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Export</source>
         <translation>匯出</translation>
     </message>
     <message>
-        <location line="-27"/>
         <source>&amp;Delete</source>
         <translation>刪掉</translation>
     </message>
     <message>
-        <location filename="../addressbookpage.cpp" line="-30"/>
         <source>Choose the address to send coins to</source>
         <translation>選擇要付錢過去的位址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Choose the address to receive coins with</source>
         <translation>選擇要收錢進來的位址</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>C&amp;hoose</source>
         <translation>選取</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Sending addresses</source>
         <translation>付款位址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Receiving addresses</source>
         <translation>收款位址</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>These are your Bitcoin addresses for sending payments. Always check the amount and the receiving address before sending coins.</source>
         <translation>這些是你要付款過去的位元幣位址。在付錢之前，務必要檢查金額和收款位址是否正確。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>These are your Bitcoin addresses for receiving payments. It is recommended to use a new receiving address for each transaction.</source>
         <translation>這些是你用來收款的位元幣位址。建議在每次交易時，都使用一個新的收款位址。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Label</source>
         <translation>複製標記</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&amp;Edit</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location line="+194"/>
         <source>Export Address List</source>
         <translation>匯出位址清單</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Comma separated file (*.csv)</source>
         <translation>逗號分隔資料檔(*.csv)</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Exporting Failed</source>
         <translation>匯出失敗</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>There was an error trying to save the address list to %1.</source>
         <translation>儲存位址列表到 %1 時發生錯誤。</translation>
     </message>
@@ -171,17 +140,14 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AddressTableModel</name>
     <message>
-        <location filename="../addresstablemodel.cpp" line="+168"/>
         <source>Label</source>
         <translation>標記</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>(no label)</source>
         <translation>(無標記)</translation>
     </message>
@@ -189,140 +155,106 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>AskPassphraseDialog</name>
     <message>
-        <location filename="../forms/askpassphrasedialog.ui" line="+26"/>
         <source>Passphrase Dialog</source>
         <translation>密碼對話視窗</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Enter passphrase</source>
         <translation>請輸入密碼</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>New passphrase</source>
         <translation>新密碼</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Repeat new passphrase</source>
         <translation>重複新密碼</translation>
     </message>
     <message>
-        <location filename="../askpassphrasedialog.cpp" line="+40"/>
         <source>Enter the new passphrase to the wallet.&lt;br/&gt;Please use a passphrase of &lt;b&gt;10 or more random characters&lt;/b&gt;, or &lt;b&gt;eight or more words&lt;/b&gt;.</source>
         <translation>請輸入錢包的新密碼。&lt;br/&gt;建議用&lt;b&gt;10 個以上的任意字元&lt;/b&gt;，或是&lt;b&gt;8 個以上的單字&lt;/b&gt;。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Encrypt wallet</source>
         <translation>加密錢包</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to unlock the wallet.</source>
         <translation>這個動作需要你的錢包密碼來解鎖錢包。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Unlock wallet</source>
         <translation>解鎖錢包</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This operation needs your wallet passphrase to decrypt the wallet.</source>
         <translation>這個動作需要你的錢包密碼來把錢包解密。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Decrypt wallet</source>
         <translation>解密錢包</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Change passphrase</source>
         <translation>改變密碼</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Enter the old and new passphrase to the wallet.</source>
         <translation>請輸入錢包的舊密碼及新密碼。</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Confirm wallet encryption</source>
         <translation>確認錢包加密</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Warning: If you encrypt your wallet and lose your passphrase, you will &lt;b&gt;LOSE ALL OF YOUR BITCOINS&lt;/b&gt;!</source>
         <translation>警告: 如果把錢包加密後又忘記密碼，你就會從此&lt;b&gt;失去其中所有的位元幣了&lt;/b&gt;！</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Are you sure you wish to encrypt your wallet?</source>
         <translation>你確定要把錢包加密嗎？</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
         <translation>重要: 請改用新產生有加密的錢包檔，來取代舊錢包檔的備份。為了安全性的理由，當你開始使用新的有加密的錢包後，舊錢包檔的備份就不能再使用了。</translation>
     </message>
     <message>
-        <location line="+100"/>
-        <location line="+24"/>
         <source>Warning: The Caps Lock key is on!</source>
         <translation>警告: 大寫字母鎖定作用中！</translation>
     </message>
     <message>
-        <location line="-130"/>
-        <location line="+58"/>
         <source>Wallet encrypted</source>
         <translation>錢包已加密</translation>
     </message>
     <message>
-        <location line="-56"/>
         <source>Bitcoin will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
         <translation>位元幣軟體現在要關閉，好完成加密程序。請注意，加密錢包不能完全防止入侵你的電腦的惡意程式偷取位元幣。</translation>
     </message>
     <message>
-        <location line="+13"/>
-        <location line="+7"/>
-        <location line="+42"/>
-        <location line="+6"/>
         <source>Wallet encryption failed</source>
         <translation>錢包加密失敗</translation>
     </message>
     <message>
-        <location line="-54"/>
         <source>Wallet encryption failed due to an internal error. Your wallet was not encrypted.</source>
         <translation>因為內部錯誤導致錢包加密失敗。你的錢包還是沒加密。</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+48"/>
         <source>The supplied passphrases do not match.</source>
         <translation>提供的密碼不一樣。</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>Wallet unlock failed</source>
         <translation>錢包解鎖失敗</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+11"/>
-        <location line="+19"/>
         <source>The passphrase entered for the wallet decryption was incorrect.</source>
         <translation>輸入要用來解密錢包的密碼不對。</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Wallet decryption failed</source>
         <translation>錢包解密失敗</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Wallet passphrase was successfully changed.</source>
         <translation>錢包密碼改成功了。</translation>
     </message>
@@ -330,363 +262,286 @@ This product includes software developed by the OpenSSL Project for use in the O
 <context>
     <name>BitcoinGUI</name>
     <message>
-        <location filename="../bitcoingui.cpp" line="+294"/>
         <source>Sign &amp;message...</source>
         <translation>簽署訊息...</translation>
     </message>
     <message>
-        <location line="+335"/>
         <source>Synchronizing with network...</source>
         <translation>正在跟網路進行同步...</translation>
     </message>
     <message>
-        <location line="-407"/>
         <source>&amp;Overview</source>
         <translation>總覽</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Node</source>
         <translation>節點</translation>
     </message>
     <message>
-        <location line="+137"/>
         <source>Show general overview of wallet</source>
         <translation>顯示錢包一般總覽</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>&amp;Transactions</source>
         <translation>交易</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Browse transaction history</source>
         <translation>瀏覽交易紀錄</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>E&amp;xit</source>
         <translation>結束</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Quit application</source>
         <translation>結束應用程式</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Show information about Bitcoin</source>
         <translation>顯示位元幣軟體相關資訊</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+2"/>
         <source>About &amp;Qt</source>
         <translation>關於 &amp;Qt</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show information about Qt</source>
         <translation>顯示 Qt 相關資訊</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Options...</source>
         <translation>選項...</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Encrypt Wallet...</source>
         <translation>加密錢包...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Backup Wallet...</source>
         <translation>備份錢包...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Change Passphrase...</source>
         <translation>改變密碼...</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sending addresses...</source>
         <translation>付款位址...</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Receiving addresses...</source>
         <translation>收款位址...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open &amp;URI...</source>
         <translation>開啓 URI...</translation>
     </message>
     <message>
-        <location line="+325"/>
         <source>Importing blocks from disk...</source>
         <translation>正在從磁碟匯入區塊資料...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Reindexing blocks on disk...</source>
         <translation>正在為磁碟裡的區塊重建索引...</translation>
     </message>
     <message>
-        <location line="-405"/>
         <source>Send coins to a Bitcoin address</source>
         <translation>付錢給一個位元幣位址</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Modify configuration options for Bitcoin</source>
         <translation>修改位元幣軟體的設定選項</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Backup wallet to another location</source>
         <translation>把錢包備份到其它地方</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Change the passphrase used for wallet encryption</source>
         <translation>改變錢包加密用的密碼</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>&amp;Debug window</source>
         <translation>除錯視窗</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Open debugging and diagnostic console</source>
         <translation>開啓除錯和診斷主控台</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>&amp;Verify message...</source>
         <translation>驗證訊息...</translation>
     </message>
     <message>
-        <location line="+440"/>
         <source>Bitcoin</source>
         <translation>位元幣</translation>
     </message>
     <message>
-        <location line="-652"/>
         <source>Wallet</source>
         <translation>錢包</translation>
     </message>
     <message>
-        <location line="+145"/>
         <source>&amp;Send</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Receive</source>
         <translation>收款</translation>
     </message>
     <message>
-        <location line="+46"/>
-        <location line="+2"/>
         <source>&amp;Show / Hide</source>
         <translation>顯示或隱藏</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show or hide the main Window</source>
         <translation>顯示或隱藏主視窗</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Encrypt the private keys that belong to your wallet</source>
         <translation>把錢包中的密鑰加密</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Sign messages with your Bitcoin addresses to prove you own them</source>
         <translation>用位元幣位址簽署訊息來證明位址是你的</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Verify messages to ensure they were signed with specified Bitcoin addresses</source>
         <translation>驗證訊息是用來確定訊息是用指定的位元幣位址簽署的</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>&amp;File</source>
         <translation>檔案</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>&amp;Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>&amp;Help</source>
         <translation>說明</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Tabs toolbar</source>
         <translation>分頁工具列</translation>
     </message>
     <message>
-        <location line="-283"/>
-        <location line="+375"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
     <message>
-        <location line="-400"/>
         <source>Bitcoin Core</source>
         <translation>位元幣核心</translation>
     </message>
     <message>
-        <location line="+162"/>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
         <translation>要求付款(產生 QR Code 和位元幣付款協議的 URI)</translation>
     </message>
     <message>
-        <location line="+29"/>
-        <location line="+2"/>
         <source>&amp;About Bitcoin Core</source>
         <translation>關於位元幣核心</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Show the list of used sending addresses and labels</source>
         <translation>顯示已使用過的付款位址和標記的清單</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Show the list of used receiving addresses and labels</source>
         <translation>顯示已使用過的收款位址和標記的清單</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open a bitcoin: URI or payment request</source>
         <translation>開啓 bitcoin 協議的 URI 或付款要求</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>&amp;Command-line options</source>
         <translation>命令列選項</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show the Bitcoin Core help message to get a list with possible Bitcoin command-line options</source>
         <translation>顯示位元幣核心的說明訊息，來取得可用命令列選項的列表</translation>
     </message>
     <message>
-        <location line="+159"/>
-        <location line="+5"/>
         <source>Bitcoin client</source>
         <translation>位元幣客戶端軟體</translation>
     </message>
     <message numerus="yes">
-        <location line="+142"/>
         <source>%n active connection(s) to Bitcoin network</source>
         <translation><numerusform>%n 個運作中的位元幣網路連線</numerusform></translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>No block source available...</source>
         <translation>沒有可用的區塊來源...</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Processed %1 of %2 (estimated) blocks of transaction history.</source>
         <translation>已處理了估計全部 %2 個區塊中的 %1 個的交易紀錄。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Processed %1 blocks of transaction history.</source>
         <translation>已處理了 %1 個區塊的交易紀錄。</translation>
     </message>
     <message numerus="yes">
-        <location line="+27"/>
         <source>%n hour(s)</source>
         <translation><numerusform>%n 個小時</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
         <source>%n day(s)</source>
         <translation><numerusform>%n 天</numerusform></translation>
     </message>
     <message numerus="yes">
-        <location line="+4"/>
-        <location line="+6"/>
         <source>%n week(s)</source>
         <translation><numerusform>%n 個星期</numerusform></translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>%1 and %2</source>
         <translation>%1又 %2</translation>
     </message>
     <message numerus="yes">
-        <location line="+0"/>
         <source>%n year(s)</source>
         <translation><numerusform>%n 年</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>%1 behind</source>
         <translation>落後 %1</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Last received block was generated %1 ago.</source>
         <translation>最近收到的區塊是在 %1 以前生出來的。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions after this will not yet be visible.</source>
         <translation>暫時會看不到在這之後的交易。</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Information</source>
         <translation>資訊</translation>
     </message>
     <message>
-        <location line="-95"/>
         <source>Up to date</source>
         <translation>最新狀態</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>Catching up...</source>
         <translation>正在趕進度...</translation>
     </message>
     <message>
-        <location line="+130"/>
         <source>Sent transaction</source>
         <translation>付款交易</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Incoming transaction</source>
         <translation>收款交易</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date: %1
 Amount: %2
 Type: %3
@@ -699,17 +554,14 @@ Address: %4
 </translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;unlocked&lt;/b&gt;</source>
         <translation>錢包&lt;b&gt;已加密&lt;/b&gt;並且&lt;b&gt;解鎖中&lt;/b&gt;</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Wallet is &lt;b&gt;encrypted&lt;/b&gt; and currently &lt;b&gt;locked&lt;/b&gt;</source>
         <translation>錢包&lt;b&gt;已加密&lt;/b&gt;並且&lt;b&gt;上鎖中&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../bitcoin.cpp" line="+443"/>
         <source>A fatal error occurred. Bitcoin can no longer continue safely and will quit.</source>
         <translation>發生了致命的錯誤。位元幣軟體沒辦法再繼續安全執行，只好結束。</translation>
     </message>
@@ -717,7 +569,6 @@ Address: %4
 <context>
     <name>ClientModel</name>
     <message>
-        <location filename="../clientmodel.cpp" line="+128"/>
         <source>Network Alert</source>
         <translation>網路警報</translation>
     </message>
@@ -725,291 +576,230 @@ Address: %4
 <context>
     <name>CoinControlDialog</name>
     <message>
-        <location filename="../forms/coincontroldialog.ui" line="+14"/>
         <source>Coin Control Address Selection</source>
         <translation>錢幣控制的位址選擇</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Quantity:</source>
         <translation>數目:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Bytes:</source>
         <translation>位元組數:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Amount:</source>
         <translation>金額:</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Priority:</source>
         <translation>優先度:</translation>
     </message>
     <message>
-        <location line="+45"/>
         <source>Fee:</source>
         <translation>手續費:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>低輸出:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>計費後金額:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>找零金額:</translation>
     </message>
     <message>
-        <location line="+56"/>
         <source>(un)select all</source>
         <translation>全選或全不選</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Tree mode</source>
         <translation>樹狀模式</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>List mode</source>
         <translation>列表模式</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Confirmations</source>
         <translation>確認次數</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirmed</source>
         <translation>已確認</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Priority</source>
         <translation>優先度</translation>
     </message>
     <message>
-        <location filename="../coincontroldialog.cpp" line="+41"/>
         <source>Copy address</source>
         <translation>複製位址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>複製標記</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+26"/>
         <source>Copy amount</source>
         <translation>複製金額</translation>
     </message>
     <message>
-        <location line="-25"/>
         <source>Copy transaction ID</source>
         <translation>複製交易識別碼</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Lock unspent</source>
         <translation>鎖定不用</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Unlock unspent</source>
         <translation>解鎖可用</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Copy quantity</source>
         <translation>複製數目</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Copy fee</source>
         <translation>複製手續費</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>複製計費後金額</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>複製位元組數</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>複製優先度</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>複製低輸出</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>複製找零金額</translation>
     </message>
     <message>
-        <location line="+332"/>
         <source>highest</source>
         <translation>最高</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>higher</source>
         <translation>很高</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>high</source>
         <translation>高</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium-high</source>
         <translation>中高</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>medium</source>
         <translation>中等</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>low-medium</source>
         <translation>中低</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>low</source>
         <translation>低</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lower</source>
         <translation>很低</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>lowest</source>
         <translation>最低</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>(%1 locked)</source>
         <translation>(鎖定 %1 枚)</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>none</source>
         <translation>無</translation>
     </message>
     <message>
-        <location line="+141"/>
         <source>Dust</source>
         <translation>零散錢</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>no</source>
         <translation>否</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>This label turns red, if the transaction size is greater than 1000 bytes.</source>
         <translation>當交易大小大於 1000 位元組時，文字會變紅色。</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+5"/>
         <source>This means a fee of at least %1 per kB is required.</source>
         <translation>表示每一千位元組(kB)需要至少 %1 的手續費。</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Can vary +/- 1 byte per input.</source>
         <translation>每組輸入可能會誤差多或少 1 個位元組。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transactions with higher priority are more likely to get included into a block.</source>
         <translation>優先度較高的交易比較有可能被接受放進區塊中。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This label turns red, if the priority is smaller than &quot;medium&quot;.</source>
         <translation>當優先度低於「中等」時，文字會變紅色。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This label turns red, if any recipient receives an amount smaller than %1.</source>
         <translation>當任何一個收款金額小於 %1 時，文字會變紅色。</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+4"/>
         <source>This means a fee of at least %1 is required.</source>
         <translation>表示至少需要 %1 的交易手續費。</translation>
     </message>
     <message>
-        <location line="-3"/>
         <source>Amounts below 0.546 times the minimum relay fee are shown as dust.</source>
         <translation>當金額低於最低轉發手續費乘以 0.546 時，會顯示成零散錢。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>This label turns red, if the change is smaller than %1.</source>
         <translation>當找零金額小於 %1 時，文字會變紅色。</translation>
     </message>
     <message>
-        <location line="+43"/>
-        <location line="+61"/>
         <source>(no label)</source>
         <translation>(無標記)</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>change from %1 (%2)</source>
         <translation>找零前是 %1 (%2)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(change)</source>
         <translation>(找零)</translation>
     </message>
@@ -1017,67 +807,54 @@ Address: %4
 <context>
     <name>EditAddressDialog</name>
     <message>
-        <location filename="../forms/editaddressdialog.ui" line="+14"/>
         <source>Edit Address</source>
         <translation>編輯位址</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Label</source>
         <translation>標記</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>The label associated with this address list entry</source>
         <translation>跟這個位址簿項目關聯的標記</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>The address associated with this address list entry. This can only be modified for sending addresses.</source>
         <translation>跟這個位址簿項目關聯的位址。只有付款位址能被修改。</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>&amp;Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location filename="../editaddressdialog.cpp" line="+28"/>
         <source>New receiving address</source>
         <translation>造新的收款位址</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>New sending address</source>
         <translation>造新的付款位址</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Edit receiving address</source>
         <translation>編輯收款位址</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Edit sending address</source>
         <translation>編輯付款位址</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>The entered address &quot;%1&quot; is already in the address book.</source>
         <translation>輸入的位址 %1 在位址簿中已經有了。</translation>
     </message>
     <message>
-        <location line="-5"/>
         <source>The entered address &quot;%1&quot; is not a valid Bitcoin address.</source>
         <translation>輸入的位址 %1 並不是有效的位元幣位址。</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Could not unlock wallet.</source>
         <translation>沒辦法把錢包解鎖。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>New key generation failed.</source>
         <translation>產生新的密鑰失敗了。</translation>
     </message>
@@ -1085,27 +862,22 @@ Address: %4
 <context>
     <name>FreespaceChecker</name>
     <message>
-        <location filename="../intro.cpp" line="+68"/>
         <source>A new data directory will be created.</source>
         <translation>就要造出新的資料目錄。</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Directory already exists. Add %1 if you intend to create a new directory here.</source>
         <translation>已經有這個目錄了。如果你要在裡面造出新的目錄的話，請加上 %1.</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Path already exists, and is not a directory.</source>
         <translation>已經有指定的路徑了，並且不是一個目錄。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Cannot create data directory here.</source>
         <translation>沒辦法在這裡造出資料目錄。</translation>
     </message>
@@ -1113,57 +885,46 @@ Address: %4
 <context>
     <name>HelpMessageDialog</name>
     <message>
-        <location filename="../forms/helpmessagedialog.ui" line="+19"/>
         <source>Bitcoin Core - Command-line options</source>
         <translation>位元幣核心 - 命令列選項</translation>
     </message>
     <message>
-        <location filename="../utilitydialog.cpp" line="+24"/>
         <source>Bitcoin Core</source>
         <translation>位元幣核心</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Usage:</source>
         <translation>用法:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>command-line options</source>
         <translation>命令列選項</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>UI options</source>
         <translation>使用界面選項</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set language, for example &quot;de_DE&quot; (default: system locale)</source>
         <translation>設定語言，比如說 de_DE (預設值: 系統語系)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Start minimized</source>
         <translation>啓動時縮到最小</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Set SSL root certificates for payment request (default: -system-)</source>
         <translation>設定付款請求時所使用的 SSL 根憑證 (預設值: 系統憑證庫)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show splash screen on startup (default: 1)</source>
         <translation>顯示啓動畫面(預設值: 1)</translation>
     </message>
     <message>
-        <location line="-4"/>
         <source>Choose data directory on startup (default: 0)</source>
         <translation>啓動時選擇資料目錄(預設值: 0)</translation>
     </message>
@@ -1171,57 +932,46 @@ Address: %4
 <context>
     <name>Intro</name>
     <message>
-        <location filename="../forms/intro.ui" line="+14"/>
         <source>Welcome</source>
         <translation>歡迎</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Welcome to Bitcoin Core.</source>
         <translation>歡迎使用位元幣核心</translation>
     </message>
     <message>
-        <location line="+26"/>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Core will store its data.</source>
         <translation>因為這是程式第一次啓動，你可以選擇位元幣核心儲存資料的地方。</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Bitcoin Core will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
         <translation>位元幣核心會下載並儲存一份位元幣區塊鏈的拷貝。至少有 %1GB 的資料會儲存到這個目錄中，並且還會持續增長。另外錢包資料也會儲存在這個目錄。</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Use the default data directory</source>
         <translation>使用預設的資料目錄</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Use a custom data directory:</source>
         <translation>使用自定的資料目錄:</translation>
     </message>
     <message>
-        <location filename="../intro.cpp" line="+82"/>
         <source>Bitcoin</source>
         <translation>位元幣</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Specified data directory &quot;%1&quot; can not be created.</source>
         <translation>錯誤: 沒辦法造出指定的資料目錄 %1 。</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>GB of free space available</source>
         <translation>GB 可用空間</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>(of %1GB needed)</source>
         <translation>(需要 %1GB)</translation>
     </message>
@@ -1229,27 +979,22 @@ Address: %4
 <context>
     <name>OpenURIDialog</name>
     <message>
-        <location filename="../forms/openuridialog.ui" line="+14"/>
         <source>Open URI</source>
         <translation>開啓 URI</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Open payment request from URI or file</source>
         <translation>從 URI 或檔案開啟付款要求</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>URI:</source>
         <translation>URI:</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Select payment request file</source>
         <translation>選擇付款要求資料檔</translation>
     </message>
     <message>
-        <location filename="../openuridialog.cpp" line="+47"/>
         <source>Select payment request file to open</source>
         <translation>選擇要開啟的付款要求資料檔</translation>
     </message>
@@ -1257,258 +1002,206 @@ Address: %4
 <context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="../forms/optionsdialog.ui" line="+14"/>
         <source>Options</source>
         <translation>選項</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>&amp;Main</source>
         <translation>主要</translation>
     </message>
     <message>
-        <location line="+116"/>
         <source>Optional transaction fee per kB that helps make sure your transactions are processed quickly. Most transactions are 1 kB.</source>
         <translation>每一千位元組(kB)要付的交易手續費，如果有付可以加速網路處理你的交易。大部份交易資料的大小是 1 kB.</translation>
     </message>
     <message>
-        <location line="+15"/>
         <source>Pay transaction &amp;fee</source>
         <translation>付交易手續費</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Automatically start Bitcoin after logging in to the system.</source>
         <translation>在登入系統後自動啓動位元幣軟體。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Start Bitcoin on system login</source>
         <translation>系統登入時啟動位元幣</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Size of &amp;database cache</source>
         <translation>資料庫快取大小</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>MB</source>
         <translation>MB (百萬位元組)</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Number of script &amp;verification threads</source>
         <translation>指令碼驗證執行緒數目</translation>
     </message>
     <message>
-        <location line="+160"/>
         <source>Connect to the Bitcoin network through a SOCKS proxy.</source>
         <translation>透過 SOCKS 代理伺服器來連線到位元幣網路。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Connect through SOCKS proxy (default proxy):</source>
         <translation>透過 SOCKS 代理伺服器連線(預設代理伺服器):</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>IP address of the proxy (e.g. IPv4: 127.0.0.1 / IPv6: ::1)</source>
         <translation>代理伺服器的網際網路位址(像是 IPv4 的 127.0.0.1 或 IPv6 的 ::1)</translation>
     </message>
     <message>
-        <location line="+214"/>
         <source>Active command-line options that override above options:</source>
         <translation>從命令列取代掉以上設定的選項有:</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Reset all client options to default.</source>
         <translation>重設所有客戶端軟體選項成預設值。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Reset Options</source>
         <translation>重設選項</translation>
     </message>
     <message>
-        <location line="-313"/>
         <source>&amp;Network</source>
         <translation>網路</translation>
     </message>
     <message>
-        <location line="-131"/>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
         <translation>(0 表示程式自動決定，小於 0 表示保留處理器核心不用的數目)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>W&amp;allet</source>
         <translation>錢包</translation>
     </message>
     <message>
-        <location line="+65"/>
         <source>Expert</source>
         <translation>專家</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Enable coin &amp;control features</source>
         <translation>開啟錢幣控制功能</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>If you disable the spending of unconfirmed change, the change from a transaction cannot be used until that transaction has at least one confirmation. This also affects how your balance is computed.</source>
         <translation>如果你關掉「可以花還沒確認的零錢」，那麼交易中找零的零錢就必須要等交易至少有一次確認後，才能夠使用。這也會影響餘額的計算方式。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Spend unconfirmed change</source>
         <translation>可以花還沒確認的零錢</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Automatically open the Bitcoin client port on the router. This only works when your router supports UPnP and it is enabled.</source>
         <translation>自動在路由器上開放位元幣的客戶端通訊埠。只有在你的路由器支援且開啓「通用即插即用」協定(UPnP)時才有作用。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Map port using &amp;UPnP</source>
         <translation>用 &amp;UPnP 設定通訊埠對應</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Proxy &amp;IP:</source>
         <translation>代理位址:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>&amp;Port:</source>
         <translation>埠號:</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Port of the proxy (e.g. 9050)</source>
         <translation>代理伺服器的通訊埠(像是 9050)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>SOCKS &amp;Version:</source>
         <translation>SOCKS 版本:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>SOCKS version of the proxy (e.g. 5)</source>
         <translation>代理伺服器的 SOCKS 協定版本(像是 5)</translation>
     </message>
     <message>
-        <location line="+36"/>
         <source>&amp;Window</source>
         <translation>視窗</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Show only a tray icon after minimizing the window.</source>
         <translation>視窗縮到最小後只在通知區域顯示圖示。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Minimize to the tray instead of the taskbar</source>
         <translation>縮到最小到通知區域而不是工作列</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Minimize instead of exit the application when the window is closed. When this option is enabled, the application will be closed only after selecting Quit in the menu.</source>
         <translation>當視窗關閉時，把應用程式縮到最小，而不是結束。當勾選這個選項時，只能夠用選單中的結束來關掉應用程式。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>M&amp;inimize on close</source>
         <translation>關閉時縮到最小</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>&amp;Display</source>
         <translation>顯示</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>User Interface &amp;language:</source>
         <translation>使用界面語言:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin.</source>
         <translation>可以在這裡設定使用者介面的語言。這個設定在重啓位元幣軟體後才會生效。</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>&amp;Unit to show amounts in:</source>
         <translation>金額顯示單位:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Choose the default subdivision unit to show in the interface and when sending coins.</source>
         <translation>選擇操作界面和付款時，預設顯示金額的細分單位。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Whether to show Bitcoin addresses in the transaction list or not.</source>
         <translation>是否要在交易列表中顯示位元幣位址。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Display addresses in transaction list</source>
         <translation>在交易列表顯示位址</translation>
     </message>
     <message>
-        <location line="-262"/>
         <source>Whether to show coin control features or not.</source>
         <translation>是否要顯示錢幣控制功能。</translation>
     </message>
     <message>
-        <location line="+398"/>
         <source>&amp;OK</source>
         <translation>好</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../optionsdialog.cpp" line="+72"/>
         <source>default</source>
         <translation>預設值</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>none</source>
         <translation>無</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Confirm options reset</source>
         <translation>確認重設選項</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+29"/>
         <source>Client restart required to activate changes.</source>
         <translation>需要重新啟動客戶端軟體來讓改變生效。</translation>
     </message>
     <message>
-        <location line="-29"/>
         <source>Client will be shutdown, do you want to proceed?</source>
         <translation>客戶端軟體就要關掉了，繼續做下去嗎?</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>This change would require a client restart.</source>
         <translation>這項改變需要重新啟動客戶端軟體。</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>The supplied proxy address is invalid.</source>
         <translation>提供的代理伺服器位址無效。</translation>
     </message>
@@ -1516,69 +1209,54 @@ Address: %4
 <context>
     <name>OverviewPage</name>
     <message>
-        <location filename="../forms/overviewpage.ui" line="+14"/>
         <source>Form</source>
         <translation>表單</translation>
     </message>
     <message>
-        <location line="+50"/>
-        <location line="+231"/>
         <source>The displayed information may be out of date. Your wallet automatically synchronizes with the Bitcoin network after a connection is established, but this process has not completed yet.</source>
         <translation>顯示的資訊可能是過期的。跟位元幣網路的連線建立後，你的錢包會自動和網路同步，但是這個步驟還沒完成。</translation>
     </message>
     <message>
-        <location line="-238"/>
         <source>Wallet</source>
         <translation>錢包</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Available:</source>
         <translation>可用金額:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current spendable balance</source>
         <translation>目前可用餘額</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Pending:</source>
         <translation>未定金額:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</source>
         <translation>還沒被確認的交易的總金額，可用餘額不包含這些金額</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Immature:</source>
         <translation>未成熟金額:</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Mined balance that has not yet matured</source>
         <translation>還沒成熟的開採金額</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Total:</source>
         <translation>總金額:</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Your current total balance</source>
         <translation>目前全部餘額</translation>
     </message>
     <message>
-        <location line="+71"/>
         <source>&lt;b&gt;Recent transactions&lt;/b&gt;</source>
         <translation>&lt;b&gt;最近交易&lt;/b&gt;</translation>
     </message>
     <message>
-        <location filename="../overviewpage.cpp" line="+120"/>
-        <location line="+1"/>
         <source>out of sync</source>
         <translation>還沒同步</translation>
     </message>
@@ -1586,93 +1264,70 @@ Address: %4
 <context>
     <name>PaymentServer</name>
     <message>
-        <location filename="../paymentserver.cpp" line="+403"/>
-        <location line="+13"/>
         <source>URI handling</source>
         <translation>URI 處理</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI can not be parsed! This can be caused by an invalid Bitcoin address or malformed URI parameters.</source>
         <translation>沒辦法解析 URI 位址！可能是因為位元幣位址無效，或是 URI 參數格式錯誤。</translation>
     </message>
     <message>
-        <location line="+96"/>
         <source>Requested payment amount of %1 is too small (considered dust).</source>
         <translation>要求付款的金額 %1 太少(會被網路認為是沒必要的零散錢)。</translation>
     </message>
     <message>
-        <location line="-221"/>
-        <location line="+212"/>
-        <location line="+13"/>
-        <location line="+95"/>
-        <location line="+18"/>
-        <location line="+16"/>
         <source>Payment request error</source>
         <translation>要求付款時發生錯誤</translation>
     </message>
     <message>
-        <location line="-353"/>
         <source>Cannot start bitcoin: click-to-pay handler</source>
         <translation>沒辦法啟動 bitcoin 協議的按就付處理器</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Net manager warning</source>
         <translation>網路管理員警告</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Your active proxy doesn&apos;t support SOCKS5, which is required for payment requests via proxy.</source>
         <translation>目前使用中的代理伺服器不支援 SOCKS5 通訊協定，因此不能透過它來要求付款。</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>Payment request fetch URL is invalid: %1</source>
         <translation>取得付款要求的 URL 無效: %1</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Payment request file handling</source>
         <translation>處理付款要求檔案</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Payment request file can not be read or processed! This can be caused by an invalid payment request file.</source>
         <translation>沒辦法讀或處理付款要求檔案！可能是無效的檔案造成的。</translation>
     </message>
     <message>
-        <location line="+73"/>
         <source>Unverified payment requests to custom payment scripts are unsupported.</source>
         <translation>不支援含有自訂付款指令碼，且沒驗證過的付款要求。</translation>
     </message>
     <message>
-        <location line="+59"/>
         <source>Refund from %1</source>
         <translation>來自 %1 的退款</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Error communicating with %1: %2</source>
         <translation>跟 %1 通訊時發生錯誤: %2</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>Payment request can not be parsed or processed!</source>
         <translation>沒辦法解析或處理付款要求！</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Bad response from server %1</source>
         <translation>伺服器 %1 的回應有誤</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>Payment acknowledged</source>
         <translation>已確認付款</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Network request error</source>
         <translation>發出要求時發生網路錯誤</translation>
     </message>
@@ -1680,29 +1335,22 @@ Address: %4
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../bitcoin.cpp" line="+63"/>
-        <location line="+7"/>
-        <location line="+13"/>
         <source>Bitcoin</source>
         <translation>位元幣</translation>
     </message>
     <message>
-        <location line="-19"/>
         <source>Error: Specified data directory &quot;%1&quot; does not exist.</source>
         <translation>錯誤: 沒有指定的資料目錄 %1 。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Error: Cannot parse configuration file: %1. Only use key=value syntax.</source>
         <translation>錯誤: 沒辦法解析設定檔: %1。請只用「名稱=設定值」這種語法。</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Error: Invalid combination of -regtest and -testnet.</source>
         <translation>錯誤: -regtest 和 -testnet 的使用組合無效。</translation>
     </message>
     <message>
-        <location filename="../guiutil.cpp" line="+89"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>請輸入位元幣位址(像是 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
@@ -1710,22 +1358,18 @@ Address: %4
 <context>
     <name>QRImageWidget</name>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+36"/>
         <source>&amp;Save Image...</source>
         <translation>儲存圖片...</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>&amp;Copy Image</source>
         <translation>複製圖片</translation>
     </message>
     <message>
-        <location line="+28"/>
         <source>Save QR Code</source>
         <translation>儲存 QR Code</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>PNG Image (*.png)</source>
         <translation>PNG 圖檔(*.png)</translation>
     </message>
@@ -1733,194 +1377,146 @@ Address: %4
 <context>
     <name>RPCConsole</name>
     <message>
-        <location filename="../forms/rpcconsole.ui" line="+46"/>
         <source>Client name</source>
         <translation>客戶端軟體名稱</translation>
     </message>
     <message>
-        <location line="+10"/>
-        <location line="+23"/>
-        <location line="+26"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+36"/>
-        <location line="+23"/>
-        <location line="+23"/>
-        <location filename="../rpcconsole.cpp" line="+373"/>
         <source>N/A</source>
         <translation>未知</translation>
     </message>
     <message>
-        <location line="-223"/>
         <source>Client version</source>
         <translation>客戶端軟體版本</translation>
     </message>
     <message>
-        <location line="-45"/>
         <source>&amp;Information</source>
         <translation>資訊</translation>
     </message>
     <message>
-        <location line="-10"/>
         <source>Debug window</source>
         <translation>除錯視窗</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>General</source>
         <translation>普通</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Using OpenSSL version</source>
         <translation>使用的 OpenSSL 版本</translation>
     </message>
     <message>
-        <location line="+49"/>
         <source>Startup time</source>
         <translation>啓動時間</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Network</source>
         <translation>網路</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Name</source>
         <translation>名稱</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Number of connections</source>
         <translation>連線數</translation>
     </message>
     <message>
-        <location line="+29"/>
         <source>Block chain</source>
         <translation>區塊鏈</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Current number of blocks</source>
         <translation>目前區塊數</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Estimated total blocks</source>
         <translation>估計總區塊數</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Last block time</source>
         <translation>最近區塊時間</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Open</source>
         <translation>開啓</translation>
     </message>
     <message>
-        <location line="+24"/>
         <source>&amp;Console</source>
         <translation>主控台</translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>&amp;Network Traffic</source>
         <translation>網路流量</translation>
     </message>
     <message>
-        <location line="+52"/>
         <source>&amp;Clear</source>
         <translation>清掉</translation>
     </message>
     <message>
-        <location line="+13"/>
         <source>Totals</source>
         <translation>總計</translation>
     </message>
     <message>
-        <location line="+64"/>
-        <location filename="../rpcconsole.cpp" line="-10"/>
         <source>In:</source>
         <translation>輸入:</translation>
     </message>
     <message>
-        <location line="+80"/>
-        <location filename="../rpcconsole.cpp" line="+1"/>
         <source>Out:</source>
         <translation>輸出:</translation>
     </message>
     <message>
-        <location line="-521"/>
         <source>Build date</source>
         <translation>建置日期</translation>
     </message>
     <message>
-        <location line="+206"/>
         <source>Debug log file</source>
         <translation>除錯紀錄檔</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Open the Bitcoin debug log file from the current data directory. This can take a few seconds for large log files.</source>
         <translation>從目前的資料目錄下開啓位元幣軟體的除錯紀錄檔。當紀錄檔很大時，可能會花好幾秒的時間。</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Clear console</source>
         <translation>清主控台</translation>
     </message>
     <message>
-        <location filename="../rpcconsole.cpp" line="-35"/>
         <source>Welcome to the Bitcoin RPC console.</source>
         <translation>歡迎使用位元幣 RPC 主控台。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
         <translation>請用上下游標鍵來瀏覽先前指令的紀錄，並用 &lt;b&gt;Ctrl-L&lt;/b&gt; 來清畫面。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type &lt;b&gt;help&lt;/b&gt; for an overview of available commands.</source>
         <translation>請打 &lt;b&gt;help&lt;/b&gt; 來看可用指令的簡介。</translation>
     </message>
     <message>
-        <location line="+136"/>
         <source>%1 B</source>
         <translation>%1 B (位元組)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 KB</source>
         <translation>%1 KB (千位元組)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 MB</source>
         <translation>%1 MB (百萬位元組)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 GB</source>
         <translation>%1 GB (十億位元組)</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>%1 m</source>
         <translation>%1 分鐘</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>%1 h</source>
         <translation>%1 小時</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 h %2 m</source>
         <translation>%1 小時 %2 分</translation>
     </message>
@@ -1928,105 +1524,82 @@ Address: %4
 <context>
     <name>ReceiveCoinsDialog</name>
     <message>
-        <location filename="../forms/receivecoinsdialog.ui" line="+107"/>
         <source>&amp;Amount:</source>
         <translation>金額:</translation>
     </message>
     <message>
-        <location line="-16"/>
         <source>&amp;Label:</source>
         <translation>標記:</translation>
     </message>
     <message>
-        <location line="-37"/>
         <source>&amp;Message:</source>
         <translation>訊息:</translation>
     </message>
     <message>
-        <location line="-20"/>
         <source>Reuse one of the previously used receiving addresses. Reusing addresses has security and privacy issues. Do not use this unless re-generating a payment request made before.</source>
         <translation>重複使用先前使用過的收款位址。重複使用位址會有安全和隱私方面的問題。除非是要重新產生先前的付款要求，不然請不要使用。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>R&amp;euse an existing receiving address (not recommended)</source>
         <translation>重複使用現有的收款位址(不建議)</translation>
     </message>
     <message>
-        <location line="+14"/>
-        <location line="+23"/>
         <source>An optional message to attach to the payment request, which will be displayed when the request is opened. Note: The message will not be sent with the payment over the Bitcoin network.</source>
         <translation>附加在付款要求中的訊息，可以不填，打開要求內容時會顯示。注意: 這個訊息不會隨著付款送到位元幣網路上。</translation>
     </message>
     <message>
-        <location line="-7"/>
-        <location line="+21"/>
         <source>An optional label to associate with the new receiving address.</source>
         <translation>跟新收款位址關聯的標記，可以不填。</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Use this form to request payments. All fields are &lt;b&gt;optional&lt;/b&gt;.</source>
         <translation>請用這份表單來要求付款。所有欄位都&lt;b&gt;可以不填&lt;/b&gt;。</translation>
     </message>
     <message>
-        <location line="+23"/>
-        <location line="+22"/>
         <source>An optional amount to request. Leave this empty or zero to not request a specific amount.</source>
         <translation>要求付款的金額，可以不填。不確定金額時可以留白或是填零。</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Clear all fields of the form.</source>
         <translation>把表單中的所有欄位清空。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear</source>
         <translation>清空</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Requested payments history</source>
         <translation>先前要求付款的記錄</translation>
     </message>
     <message>
-        <location line="-98"/>
         <source>&amp;Request payment</source>
         <translation>要求付款</translation>
     </message>
     <message>
-        <location line="+120"/>
         <source>Show the selected request (does the same as double clicking an entry)</source>
         <translation>顯示選擇的要求內容(效果跟按它兩下一樣)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Show</source>
         <translation>顯示</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Remove the selected entries from the list</source>
         <translation>從列表中刪掉選擇的項目</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Remove</source>
         <translation>刪掉</translation>
     </message>
     <message>
-        <location filename="../receivecoinsdialog.cpp" line="+39"/>
         <source>Copy label</source>
         <translation>複製標記</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy message</source>
         <translation>複製訊息</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>複製金額</translation>
     </message>
@@ -2034,67 +1607,54 @@ Address: %4
 <context>
     <name>ReceiveRequestDialog</name>
     <message>
-        <location filename="../forms/receiverequestdialog.ui" line="+29"/>
         <source>QR Code</source>
         <translation>QR Code</translation>
     </message>
     <message>
-        <location line="+46"/>
         <source>Copy &amp;URI</source>
         <translation>複製 URI</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Copy &amp;Address</source>
         <translation>複製位址</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>&amp;Save Image...</source>
         <translation>儲存圖片...</translation>
     </message>
     <message>
-        <location filename="../receiverequestdialog.cpp" line="+56"/>
         <source>Request payment to %1</source>
         <translation>付款給 %1 的要求</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Payment information</source>
         <translation>付款資訊</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>URI</source>
         <translation>URI</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Label</source>
         <translation>標記</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Message</source>
         <translation>訊息</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Resulting URI too long, try to reduce the text for label / message.</source>
         <translation>產生的 URI 過長，請試著縮短標記或訊息的文字內容。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Error encoding URI into QR Code.</source>
         <translation>把 URI 編碼成 QR Code 時發生錯誤。</translation>
     </message>
@@ -2102,37 +1662,30 @@ Address: %4
 <context>
     <name>RecentRequestsTableModel</name>
     <message>
-        <location filename="../recentrequeststablemodel.cpp" line="+24"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Label</source>
         <translation>標記</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Message</source>
         <translation>訊息</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(no label)</source>
         <translation>(無標記)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(no message)</source>
         <translation>(無訊息)</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>(no amount)</source>
         <translation>(無金額)</translation>
     </message>
@@ -2140,247 +1693,194 @@ Address: %4
 <context>
     <name>SendCoinsDialog</name>
     <message>
-        <location filename="../forms/sendcoinsdialog.ui" line="+14"/>
-        <location filename="../sendcoinsdialog.cpp" line="+380"/>
-        <location line="+80"/>
         <source>Send Coins</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location line="+76"/>
         <source>Coin Control Features</source>
         <translation>錢幣控制功能</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>Inputs...</source>
         <translation>輸入...</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>automatically selected</source>
         <translation>自動選擇</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Insufficient funds!</source>
         <translation>累計金額不足！</translation>
     </message>
     <message>
-        <location line="+89"/>
         <source>Quantity:</source>
         <translation>數目:</translation>
     </message>
     <message>
-        <location line="+35"/>
         <source>Bytes:</source>
         <translation>位元組數:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Amount:</source>
         <translation>金額:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Priority:</source>
         <translation>優先度:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>Fee:</source>
         <translation>手續費:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Low Output:</source>
         <translation>低輸出:</translation>
     </message>
     <message>
-        <location line="+48"/>
         <source>After Fee:</source>
         <translation>計費後金額:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Change:</source>
         <translation>找零金額:</translation>
     </message>
     <message>
-        <location line="+44"/>
         <source>If this is activated, but the change address is empty or invalid, change will be sent to a newly generated address.</source>
         <translation>如果這項有打開，但是找零位址是空的或無效，那麼找零的錢會送到一個新產生的位址去。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Custom change address</source>
         <translation>自定找零位址</translation>
     </message>
     <message>
-        <location line="+164"/>
         <source>Send to multiple recipients at once</source>
         <translation>一次付給多個收款人</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Add &amp;Recipient</source>
         <translation>增加收款人</translation>
     </message>
     <message>
-        <location line="-23"/>
         <source>Clear all fields of the form.</source>
         <translation>把表單中的所有欄位清空。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Clear &amp;All</source>
         <translation>全部清掉</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>Balance:</source>
         <translation>餘額:</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>Confirm the send action</source>
         <translation>確認付款動作</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>S&amp;end</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location filename="../sendcoinsdialog.cpp" line="-229"/>
         <source>Confirm send coins</source>
         <translation>確認付款金額</translation>
     </message>
     <message>
-        <location line="-74"/>
-        <location line="+5"/>
-        <location line="+5"/>
-        <location line="+4"/>
         <source>%1 to %2</source>
         <translation>%1 給 %2</translation>
     </message>
     <message>
-        <location line="-121"/>
         <source>Copy quantity</source>
         <translation>複製數目</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>複製金額</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy fee</source>
         <translation>複製手續費</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy after fee</source>
         <translation>複製計費後金額</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy bytes</source>
         <translation>複製位元組數</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy priority</source>
         <translation>複製優先度</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy low output</source>
         <translation>複製低輸出</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy change</source>
         <translation>複製找零金額</translation>
     </message>
     <message>
-        <location line="+170"/>
         <source>Total Amount %1 (= %2)</source>
         <translation>總金額 %1 (= %2)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>or</source>
         <translation>或</translation>
     </message>
     <message>
-        <location line="+203"/>
         <source>The recipient address is not valid, please recheck.</source>
         <translation>收款位址無效，請再檢查看看。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount to pay must be larger than 0.</source>
         <translation>付款金額必須大於零。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The amount exceeds your balance.</source>
         <translation>金額超過餘額了。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>The total exceeds your balance when the %1 transaction fee is included.</source>
         <translation>包含 %1 的交易手續費後，總金額超過你的餘額了。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Duplicate address found, can only send to each address once per send operation.</source>
         <translation>發現有重複的位址。每個付款動作中，只能付給個別的位址一次。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Transaction creation failed!</source>
         <translation>製造交易失敗了！</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>交易被拒絕了！有時候會發生這種錯誤，是因為你錢包中的一些錢已經被花掉了。比如說你複製了錢包檔 wallet.dat, 然後用複製的錢包花掉了錢，你現在所用的原來的錢包中，卻沒有那筆錢已經花掉的紀錄。</translation>
     </message>
     <message>
-        <location line="+113"/>
         <source>Warning: Invalid Bitcoin address</source>
         <translation>警告: 位元幣位址無效</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>(no label)</source>
         <translation>(無標記)</translation>
     </message>
     <message>
-        <location line="-11"/>
         <source>Warning: Unknown change address</source>
         <translation>警告: 不明的找零位址</translation>
     </message>
     <message>
-        <location line="-367"/>
         <source>Are you sure you want to send?</source>
         <translation>你確定要付錢出去嗎？</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>added as transaction fee</source>
         <translation>加做交易手續費</translation>
     </message>
     <message>
-        <location line="+171"/>
         <source>Payment request expired</source>
         <translation>付款的要求已經過期</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Invalid payment address %1</source>
         <translation>無效的付款位址 %1</translation>
     </message>
@@ -2388,98 +1888,74 @@ Address: %4
 <context>
     <name>SendCoinsEntry</name>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+131"/>
-        <location line="+521"/>
-        <location line="+536"/>
         <source>A&amp;mount:</source>
         <translation>金額:</translation>
     </message>
     <message>
-        <location line="-1152"/>
         <source>Pay &amp;To:</source>
         <translation>付給:</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to send the payment to (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>付款的目標位址(像是 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location filename="../sendcoinsentry.cpp" line="+30"/>
         <source>Enter a label for this address to add it to your address book</source>
         <translation>請輸入這個位址的標記來把它加進位址簿中</translation>
     </message>
     <message>
-        <location filename="../forms/sendcoinsentry.ui" line="+57"/>
         <source>&amp;Label:</source>
         <translation>標記:</translation>
     </message>
     <message>
-        <location line="-50"/>
         <source>Choose previously used address</source>
         <translation>選擇先前使用過的位址</translation>
     </message>
     <message>
-        <location line="-40"/>
         <source>This is a normal payment.</source>
         <translation>這是一筆正常的付款。</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Paste address from clipboard</source>
         <translation>貼上剪貼簿裡的位址</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+524"/>
-        <location line="+536"/>
         <source>Remove this entry</source>
         <translation>刪掉這個項目</translation>
     </message>
     <message>
-        <location line="-1008"/>
         <source>Message:</source>
         <translation>訊息:</translation>
     </message>
     <message>
-        <location line="+968"/>
         <source>This is a verified payment request.</source>
         <translation>這是個已驗證的付款要求。</translation>
     </message>
     <message>
-        <location line="-991"/>
         <source>Enter a label for this address to add it to the list of used addresses</source>
         <translation>請輸入這個位址的標記，來把它加進去已使用過位址的清單。</translation>
     </message>
     <message>
-        <location line="+33"/>
         <source>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</source>
         <translation>附加在位元幣付款協議 URI 中的訊息，會和交易內容一起存起來，給你自己做參考。注意: 這個訊息不會送到位元幣網路上。</translation>
     </message>
     <message>
-        <location line="+426"/>
         <source>This is an unverified payment request.</source>
         <translation>這是個沒驗證過的付款要求。</translation>
     </message>
     <message>
-        <location line="+18"/>
-        <location line="+532"/>
         <source>Pay To:</source>
         <translation>付給:</translation>
     </message>
     <message>
-        <location line="-498"/>
-        <location line="+536"/>
         <source>Memo:</source>
         <translation>備註:</translation>
     </message>
@@ -2487,12 +1963,10 @@ Address: %4
 <context>
     <name>ShutdownWindow</name>
     <message>
-        <location filename="../utilitydialog.cpp" line="+52"/>
         <source>Bitcoin Core is shutting down...</source>
         <translation>位元幣核心正在關閉中...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not shut down the computer until this window disappears.</source>
         <translation> 在這個視窗不見以前，請不要關掉電腦。</translation>
     </message>
@@ -2500,186 +1974,142 @@ Address: %4
 <context>
     <name>SignVerifyMessageDialog</name>
     <message>
-        <location filename="../forms/signverifymessagedialog.ui" line="+14"/>
         <source>Signatures - Sign / Verify a Message</source>
         <translation>簽章 - 簽署或驗證訊息</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>&amp;Sign Message</source>
         <translation>簽署訊息</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>You can sign messages with your addresses to prove you own them. Be careful not to sign anything vague, as phishing attacks may try to trick you into signing your identity over to them. Only sign fully-detailed statements you agree to.</source>
         <translation>你可以用自己的位址簽署訊息，來證明你對位址的所有權。但是請小心，不要簽署語意含糊不清的內容，因為釣魚式詐騙可能會用騙你簽署的手法來冒充是你。只有在語句中的細節你都同意時才簽署。</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>The address to sign the message with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>用來簽署訊息的位址(像是 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+7"/>
-        <location line="+210"/>
         <source>Choose previously used address</source>
         <translation>選擇先前使用過的位址</translation>
     </message>
     <message>
-        <location line="-200"/>
-        <location line="+210"/>
         <source>Alt+A</source>
         <translation>Alt+A</translation>
     </message>
     <message>
-        <location line="-200"/>
         <source>Paste address from clipboard</source>
         <translation>貼上剪貼簿裡的位址</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Alt+P</source>
         <translation>Alt+P</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Enter the message you want to sign here</source>
         <translation>請在這裡輸入你想簽署的訊息</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Signature</source>
         <translation>簽章</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Copy the current signature to the system clipboard</source>
         <translation>複製目前的簽章到系統剪貼簿</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>Sign the message to prove you own this Bitcoin address</source>
         <translation>簽署這個訊息來證明這個位元幣位址是你的</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sign &amp;Message</source>
         <translation>簽署訊息</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all sign message fields</source>
         <translation>重設所有訊息簽署欄位</translation>
     </message>
     <message>
-        <location line="+3"/>
-        <location line="+143"/>
         <source>Clear &amp;All</source>
         <translation>全部清掉</translation>
     </message>
     <message>
-        <location line="-84"/>
         <source>&amp;Verify Message</source>
         <translation>驗證訊息</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter the signing address, message (ensure you copy line breaks, spaces, tabs, etc. exactly) and signature below to verify the message. Be careful not to read more into the signature than what is in the signed message itself, to avoid being tricked by a man-in-the-middle attack.</source>
         <translation>請在下面輸入簽署的位址，訊息(請確定完整複製了所包含的換行，空格，跳位符號等等)，以及簽章，來驗證這個訊息。請小心，除了訊息內容以外，不要對簽章本身過度解讀，以避免被用「中間人攻擊法」詐騙。</translation>
     </message>
     <message>
-        <location line="+21"/>
         <source>The address the message was signed with (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>簽署這個訊息的位址(像是 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="+37"/>
         <source>Verify the message to ensure it was signed with the specified Bitcoin address</source>
         <translation>驗證這個訊息來確定是用指定的位元幣位址簽署的</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Verify &amp;Message</source>
         <translation>驗證訊息</translation>
     </message>
     <message>
-        <location line="+14"/>
         <source>Reset all verify message fields</source>
         <translation>重設所有訊息驗證欄位</translation>
     </message>
     <message>
-        <location filename="../signverifymessagedialog.cpp" line="+30"/>
         <source>Enter a Bitcoin address (e.g. 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</source>
         <translation>請輸入位元幣位址(像是 1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Click &quot;Sign Message&quot; to generate signature</source>
         <translation>請按一下「簽署訊息」來產生簽章</translation>
     </message>
     <message>
-        <location line="+84"/>
-        <location line="+80"/>
         <source>The entered address is invalid.</source>
         <translation>輸入的位址無效。</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+8"/>
-        <location line="+72"/>
-        <location line="+8"/>
         <source>Please check the address and try again.</source>
         <translation>請檢查位址是否正確後再試一次。</translation>
     </message>
     <message>
-        <location line="-80"/>
-        <location line="+80"/>
         <source>The entered address does not refer to a key.</source>
         <translation>輸入的位址沒有對應到你的任何密鑰。</translation>
     </message>
     <message>
-        <location line="-72"/>
         <source>Wallet unlock was cancelled.</source>
         <translation>錢包解鎖已取消。</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Private key for the entered address is not available.</source>
         <translation>沒有對應輸入位址的密鑰。</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Message signing failed.</source>
         <translation>訊息簽署失敗。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message signed.</source>
         <translation>訊息簽署好了。</translation>
     </message>
     <message>
-        <location line="+58"/>
         <source>The signature could not be decoded.</source>
         <translation>沒辦法把這個簽章解碼。</translation>
     </message>
     <message>
-        <location line="+0"/>
-        <location line="+13"/>
         <source>Please check the signature and try again.</source>
         <translation>請檢查簽章是否正確後再試一次。</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The signature did not match the message digest.</source>
         <translation>這個簽章跟訊息的數位摘要不符。</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Message verification failed.</source>
         <translation>訊息驗證失敗。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Message verified.</source>
         <translation>訊息驗證沒錯。</translation>
     </message>
@@ -2687,17 +2117,14 @@ Address: %4
 <context>
     <name>SplashScreen</name>
     <message>
-        <location filename="../splashscreen.cpp" line="+32"/>
         <source>Bitcoin Core</source>
         <translation>位元幣核心</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>The Bitcoin Core developers</source>
         <translation>位元幣核心開發人員</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>[testnet]</source>
         <translation>[testnet]</translation>
     </message>
@@ -2705,7 +2132,6 @@ Address: %4
 <context>
     <name>TrafficGraphWidget</name>
     <message>
-        <location filename="../trafficgraphwidget.cpp" line="+79"/>
         <source>KB/s</source>
         <translation>KB/s</translation>
     </message>
@@ -2713,184 +2139,138 @@ Address: %4
 <context>
     <name>TransactionDesc</name>
     <message>
-        <location filename="../transactiondesc.cpp" line="+28"/>
         <source>Open until %1</source>
         <translation>到 %1 前可修改</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>conflicted</source>
         <translation>有衝突</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/offline</source>
         <translation>%1 次/離線中</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1/unconfirmed</source>
         <translation>%1 次/未確認</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>%1 confirmations</source>
         <translation>確認 %1 次</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Status</source>
         <translation>狀態</translation>
     </message>
     <message numerus="yes">
-        <location line="+7"/>
         <source>, broadcast through %n node(s)</source>
         <translation><numerusform>，已公告給 %n 個節點</numerusform></translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Source</source>
         <translation>來源</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Generated</source>
         <translation>生產出來</translation>
     </message>
     <message>
-        <location line="+5"/>
-        <location line="+17"/>
         <source>From</source>
         <translation>來源</translation>
     </message>
     <message>
-        <location line="+1"/>
-        <location line="+22"/>
-        <location line="+58"/>
         <source>To</source>
         <translation>目的</translation>
     </message>
     <message>
-        <location line="-77"/>
-        <location line="+2"/>
         <source>own address</source>
         <translation>自己的位址</translation>
     </message>
     <message>
-        <location line="-2"/>
         <source>label</source>
         <translation>標記</translation>
     </message>
     <message>
-        <location line="+37"/>
-        <location line="+12"/>
-        <location line="+45"/>
-        <location line="+17"/>
-        <location line="+53"/>
         <source>Credit</source>
         <translation>入帳</translation>
     </message>
     <message numerus="yes">
-        <location line="-125"/>
         <source>matures in %n more block(s)</source>
         <translation><numerusform>再等 %n 個區塊生出來後成熟</numerusform></translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>not accepted</source>
         <translation>不被接受</translation>
     </message>
     <message>
-        <location line="+44"/>
-        <location line="+8"/>
-        <location line="+15"/>
-        <location line="+53"/>
         <source>Debit</source>
         <translation>出帳</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Transaction fee</source>
         <translation>交易手續費</translation>
     </message>
     <message>
-        <location line="+16"/>
         <source>Net amount</source>
         <translation>淨額</translation>
     </message>
     <message>
-        <location line="+6"/>
-        <location line="+9"/>
         <source>Message</source>
         <translation>訊息</translation>
     </message>
     <message>
-        <location line="-7"/>
         <source>Comment</source>
         <translation>附註</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Transaction ID</source>
         <translation>交易識別碼</translation>
     </message>
     <message>
-        <location line="+18"/>
         <source>Merchant</source>
         <translation>商家</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Generated coins must mature %1 blocks before they can be spent. When you generated this block, it was broadcast to the network to be added to the block chain. If it fails to get into the chain, its state will change to &quot;not accepted&quot; and it won&apos;t be spendable. This may occasionally happen if another node generates a block within a few seconds of yours.</source>
         <translation>生產出來的錢要再等 %1 個區塊生出來後才成熟可以用。當區塊生產出來時會公布到網路上，來被加進區塊鏈。如果加失敗了，狀態就會變成「不被接受」，而且不能夠花。如果在你生產出區塊的幾秒鐘內，也有其他節點生產出來的話，就有可能會發生這種情形。</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Debug information</source>
         <translation>除錯資訊</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Transaction</source>
         <translation>交易</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Inputs</source>
         <translation>輸入</translation>
     </message>
     <message>
-        <location line="+23"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>true</source>
         <translation>是</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>false</source>
         <translation>否</translation>
     </message>
     <message>
-        <location line="-232"/>
         <source>, has not been successfully broadcast yet</source>
         <translation>，還沒成功公告出去</translation>
     </message>
     <message numerus="yes">
-        <location line="-37"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>到下 %n 個區塊生出來前可修改</numerusform></translation>
     </message>
     <message>
-        <location line="+72"/>
         <source>unknown</source>
         <translation>未知</translation>
     </message>
@@ -2898,12 +2278,10 @@ Address: %4
 <context>
     <name>TransactionDescDialog</name>
     <message>
-        <location filename="../forms/transactiondescdialog.ui" line="+14"/>
         <source>Transaction details</source>
         <translation>交易明細</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>This pane shows a detailed description of the transaction</source>
         <translation>這個版面顯示這次交易的詳細說明</translation>
     </message>
@@ -2911,127 +2289,102 @@ Address: %4
 <context>
     <name>TransactionTableModel</name>
     <message>
-        <location filename="../transactiontablemodel.cpp" line="+234"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Type</source>
         <translation>種類</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location line="+78"/>
         <source>Immature (%1 confirmations, will be available after %2)</source>
         <translation>未成熟(確認 %1 次，會在 %2 次後可用)</translation>
     </message>
     <message numerus="yes">
-        <location line="-21"/>
         <source>Open for %n more block(s)</source>
         <translation><numerusform>到下 %n 個區塊生出來前可修改</numerusform></translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Open until %1</source>
         <translation>到 %1 前可修改</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Confirmed (%1 confirmations)</source>
         <translation>已確認(%1 次)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>This block was not received by any other nodes and will probably not be accepted!</source>
         <translation>沒有其他節點收到這個區塊，也許它不會被接受！</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Generated but not accepted</source>
         <translation>生產出來但是不被接受</translation>
     </message>
     <message>
-        <location line="-21"/>
         <source>Offline</source>
         <translation>離線中</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unconfirmed</source>
         <translation>未確認</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Confirming (%1 of %2 recommended confirmations)</source>
         <translation>確認中(已經 %1 次，建議至少 %2 次)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Conflicted</source>
         <translation>有衝突</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Received with</source>
         <translation>收款在</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Received from</source>
         <translation>收款自</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Sent to</source>
         <translation>付款給</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Payment to yourself</source>
         <translation>付給自己</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Mined</source>
         <translation>開採所得</translation>
     </message>
     <message>
-        <location line="+38"/>
         <source>(n/a)</source>
         <translation>(不適用)</translation>
     </message>
     <message>
-        <location line="+190"/>
         <source>Transaction status. Hover over this field to show number of confirmations.</source>
         <translation>交易狀態。把游標停在欄位上會顯示確認次數。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Date and time that the transaction was received.</source>
         <translation>收到交易的日期和時間。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Type of transaction.</source>
         <translation>交易的種類。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Destination address of transaction.</source>
         <translation>交易的目的地位址。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Amount removed from or added to balance.</source>
         <translation>要減掉或加進餘額的金額。</translation>
     </message>
@@ -3039,178 +2392,142 @@ Address: %4
 <context>
     <name>TransactionView</name>
     <message>
-        <location filename="../transactionview.cpp" line="+57"/>
-        <location line="+16"/>
         <source>All</source>
         <translation>全部</translation>
     </message>
     <message>
-        <location line="-15"/>
         <source>Today</source>
         <translation>今天</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This week</source>
         <translation>這星期</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This month</source>
         <translation>這個月</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Last month</source>
         <translation>上個月</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>This year</source>
         <translation>今年</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Range...</source>
         <translation>指定範圍...</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Received with</source>
         <translation>收款</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sent to</source>
         <translation>付款</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>To yourself</source>
         <translation>給自己</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Mined</source>
         <translation>開採所得</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Other</source>
         <translation>其它</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Enter address or label to search</source>
         <translation>請輸入要搜尋的位址或標記</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Min amount</source>
         <translation>最小金額</translation>
     </message>
     <message>
-        <location line="+34"/>
         <source>Copy address</source>
         <translation>複製位址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy label</source>
         <translation>複製標記</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy amount</source>
         <translation>複製金額</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Copy transaction ID</source>
         <translation>複製交易識別碼</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Edit label</source>
         <translation>編輯標記</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show transaction details</source>
         <translation>顯示交易明細</translation>
     </message>
     <message>
-        <location line="+140"/>
         <source>Export Transaction History</source>
         <translation>匯出交易記錄</translation>
     </message>
     <message>
-        <location line="+19"/>
         <source>Exporting Failed</source>
         <translation>匯出失敗</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the transaction history to %1.</source>
         <translation>儲存交易記錄到 %1 時發生錯誤。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Exporting Successful</source>
         <translation>匯出成功</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>The transaction history was successfully saved to %1.</source>
         <translation>交易記錄已經成功儲存到 %1 了。</translation>
     </message>
     <message>
-        <location line="-22"/>
         <source>Comma separated file (*.csv)</source>
         <translation>逗點分隔資料檔(*.csv)</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>Confirmed</source>
         <translation>已確認</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Date</source>
         <translation>日期</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Type</source>
         <translation>種類</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Label</source>
         <translation>標記</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Address</source>
         <translation>位址</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Amount</source>
         <translation>金額</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>ID</source>
         <translation>識別碼</translation>
     </message>
     <message>
-        <location line="+107"/>
         <source>Range:</source>
         <translation>範圍:</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>to</source>
         <translation>到</translation>
     </message>
@@ -3218,7 +2535,6 @@ Address: %4
 <context>
     <name>WalletFrame</name>
     <message>
-        <location filename="../walletframe.cpp" line="+26"/>
         <source>No wallet has been loaded.</source>
         <translation>沒有載入錢包。</translation>
     </message>
@@ -3226,7 +2542,6 @@ Address: %4
 <context>
     <name>WalletModel</name>
     <message>
-        <location filename="../walletmodel.cpp" line="+245"/>
         <source>Send Coins</source>
         <translation>付款</translation>
     </message>
@@ -3234,42 +2549,34 @@ Address: %4
 <context>
     <name>WalletView</name>
     <message>
-        <location filename="../walletview.cpp" line="+44"/>
         <source>&amp;Export</source>
         <translation>匯出</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Export the data in the current tab to a file</source>
         <translation>把目前分頁的資料匯出存成檔案</translation>
     </message>
     <message>
-        <location line="+184"/>
         <source>Backup Wallet</source>
         <translation>備份錢包</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet Data (*.dat)</source>
         <translation>錢包資料檔(*.dat)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Backup Failed</source>
         <translation>備份失敗</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>There was an error trying to save the wallet data to %1.</source>
         <translation>儲存錢包資料到 %1 時發生錯誤。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>The wallet data was successfully saved to %1.</source>
         <translation>錢包的資料已經成功儲存到 %1 了。</translation>
     </message>
     <message>
-        <location line="+0"/>
         <source>Backup Successful</source>
         <translation>備份成功</translation>
     </message>
@@ -3277,108 +2584,87 @@ Address: %4
 <context>
     <name>bitcoin-core</name>
     <message>
-        <location filename="../bitcoinstrings.cpp" line="+261"/>
         <source>Usage:</source>
         <translation>用法:</translation>
     </message>
     <message>
-        <location line="-66"/>
         <source>List commands</source>
         <translation>列出指令</translation>
     </message>
     <message>
-        <location line="-14"/>
         <source>Get help for a command</source>
         <translation>取得指令說明</translation>
     </message>
     <message>
-        <location line="+27"/>
         <source>Options:</source>
         <translation>選項:</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Specify configuration file (default: bitcoin.conf)</source>
         <translation>指定設定檔(預設值: bitcoin.conf)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Specify pid file (default: bitcoind.pid)</source>
         <translation>指定行程識別碼(PID)檔(預設值:  bitcoind.pid)</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Specify data directory</source>
         <translation>指定資料目錄</translation>
     </message>
     <message>
-        <location line="-46"/>
         <source>Listen for connections on &lt;port&gt; (default: 8333 or testnet: 18333)</source>
         <translation>在通訊埠 &lt;port&gt; 聽候連線(預設值: 8333, 或若是測試網路: 18333)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Maintain at most &lt;n&gt; connections to peers (default: 125)</source>
         <translation>維持連線節點數的上限為 &lt;n&gt; 個(預設值: 125)</translation>
     </message>
     <message>
-        <location line="-57"/>
         <source>Connect to a node to retrieve peer addresses, and disconnect</source>
         <translation>連線到某個節點來取得其它節點的位址，然後斷線</translation>
     </message>
     <message>
-        <location line="+100"/>
         <source>Specify your own public address</source>
         <translation>指定自己的公開位址</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Threshold for disconnecting misbehaving peers (default: 100)</source>
         <translation>把異常節點斷線的臨界值(預設值: 100)</translation>
     </message>
     <message>
-        <location line="-172"/>
         <source>Number of seconds to keep misbehaving peers from reconnecting (default: 86400)</source>
         <translation>拒絕跟異常節點連線的秒數(預設值: 86400)</translation>
     </message>
     <message>
-        <location line="-52"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv4: %s</source>
         <translation>設定在 IPv4 網路上以通訊埠 %u 聽取 RPC 連線時發生錯誤: %s</translation>
     </message>
     <message>
-        <location line="+50"/>
         <source>Listen for JSON-RPC connections on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>在通訊埠 &lt;port&gt; 聽候 JSON-RPC 連線(預設值: 8332, 或若是測試網路: 18332)</translation>
     </message>
     <message>
-        <location line="+51"/>
         <source>Accept command line and JSON-RPC commands</source>
         <translation>接受指令列和 JSON-RPC 指令
 </translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Bitcoin Core RPC client version</source>
         <translation>位元幣核心 RPC 客戶端軟體版本</translation>
     </message>
     <message>
-        <location line="+87"/>
         <source>Run in the background as a daemon and accept commands</source>
         <translation>用護靈模式在背後執行並接受指令</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use the test network</source>
         <translation>使用測試網路</translation>
     </message>
     <message>
-        <location line="-136"/>
         <source>Accept connections from outside (default: 1 if no -proxy or -connect)</source>
         <translation>是否接受外來連線(預設值: 當沒有 -proxy 或 -connect 時為 1)</translation>
     </message>
     <message>
-        <location line="-117"/>
         <source>%s, you must set a rpcpassword in the configuration file:
 %s
 It is recommended you use the following random password:
@@ -3403,852 +2689,682 @@ rpcpassword=%s
 alertnotify=echo %%s | mail -s &quot;Bitcoin Alert&quot; admin@foo.com</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Acceptable ciphers (default: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</source>
         <translation>可接受的加密演算法 (預設值: TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH)</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>An error occurred while setting up the RPC port %u for listening on IPv6, falling back to IPv4: %s</source>
         <translation>設定在 IPv6 網路上以通訊埠 %u 聽候 RPC 連線失敗，退而改用 IPv4 網路: %s</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Bind to given address and always listen on it. Use [host]:port notation for IPv6</source>
         <translation>和指定的位址繫結，並總是在指定位址聽候連線。IPv6 請用 [主機]:通訊埠 這種格式</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Continuously rate-limit free transactions to &lt;n&gt;*1000 bytes per minute (default:15)</source>
         <translation>對沒付手續費的交易持續限制一分鐘內最多只能有 &lt;n&gt; 千位元組 (預設值: 15)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly. This is intended for regression testing tools and app development.</source>
         <translation>進入回歸測試模式，使用可以立即解出區塊的特殊區塊鏈。目的是用來做回歸測試，以及配合應用程式的開發。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Enter regression test mode, which uses a special chain in which blocks can be solved instantly.</source>
         <translation>進入回歸測試模式，使用可以立即解出區塊的特殊區塊鏈。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Error: Listening for incoming connections failed (listen returned error %d)</source>
         <translation>錯誤: 聽候外來連線失敗(回傳錯誤 %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: The transaction was rejected! This might happen if some of the coins in your wallet were already spent, such as if you used a copy of wallet.dat and coins were spent in the copy but not marked as spent here.</source>
         <translation>錯誤: 交易被拒絕了！有時候會發生這種錯誤，是因為你錢包中的一些錢已經被花掉了。比如說你複製了錢包檔 wallet.dat, 然後用複製的錢包花掉了錢，你現在所用的原來的錢包中，卻沒有那筆錢已經花掉的紀錄。</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error: This transaction requires a transaction fee of at least %s because of its amount, complexity, or use of recently received funds!</source>
         <translation>錯誤: 這筆交易需要至少 %s 的手續費！因為它的金額太大，或複雜度太高，或是使用了最近才剛收到的款項。</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)</source>
         <translation>當錢包有交易改變時要執行的指令(指令中的 %s 會被取代成交易識別碼)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Fees smaller than this are considered zero fee (for transaction creation) (default:</source>
         <translation>手續費低於這個時會被認為是沒付手續費(產生交易用)(預設值:</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Flush database activity from memory pool to disk log every &lt;n&gt; megabytes (default: 100)</source>
         <translation>每當累積到 &lt;n&gt; 百萬位元組(MB)時，才將資料庫的變動從記憶體暫存池中寫進磁碟紀錄檔 (預設值: 100)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>How thorough the block verification of -checkblocks is (0-4, default: 3)</source>
         <translation>使用 -checkblocks 檢查區塊的仔細程度 (0 到 4，預設值: 3)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>In this mode -genproclimit controls how many blocks are generated immediately.</source>
         <translation>在這個運作模式下，-genproclimit 選項控制立刻產生出的區塊數目。</translation>
     </message>
     <message>
-        <location line="+12"/>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
         <translation>設定指令碼驗證的執行緒數目 (%u 到 %d，0 表示程式自動決定，小於 0 表示保留處理器核心不用的數目，預設值: 0)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Set the processor limit for when generation is on (-1 = unlimited, default: -1)</source>
         <translation>當生產位元幣打開時，設定處理器使用數目限制 (-1 表示不限制，預設值: -1)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>This is a pre-release test build - use at your own risk - do not use for mining or merchant applications</source>
         <translation>這是個還沒發表的測試版本 - 使用請自負風險 - 請不要用來開採或商業應用</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Unable to bind to %s on this computer. Bitcoin Core is probably already running.</source>
         <translation>沒辦法繫結在這台電腦上的 %s 。位元幣核心可能已經在執行了。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: -proxy)</source>
         <translation>使用另外的 SOCK5 代理伺服器，來透過 Tor 隱藏服務跟節點聯繫(預設值: 同 -proxy)</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: -paytxfee is set very high! This is the transaction fee you will pay if you send a transaction.</source>
         <translation>警告: -paytxfee 設定了很高的金額！這可是你交易付款所要付的手續費。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: Please check that your computer&apos;s date and time are correct! If your clock is wrong Bitcoin will not work properly.</source>
         <translation>警告: 請檢查電腦日期和時間是否正確！位元幣軟體沒辦法在時鐘不準的情況下正常運作。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: The network does not appear to fully agree! Some miners appear to be experiencing issues.</source>
         <translation>警告: 位元幣網路對於區塊鏈結的決定目前有分歧！看來有些礦工會有問題。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: We do not appear to fully agree with our peers! You may need to upgrade, or other nodes may need to upgrade.</source>
         <translation>警告: 我們和某些連線的節點對於區塊鏈結的決定不同！你可能需要升級，或是需要等其它的節點升級。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: error reading wallet.dat! All keys read correctly, but transaction data or address book entries might be missing or incorrect.</source>
         <translation>警告: 讀取錢包檔 wallet.dat 時發生錯誤！所有的密鑰都正確讀取了，但是交易資料或位址簿資料可能會缺少或不正確。</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Warning: wallet.dat corrupt, data salvaged! Original wallet.dat saved as wallet.{timestamp}.bak in %s; if your balance or transactions are incorrect you should restore from a backup.</source>
         <translation>警告: 錢包檔 wallet.dat 壞掉，但資料被拯救回來了！原來的 wallet.dat 會改儲存在 %s, 檔名是 wallet.{timestamp}.bak. 如果餘額或交易資料有誤，你應該要用備份資料復原回來。</translation>
     </message>
     <message>
-        <location line="+9"/>
         <source>(default: 1)</source>
         <translation>(預設值: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>(default: wallet.dat)</source>
         <translation>(預設值: wallet.dat)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>&lt;category&gt; can be:</source>
         <translation>&lt;category&gt; 可以是:</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Attempt to recover private keys from a corrupt wallet.dat</source>
         <translation>嘗試從壞掉的錢包檔 wallet.dat 復原密鑰</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Bitcoin Core Daemon</source>
         <translation>位元幣核心護靈</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Block creation options:</source>
         <translation>區塊製造選項:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Clear list of wallet transactions (diagnostic tool; implies -rescan)</source>
         <translation>清掉錢包裡交易的列表(診斷用的工具; 也會做 -rescan)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect only to the specified node(s)</source>
         <translation>只連線到指定節點(可多個)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect through SOCKS proxy</source>
         <translation>透過 SOCKS 代理伺服器來連線</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Connect to JSON-RPC on &lt;port&gt; (default: 8332 or testnet: 18332)</source>
         <translation>連線到埠號 &lt;port&gt; 上的 JSON-RPC 伺服器(預設值: 8332，或若是測試網路: 18332)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Connection options:</source>
         <translation>連線選項:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Corrupted block database detected</source>
         <translation>發現區塊資料庫壞掉了</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Debugging/Testing options:</source>
         <translation>除錯與測試選項</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Disable safemode, override a real safe mode event (default: 0)</source>
         <translation>不進入安全模式，用在真的發生需要進入安全模式的事件時，強制不進入 (預設值: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Discover own IP address (default: 1 when listening and no -externalip)</source>
         <translation>找出自己的網際網路位址(預設值: 當有聽候連線且沒有 -externalip 時為 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do not load the wallet and disable wallet RPC calls</source>
         <translation>不要載入錢包，並且拿掉錢包相關的 RPC 功能呼叫。</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Do you want to rebuild the block database now?</source>
         <translation>你想要現在重建區塊資料庫嗎？</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error initializing block database</source>
         <translation>初始化區塊資料庫時發生錯誤</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error initializing wallet database environment %s!</source>
         <translation>初始化錢包資料庫環境 %s 時發生錯誤！</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading block database</source>
         <translation>載入區塊資料庫時發生錯誤</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Error opening block database</source>
         <translation>打開區塊資料庫時發生錯誤</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Error: Disk space is low!</source>
         <translation>錯誤: 磁碟空間很少！</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: Wallet locked, unable to create transaction!</source>
         <translation>錯誤: 錢包被上鎖了，沒辦法製造新的交易！</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error: system error: </source>
         <translation>錯誤: 系統錯誤:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to listen on any port. Use -listen=0 if you want this.</source>
         <translation>在任意的通訊埠聽候失敗。如果你希望這樣的話，可以設定 -listen=0.</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block info</source>
         <translation>讀取區塊資訊失敗</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to read block</source>
         <translation>讀取區塊失敗</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to sync block index</source>
         <translation>同步區塊索引失敗</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block index</source>
         <translation>把區塊索引寫進去失敗了</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block info</source>
         <translation>把區塊資訊寫進去失敗了</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write block</source>
         <translation>把區塊資料寫進去失敗了</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write file info</source>
         <translation>把檔案資訊寫進去失敗了</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write to coin database</source>
         <translation>寫進錢幣資料庫失敗了</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write transaction index</source>
         <translation>把交易索引寫進去失敗了</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Failed to write undo data</source>
         <translation>把回復資料寫進去失敗了</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fee per kB to add to transactions you send</source>
         <translation>交易時每一千位元組(kB)加付的交易手續費</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Fees smaller than this are considered zero fee (for relaying) (default:</source>
         <translation>手續費比這個低時會被認為是沒付手續費(轉發用)(預設值:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Find peers using DNS lookup (default: 1 unless -connect)</source>
         <translation>是否允許在找節點時使用域名查詢(預設值: 當沒用 -connect 時為 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Force safe mode (default: 0)</source>
         <translation>強制進入安全模式 (預設值: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Generate coins (default: 0)</source>
         <translation>生產位元幣(預設值: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>How many blocks to check at startup (default: 288, 0 = all)</source>
         <translation>啓動時檢查的區塊數(預設值: 288, 指定 0 表示全部)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>If &lt;category&gt; is not supplied, output all debugging information.</source>
         <translation>如果沒有提供 &lt;category&gt; 就會輸出所有的除錯資訊。</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Incorrect or no genesis block found. Wrong datadir for network?</source>
         <translation>創世區塊不正確或找不到。資料目錄錯了嗎？</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Invalid -onion address: &apos;%s&apos;</source>
         <translation>無效的 -onion 位址: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+17"/>
         <source>Not enough file descriptors available.</source>
         <translation>檔案描述元不足。</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Prepend debug output with timestamp (default: 1)</source>
         <translation>在除錯輸出內容前附加時間(預設值: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>RPC client options:</source>
         <translation>RPC 客戶端選項:</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Rebuild block chain index from current blk000??.dat files</source>
         <translation>從目前的區塊檔 blk000??.dat 重建區塊鏈的索引</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Select SOCKS version for -proxy (4 or 5, default: 5)</source>
         <translation>選擇 -proxy 指定代理伺服器的 SOCKS 協定版本(4 或 5, 預設值: 5)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set database cache size in megabytes (%d to %d, default: %d)</source>
         <translation>設定資料庫快取大小是多少百萬位元組(MB，範圍: %d 到 %d，預設值: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum block size in bytes (default: %d)</source>
         <translation>設定區塊大小上限成多少位元組(預設值: %d)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set the number of threads to service RPC calls (default: 4)</source>
         <translation>設定處理 RPC 服務請求的執行緒數目(預設值: 4)</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Specify wallet file (within data directory)</source>
         <translation>指定錢包檔(會在資料目錄中)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Spend unconfirmed change when sending transactions (default: 1)</source>
         <translation>傳送交易時可以花還沒確認的零錢(預設值: 1)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>This is intended for regression testing tools and app development.</source>
         <translation>這是設計用來給回歸測試工具和應用程式開發用的。</translation>
     </message>
     <message>
-        <location line="+10"/>
         <source>Usage (deprecated, use bitcoin-cli):</source>
         <translation>用法(已過時，請改用 bitcoin-cli):</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Verifying blocks...</source>
         <translation>正在驗證區塊資料...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Verifying wallet...</source>
         <translation>正在驗證錢包資料...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wait for RPC server to start</source>
         <translation>等待 RPC 伺服器啟動</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Wallet %s resides outside data directory %s</source>
         <translation>錢包檔 %s 沒有在資料目錄 %s 裡面</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Wallet options:</source>
         <translation>錢包選項:</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: Deprecated argument -debugnet ignored, use -debug=net</source>
         <translation>警告: 參數 -debugnet 因為已經淘汰掉了而被忽略，請改用 -debug=net</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>You need to rebuild the database using -reindex to change -txindex</source>
         <translation>改變 -txindex 參數後，必須要用 -reindex 參數來重建資料庫</translation>
     </message>
     <message>
-        <location line="-92"/>
         <source>Imports blocks from external blk000??.dat file</source>
         <translation>從其它來源的 blk000??.dat 檔匯入區塊</translation>
     </message>
     <message>
-        <location line="-149"/>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Core is probably already running.</source>
         <translation>沒辦法鎖定資料目錄 %s。位元幣核心可能已經在執行了。</translation>
     </message>
     <message>
-        <location line="+22"/>
         <source>Execute command when a relevant alert is received or we see a really long fork (%s in cmd is replaced by message)</source>
         <translation>當收到相關警示，或發現相當長的分支時，所要執行的指令(指令中的 %s 會被取代成警示訊息)</translation>
     </message>
     <message>
-        <location line="+25"/>
         <source>Output debugging information (default: 0, supplying &lt;category&gt; is optional)</source>
         <translation>輸出除錯資訊(預設值: 0, 可以不指定 &lt;category&gt;)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Set maximum size of high-priority/low-fee transactions in bytes (default: %d)</source>
         <translation>設定高優先度或低手續費的交易資料大小上限成多少位元組(預設值: %d)</translation>
     </message>
     <message>
-        <location line="+102"/>
         <source>Information</source>
         <translation>資訊</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Invalid amount for -minrelaytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>設定最低轉發手續費 -minrelaytxfee=&lt;金額&gt; 的金額無效: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount for -mintxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>設定 -mintxfee=&lt;金額&gt; 的金額無效: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Limit size of signature cache to &lt;n&gt; entries (default: 50000)</source>
         <translation>限制簽章快取大小為 &lt;n&gt; 筆 (預設值: 50000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Log transaction priority and fee per kB when mining blocks (default: 0)</source>
         <translation>開採區塊的時候紀錄交易的優先度以及每千位元組(kB)的手續費 (預設值: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maintain a full transaction index (default: 0)</source>
         <translation>維護全部交易的索引(預設值: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Maximum per-connection receive buffer, &lt;n&gt;*1000 bytes (default: 5000)</source>
         <translation>每個連線的接收緩衝區大小上限為 &lt;n&gt;*1000 個位元組(預設值: 5000)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Maximum per-connection send buffer, &lt;n&gt;*1000 bytes (default: 1000)</source>
         <translation>每個連線的傳送緩衝區大小上限為 &lt;n&gt;*1000 位元組(預設值: 1000)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Only accept block chain matching built-in checkpoints (default: 1)</source>
         <translation>只接受跟內建的檢查段點吻合的區塊鏈(預設值: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Only connect to nodes in network &lt;net&gt; (IPv4, IPv6 or Tor)</source>
         <translation>只和 &lt;net&gt; 網路上的節點連線(IPv4, IPv6, 或 Tor)</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Print block on startup, if found in block index</source>
         <translation>啟動時輸出指定的區塊內容，如果有在區塊索引中找到的話</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Print block tree on startup (default: 0)</source>
         <translation>啟動時輸出區塊樹 (預設值: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>RPC SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>RPC SSL 選項: (SSL 設定程序請見 Bitcoin Wiki)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>RPC server options:</source>
         <translation>RPC 伺服器選項:</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly drop 1 of every &lt;n&gt; network messages</source>
         <translation>隨機丟掉 &lt;n&gt; 分之一的網路訊息</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Randomly fuzz 1 of every &lt;n&gt; network messages</source>
         <translation>隨機亂動 &lt;n&gt; 分之一的網路訊息裡的資料</translation>
     </message>
     <message>
-        <location line="+4"/>
         <source>Run a thread to flush wallet periodically (default: 1)</source>
         <translation>啟用定期將變動寫入錢包檔的執行緒 (預設值: 1)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>SSL options: (see the Bitcoin Wiki for SSL setup instructions)</source>
         <translation>SSL 選項: (SSL 設定程序請見 Bitcoin Wiki)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send command to Bitcoin Core</source>
         <translation>傳送指令給位元幣核心</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Send trace/debug info to console instead of debug.log file</source>
         <translation>在終端機顯示追蹤或除錯資訊，而不是寫到檔案 debug.log 中</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Set minimum block size in bytes (default: 0)</source>
         <translation>設定區塊大小下限成多少位元組(預設值: 0)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Sets the DB_PRIVATE flag in the wallet db environment (default: 1)</source>
         <translation>在錢包資料庫環境變數設定 DB_PRIVATE 旗標 (預設值: 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show all debugging options (usage: --help -help-debug)</source>
         <translation>顯示所有的除錯選項 (用法: --help --help-debug)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Show benchmark information (default: 0)</source>
         <translation>顯示效能評比資訊 (預設值: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Shrink debug.log file on client startup (default: 1 when no -debug)</source>
         <translation>客戶端軟體啓動時把 debug.log 檔縮小(預設值: 當沒有 -debug 時為 1)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Signing transaction failed</source>
         <translation>簽署交易失敗</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Specify connection timeout in milliseconds (default: 5000)</source>
         <translation>指定連線在幾毫秒後逾時(預設值: 5000)</translation>
     </message>
     <message>
-        <location line="+6"/>
         <source>Start Bitcoin Core Daemon</source>
         <translation>啟動位元幣核心護靈</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>System error: </source>
         <translation>系統錯誤:</translation>
     </message>
     <message>
-        <location line="+5"/>
         <source>Transaction amount too small</source>
         <translation>交易金額太小</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction amounts must be positive</source>
         <translation>交易金額必須是正的</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Transaction too large</source>
         <translation>交易位元量太大</translation>
     </message>
     <message>
-        <location line="+8"/>
         <source>Use UPnP to map the listening port (default: 0)</source>
         <translation>是否要使用「通用即插即用」協定(UPnP)，來設定聽候連線的通訊埠的對應(預設值: 0)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Use UPnP to map the listening port (default: 1 when listening)</source>
         <translation>是否要使用「通用即插即用」協定(UPnP)，來設定聽候連線的通訊埠的對應(預設值: 當有聽候連線時為 1)</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Username for JSON-RPC connections</source>
         <translation>JSON-RPC 連線使用者名稱</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Warning: This version is obsolete, upgrade required!</source>
         <translation>警告: 這個版本已經被淘汰了，必須要升級！</translation>
     </message>
     <message>
-        <location line="+2"/>
         <source>Zapping all transactions from wallet...</source>
         <translation>正在砍掉錢包中的所有交易...</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>on startup</source>
         <translation>當啟動時</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>version</source>
         <translation>版本</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>wallet.dat corrupt, salvage failed</source>
         <translation>錢包檔 weallet.dat 壞掉了，拯救失敗</translation>
     </message>
     <message>
-        <location line="-71"/>
         <source>Password for JSON-RPC connections</source>
         <translation>JSON-RPC 連線密碼</translation>
     </message>
     <message>
-        <location line="-77"/>
         <source>Allow JSON-RPC connections from specified IP address</source>
         <translation>允許指定的來源 IP 位址進行 JSON-RPC 連線</translation>
     </message>
     <message>
-        <location line="+94"/>
         <source>Send commands to node running on &lt;ip&gt; (default: 127.0.0.1)</source>
         <translation>傳送指令給在 &lt;ip&gt; 的節點(預設值: 127.0.0.1)</translation>
     </message>
     <message>
-        <location line="-163"/>
         <source>Execute command when the best block changes (%s in cmd is replaced by block hash)</source>
         <translation>當最新區塊改變時要執行的指令(指令中的 %s 會被取代成區塊雜湊值)</translation>
     </message>
     <message>
-        <location line="+196"/>
         <source>Upgrade wallet to latest format</source>
         <translation>把錢包檔案升級成最新的格式</translation>
     </message>
     <message>
-        <location line="-28"/>
         <source>Set key pool size to &lt;n&gt; (default: 100)</source>
         <translation>設定密鑰池大小成 &lt;n&gt; (預設值: 100)</translation>
     </message>
     <message>
-        <location line="-12"/>
         <source>Rescan the block chain for missing wallet transactions</source>
         <translation>重新掃描區塊鏈，來尋找錢包可能漏掉的交易。</translation>
     </message>
     <message>
-        <location line="+43"/>
         <source>Use OpenSSL (https) for JSON-RPC connections</source>
         <translation>在 JSON-RPC 連線使用 OpenSSL (https)</translation>
     </message>
     <message>
-        <location line="-34"/>
         <source>Server certificate file (default: server.cert)</source>
         <translation>伺服器憑證檔(預設值: server.cert)</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Server private key (default: server.pem)</source>
         <translation>伺服器私鑰檔(預設值: server.pem)</translation>
     </message>
     <message>
-        <location line="+20"/>
         <source>This help message</source>
         <translation>這些說明訊息</translation>
     </message>
     <message>
-        <location line="+7"/>
         <source>Unable to bind to %s on this computer (bind returned error %d, %s)</source>
         <translation>沒辦法和這台電腦上的 %s 繫結(回傳錯誤 %d, %s)</translation>
     </message>
     <message>
-        <location line="-125"/>
         <source>Allow DNS lookups for -addnode, -seednode and -connect</source>
         <translation>允許對 -addnode, -seednode, -connect 的參數使用域名查詢 </translation>
     </message>
     <message>
-        <location line="+66"/>
         <source>Loading addresses...</source>
         <translation>正在載入位址資料...</translation>
     </message>
     <message>
-        <location line="-39"/>
         <source>Error loading wallet.dat: Wallet corrupted</source>
         <translation>載入檔案 wallet.dat 時發生錯誤: 錢包損毀了</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin</source>
         <translation>載入 wallet.dat 檔案時發生錯誤: 這個錢包需要新版的位元幣軟體</translation>
     </message>
     <message>
-        <location line="+112"/>
         <source>Wallet needed to be rewritten: restart Bitcoin to complete</source>
         <translation>錢包需要重寫: 請重新啓動位元幣軟體來完成</translation>
     </message>
     <message>
-        <location line="-114"/>
         <source>Error loading wallet.dat</source>
         <translation>載入錢包檔 wallet.dat 時發生錯誤</translation>
     </message>
     <message>
-        <location line="+32"/>
         <source>Invalid -proxy address: &apos;%s&apos;</source>
         <translation>無效的 -proxy 位址: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Unknown network specified in -onlynet: &apos;%s&apos;</source>
         <translation>在 -onlynet 指定了不明的網路別: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="-1"/>
         <source>Unknown -socks proxy version requested: %i</source>
         <translation>在 -socks 指定了不明的代理協定版本: %i</translation>
     </message>
     <message>
-        <location line="-119"/>
         <source>Cannot resolve -bind address: &apos;%s&apos;</source>
         <translation>沒辦法解析 -bind 位址: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Cannot resolve -externalip address: &apos;%s&apos;</source>
         <translation>沒辦法解析 -externalip 位址: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+53"/>
         <source>Invalid amount for -paytxfee=&lt;amount&gt;: &apos;%s&apos;</source>
         <translation>設定 -paytxfee=&lt;金額&gt; 的金額無效: &apos;%s&apos;</translation>
     </message>
     <message>
-        <location line="+1"/>
         <source>Invalid amount</source>
         <translation>無效的金額</translation>
     </message>
     <message>
-        <location line="-6"/>
         <source>Insufficient funds</source>
         <translation>累積金額不足</translation>
     </message>
     <message>
-        <location line="+11"/>
         <source>Loading block index...</source>
         <translation>正在載入區塊索引...</translation>
     </message>
     <message>
-        <location line="-68"/>
         <source>Add a node to connect to and attempt to keep the connection open</source>
         <translation>增加一個要連線的節線，並試著保持對它的連線暢通</translation>
     </message>
     <message>
-        <location line="+69"/>
         <source>Loading wallet...</source>
         <translation>正在載入錢包資料...</translation>
     </message>
     <message>
-        <location line="-62"/>
         <source>Cannot downgrade wallet</source>
         <translation>沒辦法把錢包格式降級</translation>
     </message>
     <message>
-        <location line="+3"/>
         <source>Cannot write default address</source>
         <translation>沒辦法把預設位址寫進去</translation>
     </message>
     <message>
-        <location line="+80"/>
         <source>Rescanning...</source>
         <translation>正在重新掃描...</translation>
     </message>
     <message>
-        <location line="-67"/>
         <source>Done loading</source>
         <translation>載入完成</translation>
     </message>
     <message>
-        <location line="+99"/>
         <source>To use the %s option</source>
         <translation>為了要使用 %s 選項</translation>
     </message>
     <message>
-        <location line="-91"/>
         <source>Error</source>
         <translation>錯誤</translation>
     </message>
     <message>
-        <location line="-41"/>
         <source>You must set rpcpassword=&lt;password&gt; in the configuration file:
 %s
 If the file does not exist, create it with owner-readable-only file permissions.</source>


### PR DESCRIPTION
- Commit transifex configuration file - so that developers don't have to create it themselves
- Add a script to fetch and postprocess translations 
  - should result in smaller and clearer diffs in the future that just show the changed messages (for languages other than English; for English we need to retain the location markers, as Transifex uses them)
  - avoids importing unparseable control characters
  - avoids missing updates due to `tx pull -a` weirdness
- Full translation update
